### PR TITLE
feat(infra): add SSL setup script for Let's Encrypt

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,116 @@
+# Infrastructure Documentation
+
+> **Last Updated**: 2025-12-26
+
+## Directory Structure
+
+```
+infrastructure/
+├── production/           # Production environment configs
+│   ├── docker-compose.yml
+│   ├── nginx/
+│   │   └── donaction.conf
+│   └── env.template
+├── staging/              # Staging environment configs
+│   ├── docker-compose.yml
+│   ├── nginx/
+│   │   └── donaction.conf
+│   └── env.template
+├── scripts/              # Infrastructure scripts
+│   └── setup-ssl.sh      # SSL certificate setup
+└── README.md             # This file
+```
+
+## SSL Certificates
+
+### Initial Setup
+
+Run the SSL setup script on each server:
+
+```bash
+# Staging server (re7.donaction.fr)
+sudo ./scripts/setup-ssl.sh staging
+
+# Production server (www.donaction.fr)
+sudo ./scripts/setup-ssl.sh production
+```
+
+**Prerequisites:**
+- Nginx installed and running
+- Domains pointing to server IP
+- Port 80 accessible (for ACME challenge)
+
+### Certificate Locations
+
+| Environment | Certificate Path |
+|-------------|------------------|
+| Production | `/etc/letsencrypt/live/www.donaction.fr/` |
+| Staging | `/etc/letsencrypt/live/re7.donaction.fr/` |
+
+### Auto-Renewal
+
+Certificates auto-renew via cron (runs twice daily at 00:00 and 12:00):
+
+```bash
+# View cron job
+cat /etc/cron.d/certbot-renew
+
+# View renewal logs
+tail -f /var/log/certbot-renew.log
+```
+
+### Manual Renewal
+
+```bash
+# Check certificate status
+sudo certbot certificates
+
+# Test renewal (dry-run)
+sudo certbot renew --dry-run
+
+# Force renewal
+sudo certbot renew --force-renewal
+
+# Renew and reload nginx
+sudo certbot renew && sudo systemctl reload nginx
+```
+
+### Troubleshooting
+
+**Certificate not found:**
+```bash
+# Verify certificate exists
+ls -la /etc/letsencrypt/live/
+
+# Re-run setup
+sudo ./scripts/setup-ssl.sh [staging|production]
+```
+
+**Renewal failing:**
+```bash
+# Check ACME challenge location
+curl -I http://yourdomain.com/.well-known/acme-challenge/test
+
+# Verify webroot exists
+ls -la /var/www/certbot/
+
+# Check nginx config
+sudo nginx -t
+```
+
+**Port 80 blocked:**
+- Ensure firewall allows port 80
+- ACME challenge requires HTTP access
+
+## Deployment
+
+See `.github/workflows/` for CI/CD deployment workflows:
+- `deploy-staging.yml` - Deploy to staging
+- `deploy-production.yml` - Deploy to production
+
+## Environments
+
+| Environment | Domain | VPS |
+|-------------|--------|-----|
+| Staging | re7.donaction.fr | Staging server |
+| Production | www.donaction.fr | Production server |

--- a/infrastructure/production/nginx/donaction.conf
+++ b/infrastructure/production/nginx/donaction.conf
@@ -30,7 +30,14 @@ server {
     ssl_certificate /etc/letsencrypt/live/www.donaction.fr/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/www.donaction.fr/privkey.pem;
 
-    return 301 https://www.donaction.fr$request_uri;
+    # Let's Encrypt ACME challenge (must be before redirect)
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://www.donaction.fr$request_uri;
+    }
 }
 
 # Redirect HTTP to HTTPS
@@ -38,7 +45,14 @@ server {
     listen 80;
     server_name www.donaction.fr;
 
-    return 301 https://$server_name$request_uri;
+    # Let's Encrypt ACME challenge (must be before redirect)
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$server_name$request_uri;
+    }
 }
 
 # Main HTTPS server

