### PR TITLE
feat(api): change default commissionPercentage from 6% to 4%

### DIFF
--- a/donaction-api/src/api/trade-policy/content-types/trade-policy/schema.json
+++ b/donaction-api/src/api/trade-policy/content-types/trade-policy/schema.json
@@ -19,7 +19,7 @@
     "commissionPercentage": {
       "type": "decimal",
       "required": true,
-      "default": 6
+      "default": 4
     },
     "noBilling": {
       "type": "boolean",


### PR DESCRIPTION
## Summary
- Change `commissionPercentage` default from 6% to 4% in trade_policy schema
- Reflects new Stripe Connect economic model with transparent donor fees
- Existing trade policies retain their current values (no impact)

## Changes
- `donaction-api/src/api/trade-policy/content-types/trade-policy/schema.json`: default 6 → 4

## Test plan
- [x] Build passes
- [ ] Create new trade_policy without specifying commissionPercentage → verify default = 4
- [ ] Existing trade policies remain unchanged after deployment

Closes #51