--- a/infrastructure/scripts/setup-ssl.sh
+++ b/infrastructure/scripts/setup-ssl.sh
@@ -1,0 +1,268 @@
+#!/bin/bash
+#
+# SSL Certificate Setup Script for Donaction Platform
+# Usage: sudo ./setup-ssl.sh [staging|production] [--dry-run]
+#
+# This script:
+# 1. Installs Certbot with nginx plugin
+# 2. Creates webroot directory for ACME challenges
+# 3. Generates Let's Encrypt certificates
+# 4. Configures automatic renewal via cron
+# 5. Tests renewal with dry-run
+#
+
+set -euo pipefail
+
+# Configuration
+WEBROOT_PATH="/var/www/certbot"
+EMAIL="hello@donaction.fr"
+LOG_FILE="/var/log/certbot-setup.log"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log() {
+    echo -e "${GREEN}[$(date +'%Y-%m-%d %H:%M:%S')]${NC} $1" | tee -a "$LOG_FILE"
+}
+
+warn() {
+    echo -e "${YELLOW}[$(date +'%Y-%m-%d %H:%M:%S')] WARNING:${NC} $1" | tee -a "$LOG_FILE"
+}
+
+error() {
+    echo -e "${RED}[$(date +'%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1" | tee -a "$LOG_FILE" >&2
+}
+
+usage() {
+    echo "Usage: sudo $0 [staging|production] [--dry-run]"
+    echo ""
+    echo "Arguments:"
+    echo "  staging     Generate certificate for re7.donaction.fr"
+    echo "  production  Generate certificates for donaction.fr and www.donaction.fr"
+    echo ""
+    echo "Options:"
+    echo "  --dry-run   Test the process without actually generating certificates"
+    echo ""
+    echo "Examples:"
+    echo "  sudo $0 staging"
+    echo "  sudo $0 production"
+    echo "  sudo $0 staging --dry-run"
+    exit 1
+}
+
+# Check if running as root
+check_root() {
+    if [[ $EUID -ne 0 ]]; then
+        error "This script must be run as root (use sudo)"
+        exit 1
+    fi
+}
+
+# Parse arguments
+parse_args() {
+    ENVIRONMENT=""
+    DRY_RUN=""
+
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            staging|production)
+                ENVIRONMENT="$1"
+                shift
+                ;;
+            --dry-run)
+                DRY_RUN="--dry-run"
+                shift
+                ;;
+            -h|--help)
+                usage
+                ;;
+            *)
+                error "Unknown argument: $1"
+                usage
+                ;;
+        esac
+    done
+
+    if [[ -z "$ENVIRONMENT" ]]; then
+        error "Environment argument required"
+        usage
+    fi
+}
+
+# Install Certbot
+install_certbot() {
+    log "Installing Certbot and nginx plugin..."
+
+    apt-get update -qq
+    apt-get install -y certbot python3-certbot-nginx
+
+    log "Certbot installed: $(certbot --version)"
+}
+
+# Create webroot directory
+create_webroot() {
+    log "Creating webroot directory at $WEBROOT_PATH..."
+
+    mkdir -p "$WEBROOT_PATH"
+    chown -R www-data:www-data "$WEBROOT_PATH"
+    chmod 755 "$WEBROOT_PATH"
+
+    log "Webroot directory created"
+}
+
+# Generate certificates
+generate_certificates() {
+    local domains=""
+    local cert_name=""
+
+    if [[ "$ENVIRONMENT" == "staging" ]]; then
+        domains="-d re7.donaction.fr"
+        cert_name="re7.donaction.fr"
+    else
+        domains="-d donaction.fr -d www.donaction.fr"
+        cert_name="www.donaction.fr"
+    fi
+
+    log "Generating certificates for: $domains"
+
+    # Check if certificate already exists
+    if [[ -d "/etc/letsencrypt/live/$cert_name" ]] && [[ -z "$DRY_RUN" ]]; then
+        warn "Certificate already exists at /etc/letsencrypt/live/$cert_name"
+        read -p "Do you want to renew/expand it? (y/N) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            log "Skipping certificate generation"
+            return 0
+        fi
+    fi
+
+    # Build certbot command
+    local certbot_cmd="certbot certonly --webroot -w $WEBROOT_PATH $domains"
+    certbot_cmd="$certbot_cmd --email $EMAIL --agree-tos --non-interactive"
+
+    if [[ -n "$DRY_RUN" ]]; then
+        certbot_cmd="$certbot_cmd --dry-run"
+        log "Running in dry-run mode..."
+    fi
+
+    # Run certbot
+    if eval "$certbot_cmd"; then
+        log "Certificate generation successful"
+    else
+        error "Certificate generation failed"
+        exit 1
+    fi
+}
+
+# Setup auto-renewal cron
+setup_cron() {
+    local cron_file="/etc/cron.d/certbot-renew"
+    local cron_job="0 0,12 * * * root certbot renew --quiet --post-hook \"systemctl reload nginx\" >> /var/log/certbot-renew.log 2>&1"
+
+    if [[ -n "$DRY_RUN" ]]; then
+        log "Dry-run: Would create cron job at $cron_file"
+        log "Dry-run: $cron_job"
+        return 0
+    fi
+
+    log "Setting up auto-renewal cron job..."
+
+    cat > "$cron_file" << EOF
+# Certbot auto-renewal for Donaction
+# Runs twice daily as recommended by Let's Encrypt
+# Managed by setup-ssl.sh - do not edit manually
+SHELL=/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+$cron_job
+EOF
+
+    chmod 644 "$cron_file"
+    log "Cron job created at $cron_file"
+}
+
+# Test renewal
+test_renewal() {
+    log "Testing certificate renewal with dry-run..."
+
+    if certbot renew --dry-run; then
+        log "Renewal test passed"
+    else
+        warn "Renewal test failed - check configuration"
+    fi
+}
+
+# Reload nginx
+reload_nginx() {
+    if [[ -n "$DRY_RUN" ]]; then
+        log "Dry-run: Would reload nginx"
+        return 0
+    fi
+
+    log "Testing nginx configuration..."
+    if nginx -t; then
+        log "Nginx configuration valid"
+        systemctl reload nginx
+        log "Nginx reloaded"
+    else
+        error "Nginx configuration test failed"
+        exit 1
+    fi
+}
+
+# Print summary
+print_summary() {
+    echo ""
+    echo "========================================"
+    log "SSL Setup Complete!"
+    echo "========================================"
+    echo ""
+
+    if [[ "$ENVIRONMENT" == "staging" ]]; then
+        echo "Certificate location: /etc/letsencrypt/live/re7.donaction.fr/"
+        echo "Domain: re7.donaction.fr"
+    else
+        echo "Certificate location: /etc/letsencrypt/live/www.donaction.fr/"
+        echo "Domains: donaction.fr, www.donaction.fr"
+    fi
+
+    echo ""
+    echo "Webroot: $WEBROOT_PATH"
+    echo "Auto-renewal: Enabled (cron twice daily)"
+    echo "Log file: $LOG_FILE"
+    echo ""
+    echo "Manual renewal command:"
+    echo "  sudo certbot renew"
+    echo ""
+    echo "Force renewal command:"
+    echo "  sudo certbot renew --force-renewal"
+    echo ""
+    echo "Check certificate expiry:"
+    echo "  sudo certbot certificates"
+    echo ""
+}
+
+# Main
+main() {
+    check_root
+    parse_args "$@"
+
+    log "Starting SSL setup for $ENVIRONMENT environment"
+
+    if [[ -n "$DRY_RUN" ]]; then
+        warn "Running in DRY-RUN mode - no changes will be made"
+    fi
+
+    install_certbot
+    create_webroot
+    generate_certificates
+    setup_cron
+    test_renewal
+    reload_nginx
+    print_summary
+}
+
+main "$@"

--- a/infrastructure/staging/nginx/donaction.conf
+++ b/infrastructure/staging/nginx/donaction.conf
@@ -25,8 +25,15 @@ server {
     listen 80;
     server_name re7.donaction.fr;
 
+    # Let's Encrypt ACME challenge (must be before redirect)
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
     # Redirect HTTP to HTTPS
-    return 301 https://$server_name$request_uri;
+    location / {
+        return 301 https://$server_name$request_uri;
+    }
 }
 
 server {


### PR DESCRIPTION
## Summary
- Create `setup-ssl.sh` for staging/production SSL certificate generation
- Add ACME challenge locations to nginx configs for webroot authentication
- Configure auto-renewal via cron (twice daily)
- Add infrastructure documentation with SSL renewal guide

## Test plan
- [ ] Run `sudo ./scripts/setup-ssl.sh staging --dry-run` on staging server
- [ ] Run `sudo ./scripts/setup-ssl.sh production --dry-run` on production server
- [ ] Verify nginx config with `nginx -t`
- [ ] Confirm ACME challenge path accessible via HTTP

Closes #27