### PR TITLE
feat(saas): add donor pays fee choice at step 3

### DIFF
--- a/docs/plans/issue-53-plan.md
+++ b/docs/plans/issue-53-plan.md
@@ -1,0 +1,91 @@
+# Implementation Plan: Issue #53
+
+## Summary
+Add a "Donor Pays Fee" radio choice component at step 3 of the donation form, allowing donors to choose whether they pay processing fees on top of their donation or have them deducted. This feature is gated by `stripe_connect` and `allow_donor_fee_choice` flags in the trade_policy, with default values depending on donation type (project vs club).
+
+## Files to Modify
+
+### Backend (Strapi API)
+- `donaction-api/src/api/trade-policy/content-types/trade-policy/schema.json` - Add new fields: `stripe_connect`, `allow_donor_fee_choice`, `donor_pays_fee_club`, `donor_pays_fee_project`
+- `donaction-api/src/api/klub-don/content-types/klub-don/schema.json` - Add `donorPaysFee` boolean field
+- `donaction-api/src/api/klubr-subscription/controllers/klubr-subscription.ts` - Update `decrypt` to populate new trade_policy fields
+
+### SaaS Widget (Svelte)
+- `donaction-saas/src/components/sponsorshipForm/logic/useSponsorshipForm.svelte.ts` - Add `donorPaysFee` to DEFAULT_VALUES
+- `donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/step3.svelte` - Add radio component
+- `donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/index.scss` - Add radio styling
+- `donaction-saas/src/components/sponsorshipForm/logic/submit.ts` - Include `donorPaysFee` in donation payload
+- `donaction-saas/src/components/sponsorshipForm/logic/utils.ts` - Add fee calculation utility
+
+## Implementation Steps
+
+### Phase 1: Backend Schema Updates
+
+**Step 1.1: Update trade-policy schema**
+Verifie that these fields exists: `stripe_connect`, `allow_donor_fee_choice`, `donor_pays_fee_club`, `donor_pays_fee_project`
+
+**Step 1.2: Update klub-don schema**
+Add `donorPaysFee` boolean field
+
+**Step 1.3: Update decrypt endpoint**
+Include new trade_policy fields in populate
+
+### Phase 2: Frontend State Management
+
+**Step 2.1: Update useSponsorshipForm.svelte.ts**
+Add `donorPaysFee` to `defVals` and `DEFAULT_VALUES`
+
+**Step 2.2: Add fee calculation utility**
+Create `calculateFeeAmount` and `calculateTotalWithFee` functions
+
+**Step 2.3: Update initComponent.ts**
+Set default `donorPaysFee` value based on trade_policy and donation type
+
+### Phase 3: Radio Component Implementation
+
+**Step 3.1: Create DonorFeeChoice section in step3.svelte**
+- 2 radio options: "Je paie les frais en plus" / "J'intègre les frais au don"
+- Show amount breakdown for each option
+- Add a info icon after "Je paie les frais en plus" that open a Tooltip with ""
+
+**Step 3.2: Add derived values for display**
+- `shouldShowFeeChoice` - guard condition
+- `commissionPercentage` - from trade_policy
+- `feeAmount`, `totalWithFee`, `netAmount` - calculated values
+
+**Step 3.3: Add a line in .recapList section**
+- if stripe connect && donorsPaysFee, than add a line "Frais bancaire + frais de plateforme" with Fee+stripe fee amount"
+
+**Step 3.4: Set default value based on donation type**
+- PROJECT: default from `donor_pays_fee_project`
+- CLUB: default from `donor_pays_fee_club`
+
+### Phase 4: Styling
+
+**Step 4.1: Add SCSS styles to index.scss**
+Radio group styling with selected state
+
+### Phase 5: Form Submission
+
+**Step 5.1: Update submit.ts**
+Include `donorPaysFee` in donation payload
+
+### Phase 6: Payment Amount Calculation
+
+**Step 6.1: Update step4.svelte payment amount**
+Account for fee when `donorPaysFee = true`
+
+## Testing Strategy
+
+### E2E Tests
+1. **Scenario 1: Display when authorized** - stripe_connect=true, allow_donor_fee_choice=true → radio visible
+2. **Scenario 2: Default by donation type** - PROJECT=true default, CLUB=per setting
+3. **Scenario 3: Legacy mode** - stripe_connect=false → no radio displayed
+
+## Definition of Done
+- [ ] Composant radio créé et stylisé
+- [ ] Logique valeur par défaut implémentée
+- [ ] Condition de garde vérifiée
+- [ ] Tests E2E modes projet/club
+- [ ] Test mode Legacy
+- [ ] PR approuvée et mergée

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/README.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/README.md
@@ -1,0 +1,127 @@
+# User Stories - Migration Stripe Connect DONACTION
+
+> **Version**: 2.0.0 | **Date**: 2026-01-11 | **Total US**: 47
+
+## 📋 Vue d'ensemble
+
+Ce package contient les User Stories pour la migration de DONACTION vers Stripe Connect Express.
+
+### ⚠️ Règle critique : Condition de garde
+
+**Toute fonctionnalité Stripe Connect doit être protégée par :**
+
+```typescript
+if (klubr.trade_policy.stripe_connect === true) {
+  // Code Stripe Connect
+} else {
+  // Code Legacy (Stripe Standard)
+}
+```
+
+## 📊 Répartition par Epic
+
+| Epic | Nom | US | Points | Priorité dominante |
+|------|-----|-----|--------|-------------------|
+| 1 | Trade Policy | 3 | 8 | P0 |
+| 2 | Formulaire Donateur ⚠️ | 4 | 13 | P0 |
+| 3 | Backend Paiement ⚠️ | 4 | 21 | P0 |
+| 4 | Webhooks & Audit | 6 | 18 | P0-P2 |
+| 5 | Onboarding Association ⚠️ | 7 | 26 | P0-P2 |
+| 6 | Documents Fiscaux ⚠️ | 4 | 13 | P0-P2 |
+| 7 | Remboursement | 5 | 18 | P2 |
+| 8 | Erreurs & Réconciliation | 3 | 13 | P1-P2 |
+| 9 | Reporting | 3 | 13 | P2 |
+| 10 | Disputes | 4 | 13 | P1-P2 |
+| 11 | Configuration & Rollout | 4 | 8 | P0-P2 |
+| **Total** | | **47** | **164** | |
+
+⚠️ = Épics avec condition de garde `stripe_connect === true`
+
+## 🔑 Changement majeur v2.0.0 : Calcul des frais Scénario B
+
+### Problème identifié
+
+Avec Stripe Connect en mode **Destination Charges**, les frais Stripe sont déduits du solde de la **plateforme** (DONACTION), pas du compte connecté.
+
+Avec l'ancienne formule (`application_fee = 4%` seulement) :
+- DONACTION ne recevait que ~2.25% net après déduction des frais Stripe
+
+### Solution implémentée
+
+L'`application_fee_amount` inclut désormais les frais Stripe estimés :
+
+```typescript
+// Scénario B : Donor Pays Fee = FALSE
+const commissionDonaction = montantDon * 0.04;  // 4%
+const fraisStripeEstimes = (totalPreleve * 0.015) + 0.25;  // ~1.75%
+const applicationFee = commissionDonaction + fraisStripeEstimes;
+```
+
+| Don | Commission 4% | Frais Stripe | application_fee | Net DONACTION | Association reçoit |
+|-----|--------------|--------------|-----------------|---------------|-------------------|
+| 100€ | 4.00€ | 1.90€ | 5.90€ | **4.00€** ✅ | 94.10€ |
+
+## 📁 Structure des fichiers
+
+```
+user-stories/
+├── README.md
+├── epic-01-trade-policy/
+│   ├── US-TP-001-schema-evolution.md
+│   ├── US-TP-002-donor-pays-fee-fields.md
+│   └── US-TP-003-migration-script.md
+├── epic-02-formulaire-donateur/
+│   ├── US-FORM-001-fee-choice-ui.md
+│   ├── US-FORM-002-amount-calculation.md
+│   ├── US-FORM-003-association-display.md
+│   └── US-FORM-004-fee-transparency.md
+├── epic-03-backend-paiement/
+│   ├── US-PAY-001-determine-donor-pays-fee.md
+│   ├── US-PAY-002-fee-model-calculation.md
+│   ├── US-PAY-003-donor-pays-fee-field.md
+│   └── US-PAY-004-payment-intent-creation.md
+├── epic-04-webhooks-audit/
+│   └── ... (6 US)
+├── epic-05-onboarding-association/
+│   └── ... (7 US)
+├── epic-06-documents-fiscaux/
+│   └── ... (4 US)
+├── epic-07-remboursement/
+│   └── ... (5 US)
+├── epic-08-erreurs-reconciliation/
+│   └── ... (3 US)
+├── epic-09-reporting/
+│   └── ... (3 US)
+├── epic-10-disputes/
+│   └── ... (4 US)
+└── epic-11-configuration-rollout/
+    └── ... (4 US)
+```
+
+## 🚀 Ordre d'implémentation recommandé
+
+### Phase 1 - Foundation (Sprint 1-2)
+1. **Epic 1** : Trade Policy schema
+2. **Epic 11** : Configuration Stripe (webhooks, secrets)
+3. **Epic 5** : Onboarding Association (comptes connectés)
+
+### Phase 2 - Core Payment Flow (Sprint 3-4)
+4. **Epic 3** : Backend Paiement
+5. **Epic 2** : Formulaire Donateur
+6. **Epic 4** : Webhooks & Audit
+
+### Phase 3 - Documents & Compliance (Sprint 5)
+7. **Epic 6** : Documents Fiscaux
+
+### Phase 4 - Edge Cases (Sprint 6-7)
+8. **Epic 7** : Remboursement
+9. **Epic 8** : Erreurs & Réconciliation
+10. **Epic 10** : Disputes
+11. **Epic 9** : Reporting
+
+## 📝 Conventions
+
+- **Gherkin** : Tous les critères d'acceptation utilisent le format Gherkin
+- **Condition de garde** : Chaque US concernée inclut le bloc de vérification `stripe_connect === true`
+- **Definition of Done** : Checklist standard pour chaque US
+- **Estimation** : Points Fibonacci (1, 2, 3, 5, 8, 13)

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-01-trade-policy/US-TP-001-schema-evolution.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-01-trade-policy/US-TP-001-schema-evolution.md
@@ -1,0 +1,40 @@
+# US-TP-001 : Évolution du schéma Trade Policy
+
+> **Epic**: 1 - Trade Policy | **Priorité**: P0 | **Estimation**: 3 points
+
+## 📋 Description
+
+**En tant que** système backend,
+**Je veux** étendre le schéma trade_policy avec les nouveaux champs Stripe Connect,
+**Afin de** configurer finement le comportement des frais par association.
+
+## 🎯 Critères d'Acceptation
+
+```gherkin
+Scenario: Nouveaux champs disponibles
+  Given le schéma trade_policy mis à jour
+  Then les champs suivants sont disponibles :
+    | Champ | Type | Défaut |
+    | stripe_connect | boolean | false |
+    | donor_pays_fee_project | boolean | true |
+    | donor_pays_fee_club | boolean | false |
+    | allow_donor_fee_choice | boolean | true |
+```
+
+## 📐 Spécifications Techniques
+
+```json
+{
+  "stripe_connect": { "type": "boolean", "default": false },
+  "donor_pays_fee_project": { "type": "boolean", "default": true },
+  "donor_pays_fee_club": { "type": "boolean", "default": false },
+  "allow_donor_fee_choice": { "type": "boolean", "default": true }
+}
+```
+
+## ✅ Definition of Done
+
+- [ ] Schéma mis à jour
+- [ ] Migration créée
+- [ ] Tests de régression
+- [ ] Documentation API mise à jour

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-01-trade-policy/US-TP-002-donor-pays-fee-fields.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-01-trade-policy/US-TP-002-donor-pays-fee-fields.md
@@ -1,0 +1,26 @@
+# US-TP-002 : Champs donor_pays_fee différenciés
+
+> **Epic**: 1 - Trade Policy | **Priorité**: P0 | **Estimation**: 2 points
+
+## 📋 Description
+
+**En tant que** administrateur d'association,
+**Je veux** configurer des comportements différents pour les dons projet vs club,
+**Afin d'** optimiser l'expérience selon le contexte du don.
+
+## 🎯 Critères d'Acceptation
+
+```gherkin
+Scenario: Configuration différenciée
+  Given une trade_policy avec stripe_connect = true
+  When je configure donor_pays_fee_project = true
+  And donor_pays_fee_club = false
+  Then les dons projet proposent par défaut que le donateur paie les frais
+  And les dons club déduisent les frais par défaut
+```
+
+## ✅ Definition of Done
+
+- [ ] Champs ajoutés au schéma
+- [ ] Interface admin Angular mise à jour
+- [ ] Valeurs par défaut appliquées

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-01-trade-policy/US-TP-003-migration-script.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-01-trade-policy/US-TP-003-migration-script.md
@@ -1,0 +1,28 @@
+# US-TP-003 : Script de migration des trade_policies existantes
+
+> **Epic**: 1 - Trade Policy | **Priorité**: P0 | **Estimation**: 3 points
+
+## 📋 Description
+
+**En tant que** système,
+**Je veux** migrer les trade_policies existantes vers le nouveau format,
+**Afin que** les associations existantes ne soient pas impactées.
+
+## 🎯 Critères d'Acceptation
+
+```gherkin
+Scenario: Migration sans impact
+  Given des trade_policies existantes avec donor_pays_fee = true
+  When la migration s'exécute
+  Then stripe_connect = false pour toutes
+  And donor_pays_fee_project = ancien donor_pays_fee
+  And donor_pays_fee_club = ancien donor_pays_fee
+  And le comportement Legacy est préservé
+```
+
+## ✅ Definition of Done
+
+- [ ] Script de migration créé
+- [ ] Rollback possible
+- [ ] Tests sur copie de prod
+- [ ] Exécution en staging validée

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-02-formulaire-donateur/US-FORM-001-fee-choice-ui.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-02-formulaire-donateur/US-FORM-001-fee-choice-ui.md
@@ -1,0 +1,42 @@
+# US-FORM-001 : Interface de choix des frais (Step 3)
+
+> **Epic**: 2 - Formulaire Donateur | **Priorité**: P0 | **Estimation**: 3 points
+
+## ⚠️ Condition de Garde
+
+```typescript
+if (klubr.trade_policy.stripe_connect === true && 
+    klubr.trade_policy.allow_donor_fee_choice === true) {
+  // Afficher le choix
+}
+```
+
+## 📋 Description
+
+**En tant que** donateur,
+**Je veux** pouvoir choisir si je prends en charge les frais ou non,
+**Afin de** décider du montant final que je paie.
+
+## 🎯 Critères d'Acceptation
+
+```gherkin
+Scenario: Affichage du choix
+  Given allow_donor_fee_choice = true
+  When j'arrive à l'étape 3
+  Then je vois deux options radio :
+    | Option | Description |
+    | "Je prends en charge les frais" | L'association reçoit 100% |
+    | "Les frais sont inclus" | Déduction sur le don |
+
+Scenario: Choix masqué si désactivé
+  Given allow_donor_fee_choice = false
+  When j'arrive à l'étape 3
+  Then le choix n'est pas affiché
+  And la valeur par défaut s'applique
+```
+
+## ✅ Definition of Done
+
+- [ ] Composant Svelte 5 créé
+- [ ] Réactif au changement
+- [ ] Tests E2E

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-02-formulaire-donateur/US-FORM-002-amount-calculation.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-02-formulaire-donateur/US-FORM-002-amount-calculation.md
@@ -1,0 +1,313 @@
+# US-FORM-002 : Affichage dynamique des montants selon `donorPaysFee`
+
+> **Epic**: 2 - Formulaire Donateur | **Priorité**: P0 | **Estimation**: 5 points
+
+---
+
+## ⚠️ Condition de Garde
+
+```typescript
+// Ce comportement ne s'applique QUE si :
+klubr.trade_policy.stripe_connect === true
+// Sinon, afficher le comportement Legacy
+```
+
+---
+
+## 📋 Description
+
+**En tant que** donateur,
+**Je veux** voir clairement la décomposition des montants selon mon choix de prise en charge des frais,
+**Afin de** comprendre combien l'association recevra réellement.
+
+---
+
+## 🎯 Critères d'Acceptation
+
+```gherkin
+Feature: Affichage des montants dans le récapitulatif (Step 3)
+
+  Background:
+    Given un klubr avec stripe_connect = true
+    And je suis à l'étape 3 du formulaire (Récapitulatif)
+
+  # SCÉNARIO A : Donor Pays Fee = TRUE
+  
+  Scenario: Affichage Scénario A - Frais payés par le donateur
+    Given j'ai saisi un don de 100€
+    And j'ai choisi une contribution de 10€
+    And donorPaysFee = true
+    When je visualise le récapitulatif
+    Then je vois :
+      | Ligne | Montant |
+      | Montant de votre don | 100,00 € |
+      | Commission plateforme (4%) | 4,00 € |
+      | Frais de transaction | 1,96 € |
+      | Contribution DONACTION | 10,00 € |
+      | ─────────────────────── | ──────── |
+      | **Total à payer** | **115,96 €** |
+    And je vois le message "L'association recevra 100,00 € (100% de votre don)"
+    And le montant du reçu fiscal indique 100,00 €
+
+  # SCÉNARIO B : Donor Pays Fee = FALSE (FORMULE CORRIGÉE)
+  
+  Scenario: Affichage Scénario B - Frais inclus dans le don
+    Given j'ai saisi un don de 100€
+    And j'ai choisi une contribution de 10€
+    And donorPaysFee = false
+    When je visualise le récapitulatif
+    Then je vois :
+      | Ligne | Montant |
+      | Montant de votre don | 100,00 € |
+      | Contribution DONACTION | 10,00 € |
+      | ─────────────────────── | ──────── |
+      | **Total à payer** | **110,00 €** |
+    And je vois le message "L'association recevra 94,10 € (après déduction des frais)"
+    And le montant du reçu fiscal indique 94,10 €
+
+  Scenario: Mise à jour dynamique lors du changement de choix
+    Given donorPaysFee = true
+    And je vois "L'association recevra 100,00 €"
+    When je change donorPaysFee à false
+    Then l'affichage se met à jour immédiatement
+    And je vois "L'association recevra 94,10 €"
+    And le total à payer passe de 115,96 € à 110,00 €
+
+  Scenario: Tooltip explicatif sur les frais
+    Given donorPaysFee = false
+    When je survole l'icône info à côté du montant association
+    Then un tooltip affiche :
+      """
+      Décomposition des frais déduits :
+      • Commission plateforme (4%) : 4,00 €
+      • Frais de transaction : 1,90 €
+      Total déduit : 5,90 €
+      """
+```
+
+---
+
+## 📐 Spécifications Techniques
+
+### Composant Svelte 5
+
+```svelte
+<!-- RecapitulatifStep.svelte -->
+<script lang="ts">
+  import { calculateFees } from '$lib/helpers/fee-calculation-helper';
+  import type { FeeCalculationOutput } from '$lib/types';
+  
+  // Props
+  let { 
+    montantDon, 
+    contribution, 
+    donorPaysFee = $bindable(),
+    tradePolicy,
+    allowDonorFeeChoice 
+  } = $props();
+  
+  // ⚠️ CONDITION DE GARDE
+  const isStripeConnect = tradePolicy.stripe_connect === true;
+  
+  // Calculs réactifs
+  const fees = $derived<FeeCalculationOutput>(
+    isStripeConnect
+      ? calculateFees({ montantDon, contribution, donorPaysFee, tradePolicy })
+      : calculateLegacyFees({ montantDon, contribution, tradePolicy })
+  );
+  
+  // Formattage
+  const formatCurrency = (cents: number) => 
+    new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' })
+      .format(cents / 100);
+</script>
+
+{#if isStripeConnect}
+  <div class="recap-amounts">
+    <!-- Montant du don -->
+    <div class="line">
+      <span>Montant de votre don</span>
+      <span>{formatCurrency(montantDon)}</span>
+    </div>
+    
+    {#if donorPaysFee}
+      <!-- Scénario A : Détail des frais -->
+      <div class="line sub">
+        <span>Commission plateforme ({tradePolicy.commissionPercentage * 100}%)</span>
+        <span>{formatCurrency(fees.commissionDonaction)}</span>
+      </div>
+      <div class="line sub">
+        <span>Frais de transaction</span>
+        <span>{formatCurrency(fees.fraisStripeEstimes)}</span>
+      </div>
+    {/if}
+    
+    <!-- Contribution optionnelle -->
+    {#if contribution > 0}
+      <div class="line">
+        <span>Contribution DONACTION</span>
+        <span>{formatCurrency(contribution)}</span>
+      </div>
+    {/if}
+    
+    <hr />
+    
+    <!-- Total -->
+    <div class="line total">
+      <span>Total à payer</span>
+      <span>{formatCurrency(fees.totalDonateur)}</span>
+    </div>
+    
+    <!-- Message association -->
+    <div class="association-message" class:success={donorPaysFee}>
+      {#if donorPaysFee}
+        <span class="icon">✅</span>
+        L'association recevra <strong>{formatCurrency(fees.netAssociation)}</strong> 
+        (100% de votre don)
+      {:else}
+        <span class="icon">ℹ️</span>
+        L'association recevra <strong>{formatCurrency(fees.netAssociation)}</strong>
+        <button class="tooltip-trigger" title="Décomposition des frais déduits :
+• Commission plateforme (4%) : {formatCurrency(fees.commissionDonaction)}
+• Frais de transaction : {formatCurrency(fees.fraisStripeEstimes)}
+Total déduit : {formatCurrency(fees.applicationFee)}">
+          (après déduction des frais)
+        </button>
+      {/if}
+    </div>
+    
+    <!-- Reçu fiscal -->
+    <div class="receipt-preview">
+      📄 Votre reçu fiscal sera de <strong>{formatCurrency(fees.montantRecuFiscal)}</strong>
+    </div>
+  </div>
+{:else}
+  <!-- Affichage Legacy -->
+  <LegacyRecapitulatif {montantDon} {contribution} />
+{/if}
+
+<style>
+  .recap-amounts {
+    background: var(--color-surface);
+    border-radius: 8px;
+    padding: 1.5rem;
+  }
+  
+  .line {
+    display: flex;
+    justify-content: space-between;
+    padding: 0.5rem 0;
+  }
+  
+  .line.sub {
+    font-size: 0.9rem;
+    color: var(--color-text-secondary);
+    padding-left: 1rem;
+  }
+  
+  .line.total {
+    font-weight: bold;
+    font-size: 1.2rem;
+    border-top: 2px solid var(--color-border);
+    padding-top: 1rem;
+    margin-top: 0.5rem;
+  }
+  
+  .association-message {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 6px;
+    background: var(--color-info-light);
+  }
+  
+  .association-message.success {
+    background: var(--color-success-light);
+  }
+  
+  .receipt-preview {
+    margin-top: 1rem;
+    padding: 0.75rem;
+    background: var(--color-surface-alt);
+    border-radius: 4px;
+    font-size: 0.9rem;
+  }
+  
+  .tooltip-trigger {
+    cursor: help;
+    text-decoration: underline dotted;
+    border: none;
+    background: none;
+    color: inherit;
+  }
+</style>
+```
+
+### Tests E2E
+
+```typescript
+// tests/e2e/donation-form.spec.ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Récapitulatif des montants', () => {
+  test.beforeEach(async ({ page }) => {
+    // Naviguer vers le formulaire avec Stripe Connect activé
+    await page.goto('/don/club-test?stripe_connect=true');
+    await page.fill('[data-testid="montant"]', '100');
+    await page.fill('[data-testid="contribution"]', '10');
+    await page.click('[data-testid="next-step"]');
+    await page.click('[data-testid="next-step"]');
+  });
+  
+  test('Scénario A - affiche les frais détaillés', async ({ page }) => {
+    await page.click('[data-testid="donor-pays-fee-true"]');
+    
+    await expect(page.locator('[data-testid="commission"]')).toContainText('4,00 €');
+    await expect(page.locator('[data-testid="stripe-fees"]')).toContainText('1,96 €');
+    await expect(page.locator('[data-testid="total"]')).toContainText('115,96 €');
+    await expect(page.locator('[data-testid="net-association"]')).toContainText('100,00 €');
+    await expect(page.locator('[data-testid="recu-fiscal"]')).toContainText('100,00 €');
+  });
+  
+  test('Scénario B - affiche le montant net réduit', async ({ page }) => {
+    await page.click('[data-testid="donor-pays-fee-false"]');
+    
+    await expect(page.locator('[data-testid="total"]')).toContainText('110,00 €');
+    await expect(page.locator('[data-testid="net-association"]')).toContainText('94,10 €');
+    await expect(page.locator('[data-testid="recu-fiscal"]')).toContainText('94,10 €');
+  });
+  
+  test('Mise à jour dynamique lors du changement de choix', async ({ page }) => {
+    // Commencer avec Scénario A
+    await page.click('[data-testid="donor-pays-fee-true"]');
+    await expect(page.locator('[data-testid="total"]')).toContainText('115,96 €');
+    
+    // Basculer vers Scénario B
+    await page.click('[data-testid="donor-pays-fee-false"]');
+    await expect(page.locator('[data-testid="total"]')).toContainText('110,00 €');
+    
+    // La transition doit être fluide (pas de rechargement)
+    await expect(page.locator('[data-testid="recap-amounts"]')).toBeVisible();
+  });
+});
+```
+
+---
+
+## 🔗 Dépendances
+
+- **Prérequis**: US-PAY-002 (calculateFees), US-FORM-001 (UI choix frais)
+- **Bloque**: US-FORM-004 (transparence frais)
+
+---
+
+## ✅ Definition of Done
+
+- [ ] Composant RecapitulatifStep implémenté
+- [ ] Condition de garde `stripe_connect === true` présente
+- [ ] Affichage correct pour Scénario A (frais séparés)
+- [ ] Affichage correct pour Scénario B (frais inclus, net ~94%)
+- [ ] Mise à jour dynamique sans rechargement
+- [ ] Tooltip explicatif fonctionnel
+- [ ] Tests E2E passants
+- [ ] Accessibilité validée (ARIA labels)
+- [ ] PR approuvée et mergée

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-02-formulaire-donateur/US-FORM-003-association-display.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-02-formulaire-donateur/US-FORM-003-association-display.md
@@ -1,0 +1,34 @@
+# US-FORM-003 : Affichage infos association (Stripe Connect)
+
+> **Epic**: 2 - Formulaire Donateur | **Priorité**: P1 | **Estimation**: 2 points
+
+## ⚠️ Condition de Garde
+
+```typescript
+if (klubr.trade_policy.stripe_connect === true) {
+  // Afficher le nom de l'association comme bénéficiaire
+}
+```
+
+## 📋 Description
+
+**En tant que** donateur,
+**Je veux** voir clairement le nom de l'association bénéficiaire,
+**Afin de** savoir à qui va mon don directement.
+
+## 🎯 Critères d'Acceptation
+
+```gherkin
+Scenario: Affichage bénéficiaire
+  Given stripe_connect = true
+  When je visualise le récapitulatif
+  Then je vois "Bénéficiaire : FC Lyon"
+  And le logo de l'association est affiché
+  And la mention "Paiement sécurisé via DONACTION" apparaît
+```
+
+## ✅ Definition of Done
+
+- [ ] Nom association affiché
+- [ ] Logo association intégré
+- [ ] Mention plateforme visible

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-02-formulaire-donateur/US-FORM-004-fee-transparency.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-02-formulaire-donateur/US-FORM-004-fee-transparency.md
@@ -1,0 +1,32 @@
+# US-FORM-004 : Transparence totale des frais
+
+> **Epic**: 2 - Formulaire Donateur | **Priorité**: P1 | **Estimation**: 3 points
+
+## 📋 Description
+
+**En tant que** donateur,
+**Je veux** comprendre exactement où va mon argent,
+**Afin d'** avoir confiance dans la plateforme.
+
+## 🎯 Critères d'Acceptation
+
+```gherkin
+Scenario: Décomposition visible
+  When je visualise le récapitulatif
+  Then je vois la décomposition :
+    | Poste | Montant |
+    | Don à l'association | 100,00 € |
+    | Commission plateforme | 4,00 € |
+    | Frais bancaires | 1,90 € |
+    | Contribution (optionnelle) | 10,00 € |
+
+Scenario: Tooltip explicatif
+  When je clique sur l'icône info
+  Then un popup explique chaque ligne de frais
+```
+
+## ✅ Definition of Done
+
+- [ ] Décomposition claire
+- [ ] Tooltips informatifs
+- [ ] Responsive mobile

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-03-backend-paiement/US-PAY-001-determine-donor-pays-fee.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-03-backend-paiement/US-PAY-001-determine-donor-pays-fee.md
@@ -1,0 +1,201 @@
+# US-PAY-001 : Implémenter la logique `determineDonorPaysFee()`
+
+> **Epic**: 3 - Backend Paiement | **Priorité**: P0 | **Estimation**: 5 points
+
+---
+
+## ⚠️ Condition de Garde
+
+```typescript
+// Cette logique ne s'applique QUE si :
+klubr.trade_policy.stripe_connect === true
+// Sinon, utiliser le comportement Legacy
+```
+
+---
+
+## 📋 Description
+
+**En tant que** système backend,
+**Je veux** déterminer automatiquement si le donateur paie les frais,
+**Afin que** le calcul des montants soit cohérent selon le contexte (projet vs club) et le choix du donateur.
+
+---
+
+## 🎯 Critères d'Acceptation
+
+```gherkin
+Feature: Détermination du mode Donor Pays Fee
+
+  Background:
+    Given un klubr avec stripe_connect = true
+
+  Scenario: Don à un projet (défaut = frais payés par donateur)
+    Given un don destiné à un projet
+    And trade_policy.donor_pays_fee_project = true
+    And le donateur n'a pas fait de choix explicite
+    When je calcule determineDonorPaysFee()
+    Then le résultat est true
+    And les frais Stripe + commission sont ajoutés au montant
+
+  Scenario: Don au club (défaut = frais inclus)
+    Given un don destiné au club (pas de projet)
+    And trade_policy.donor_pays_fee_club = false
+    And le donateur n'a pas fait de choix explicite
+    When je calcule determineDonorPaysFee()
+    Then le résultat est false
+    And le montant saisi est le total (frais déduits de l'association)
+
+  Scenario: Donateur override le défaut
+    Given trade_policy.allow_donor_fee_choice = true
+    And le donateur a explicitement choisi donorPaysFee = true
+    When je calcule determineDonorPaysFee()
+    Then le résultat respecte le choix du donateur (true)
+    And le défaut du contexte est ignoré
+
+  Scenario: Choix donateur désactivé
+    Given trade_policy.allow_donor_fee_choice = false
+    And le donateur tente de modifier donorPaysFee
+    When je calcule determineDonorPaysFee()
+    Then le choix du donateur est ignoré
+    And le défaut du contexte s'applique
+
+  Scenario: Mode Legacy (stripe_connect = false)
+    Given klubr.trade_policy.stripe_connect = false
+    When je calcule determineDonorPaysFee()
+    Then le comportement Legacy s'applique
+    And la fonction retourne la valeur historique
+```
+
+---
+
+## 📐 Spécifications Techniques
+
+### Fonction principale
+
+```typescript
+// helpers/fee-calculation-helper.ts
+
+interface DonorPaysFeeParams {
+  klubr: Klubr;
+  isProjectDon: boolean;
+  donorChoice?: boolean | null;
+}
+
+export function determineDonorPaysFee(params: DonorPaysFeeParams): boolean {
+  const { klubr, isProjectDon, donorChoice } = params;
+  const tradePolicy = klubr.trade_policy;
+  
+  // ⚠️ CONDITION DE GARDE - Mode Legacy
+  if (!tradePolicy.stripe_connect) {
+    return tradePolicy.donor_pays_fee ?? false; // Legacy behavior
+  }
+  
+  // 1. Récupérer la valeur par défaut selon le contexte
+  const defaultValue = isProjectDon 
+    ? tradePolicy.donor_pays_fee_project 
+    : tradePolicy.donor_pays_fee_club;
+  
+  // 2. Si le choix donateur est désactivé, retourner le défaut
+  if (!tradePolicy.allow_donor_fee_choice) {
+    return defaultValue;
+  }
+  
+  // 3. Si le donateur a fait un choix explicite, le respecter
+  if (donorChoice !== null && donorChoice !== undefined) {
+    return donorChoice;
+  }
+  
+  // 4. Sinon, retourner le défaut
+  return defaultValue;
+}
+```
+
+### Interface TradePolicy étendue
+
+```typescript
+interface TradePolicy {
+  // Champs existants
+  fee_model: 'percentage_only' | 'fixed_only' | 'percentage_plus_fixed';
+  commissionPercentage: number;
+  fixed_amount: number;
+  
+  // Nouveaux champs Stripe Connect
+  stripe_connect: boolean;
+  donor_pays_fee_project: boolean;  // Défaut pour dons projet
+  donor_pays_fee_club: boolean;     // Défaut pour dons club
+  allow_donor_fee_choice: boolean;  // Autoriser le donateur à choisir
+  
+  // Legacy (déprécié mais conservé)
+  donor_pays_fee?: boolean;
+}
+```
+
+### Tests unitaires requis
+
+```typescript
+describe('determineDonorPaysFee', () => {
+  it('should use project default for project donations', () => {
+    const result = determineDonorPaysFee({
+      klubr: { trade_policy: { stripe_connect: true, donor_pays_fee_project: true }},
+      isProjectDon: true,
+      donorChoice: null
+    });
+    expect(result).toBe(true);
+  });
+  
+  it('should use club default for club donations', () => {
+    const result = determineDonorPaysFee({
+      klubr: { trade_policy: { stripe_connect: true, donor_pays_fee_club: false }},
+      isProjectDon: false,
+      donorChoice: null
+    });
+    expect(result).toBe(false);
+  });
+  
+  it('should respect donor choice when allowed', () => {
+    const result = determineDonorPaysFee({
+      klubr: { trade_policy: { stripe_connect: true, allow_donor_fee_choice: true }},
+      isProjectDon: true,
+      donorChoice: false
+    });
+    expect(result).toBe(false);
+  });
+  
+  it('should ignore donor choice when not allowed', () => {
+    const result = determineDonorPaysFee({
+      klubr: { trade_policy: { stripe_connect: true, allow_donor_fee_choice: false, donor_pays_fee_project: true }},
+      isProjectDon: true,
+      donorChoice: false
+    });
+    expect(result).toBe(true);
+  });
+  
+  it('should use legacy behavior when stripe_connect is false', () => {
+    const result = determineDonorPaysFee({
+      klubr: { trade_policy: { stripe_connect: false, donor_pays_fee: true }},
+      isProjectDon: true,
+      donorChoice: null
+    });
+    expect(result).toBe(true);
+  });
+});
+```
+
+---
+
+## 🔗 Dépendances
+
+- **Prérequis**: US-TP-002 (champs donor_pays_fee_* dans trade_policy)
+- **Bloque**: US-PAY-002, US-FORM-002
+
+---
+
+## ✅ Definition of Done
+
+- [ ] Fonction `determineDonorPaysFee()` implémentée
+- [ ] Condition de garde `stripe_connect === true` présente
+- [ ] Comportement Legacy préservé si `stripe_connect === false`
+- [ ] Tests unitaires passants (5 cas minimum)
+- [ ] Documentation JSDoc ajoutée
+- [ ] PR approuvée et mergée

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-03-backend-paiement/US-PAY-002-fee-model-calculation.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-03-backend-paiement/US-PAY-002-fee-model-calculation.md
@@ -1,0 +1,383 @@
+# US-PAY-002 : Implémenter les 3 modes de `fee_model` avec correction Scénario B
+
+> **Epic**: 3 - Backend Paiement | **Priorité**: P0 | **Estimation**: 8 points
+
+---
+
+## ⚠️ Condition de Garde
+
+```typescript
+// Ce calcul ne s'applique QUE si :
+klubr.trade_policy.stripe_connect === true
+// Sinon, utiliser le calcul Legacy
+```
+
+---
+
+## 📋 Description
+
+**En tant que** système backend,
+**Je veux** calculer les montants selon le mode de frais configuré,
+**Afin que** DONACTION maintienne sa commission de 4% net dans tous les scénarios, y compris quand le donateur ne paie pas les frais.
+
+---
+
+## 🚨 Point Technique Critique : Scénario B
+
+### Problème identifié
+
+Avec Stripe Connect en mode **Destination Charges**, les frais Stripe sont toujours déduits du solde de la **plateforme** (DONACTION), pas du compte connecté.
+
+Avec l'ancienne formule (`application_fee = 4%` seulement) :
+- Sur un don de 100€, application_fee = 4€
+- Stripe prélève ~1.90€ sur DONACTION
+- DONACTION ne reçoit que **2.10€ net** (au lieu de 4€)
+
+### Solution implémentée
+
+L'`application_fee_amount` inclut les frais Stripe estimés :
+
+```
+application_fee = commission_DONACTION + frais_Stripe_estimés
+```
+
+---
+
+## 🎯 Critères d'Acceptation
+
+```gherkin
+Feature: Calcul des montants selon fee_model
+
+  Background:
+    Given un klubr avec stripe_connect = true
+    And commissionPercentage = 4%
+
+  # SCÉNARIO A : Donor Pays Fee = TRUE
+  
+  Scenario: Percentage only + Donor Pays Fee = TRUE
+    Given fee_model = "percentage_only"
+    And donorPaysFee = true
+    And montant don = 100€
+    And contribution = 10€
+    When je calcule les montants
+    Then frais_stripe = (114€ × 1.5%) + 0.25€ = 1.96€
+    And commission_donaction = 100€ × 4% = 4.00€
+    And total_donateur = 100€ + 4€ + 1.96€ + 10€ = 115.96€
+    And application_fee = 4.00€ + 1.96€ = 5.96€
+    And net_association = 100.00€
+    And net_donaction = 10€ + 4€ = 14.00€
+    And recu_fiscal = 100.00€
+
+  Scenario: Fixed only + Donor Pays Fee = TRUE
+    Given fee_model = "fixed_only"
+    And fixed_amount = 5€
+    And donorPaysFee = true
+    And montant don = 100€
+    When je calcule les montants
+    Then commission_donaction = 5€
+    And le calcul utilise le montant fixe
+
+  Scenario: Percentage plus fixed + Donor Pays Fee = TRUE
+    Given fee_model = "percentage_plus_fixed"
+    And commissionPercentage = 4%
+    And fixed_amount = 1€
+    And donorPaysFee = true
+    And montant don = 100€
+    When je calcule les montants
+    Then commission_donaction = (100€ × 4%) + 1€ = 5€
+    And les deux composants sont additionnés
+
+  # SCÉNARIO B : Donor Pays Fee = FALSE (CORRIGÉ)
+  
+  Scenario: Percentage only + Donor Pays Fee = FALSE (FORMULE CORRIGÉE)
+    Given fee_model = "percentage_only"
+    And donorPaysFee = false
+    And montant don = 100€
+    And contribution = 10€
+    When je calcule les montants
+    Then total_preleve = 100€ + 10€ = 110€
+    And frais_stripe_estimes = (110€ × 1.5%) + 0.25€ = 1.90€
+    And commission_donaction = 100€ × 4% = 4.00€
+    And application_fee = 4.00€ + 1.90€ = 5.90€
+    And net_association = 100€ - 5.90€ = 94.10€
+    And net_donaction_brut = 10€ + 5.90€ = 15.90€
+    And net_donaction_apres_stripe = 15.90€ - 1.90€ = 14.00€
+    And recu_fiscal = 94.10€
+
+  Scenario: Vérification commission 4% maintenue (Scénario B)
+    Given donorPaysFee = false
+    And montant don = 100€
+    And contribution = 10€
+    When le paiement est finalisé
+    Then DONACTION reçoit net = 14.00€ (contribution 10€ + commission 4€)
+    And la commission effective = 4% du don
+
+  # MODE LEGACY
+  
+  Scenario: Mode Legacy préservé
+    Given klubr.trade_policy.stripe_connect = false
+    When je calcule les montants
+    Then le calcul utilise l'ancien algorithme
+    And aucune application_fee_amount n'est définie
+```
+
+---
+
+## 📐 Spécifications Techniques
+
+### Constantes Stripe (France)
+
+```typescript
+// constants/stripe.ts
+export const STRIPE_FEES = {
+  PERCENTAGE: 0.015,  // 1.5% pour cartes européennes
+  FIXED: 0.25,        // 0.25€ par transaction
+} as const;
+
+export const DONACTION_COMMISSION = {
+  DEFAULT_PERCENTAGE: 0.04,  // 4%
+} as const;
+```
+
+### Interface de calcul
+
+```typescript
+interface FeeCalculationInput {
+  montantDon: number;           // En centimes
+  contribution: number;         // En centimes (contribution volontaire DONACTION)
+  donorPaysFee: boolean;
+  tradePolicy: {
+    fee_model: 'percentage_only' | 'fixed_only' | 'percentage_plus_fixed';
+    commissionPercentage: number;
+    fixed_amount: number;
+    stripe_connect: boolean;
+  };
+}
+
+interface FeeCalculationOutput {
+  totalDonateur: number;        // Ce que le donateur paie
+  netAssociation: number;       // Ce que l'association reçoit
+  applicationFee: number;       // application_fee_amount pour Stripe
+  commissionDonaction: number;  // Commission DONACTION (4%)
+  fraisStripeEstimes: number;   // Frais Stripe estimés
+  montantRecuFiscal: number;    // Montant pour le reçu fiscal
+}
+```
+
+### Fonction de calcul principale
+
+```typescript
+// helpers/fee-calculation-helper.ts
+
+export function calculateFees(input: FeeCalculationInput): FeeCalculationOutput {
+  const { montantDon, contribution, donorPaysFee, tradePolicy } = input;
+  
+  // ⚠️ CONDITION DE GARDE
+  if (!tradePolicy.stripe_connect) {
+    return calculateLegacyFees(input);
+  }
+  
+  // 1. Calculer la commission DONACTION selon le fee_model
+  const commissionDonaction = calculateCommission(montantDon, tradePolicy);
+  
+  if (donorPaysFee) {
+    // SCÉNARIO A : Le donateur paie les frais séparément
+    return calculateScenarioA(montantDon, contribution, commissionDonaction);
+  } else {
+    // SCÉNARIO B : Les frais sont déduits du don (FORMULE CORRIGÉE)
+    return calculateScenarioB(montantDon, contribution, commissionDonaction);
+  }
+}
+
+function calculateCommission(montantDon: number, tradePolicy: TradePolicy): number {
+  switch (tradePolicy.fee_model) {
+    case 'percentage_only':
+      return Math.round(montantDon * tradePolicy.commissionPercentage);
+    case 'fixed_only':
+      return tradePolicy.fixed_amount * 100; // Convertir en centimes
+    case 'percentage_plus_fixed':
+      return Math.round(montantDon * tradePolicy.commissionPercentage) 
+             + (tradePolicy.fixed_amount * 100);
+    default:
+      return Math.round(montantDon * DONACTION_COMMISSION.DEFAULT_PERCENTAGE);
+  }
+}
+
+function calculateScenarioA(
+  montantDon: number, 
+  contribution: number, 
+  commissionDonaction: number
+): FeeCalculationOutput {
+  // Total avant frais Stripe
+  const subtotal = montantDon + commissionDonaction + contribution;
+  
+  // Frais Stripe sur le total
+  const fraisStripeEstimes = Math.round(subtotal * STRIPE_FEES.PERCENTAGE) + STRIPE_FEES.FIXED * 100;
+  
+  // Total final pour le donateur
+  const totalDonateur = subtotal + fraisStripeEstimes;
+  
+  // Application fee = commission + frais Stripe (pour que DONACTION paie les frais)
+  const applicationFee = commissionDonaction + fraisStripeEstimes;
+  
+  return {
+    totalDonateur,
+    netAssociation: montantDon,  // L'association reçoit 100% du don
+    applicationFee,
+    commissionDonaction,
+    fraisStripeEstimes,
+    montantRecuFiscal: montantDon,  // Reçu = montant intentionnel
+  };
+}
+
+function calculateScenarioB(
+  montantDon: number, 
+  contribution: number, 
+  commissionDonaction: number
+): FeeCalculationOutput {
+  // Total prélevé = don + contribution (pas de frais additionnels visibles)
+  const totalDonateur = montantDon + contribution;
+  
+  // ⚠️ FORMULE CORRIGÉE : Estimer les frais Stripe sur le total prélevé
+  const fraisStripeEstimes = Math.round(totalDonateur * STRIPE_FEES.PERCENTAGE) + STRIPE_FEES.FIXED * 100;
+  
+  // ⚠️ Application fee INCLUT les frais Stripe pour garantir 4% net à DONACTION
+  const applicationFee = commissionDonaction + fraisStripeEstimes;
+  
+  // L'association reçoit le don MOINS l'application fee
+  const netAssociation = montantDon - applicationFee;
+  
+  return {
+    totalDonateur,
+    netAssociation,
+    applicationFee,
+    commissionDonaction,
+    fraisStripeEstimes,
+    montantRecuFiscal: netAssociation,  // Reçu = ce que l'association reçoit réellement
+  };
+}
+```
+
+### Exemple de calcul détaillé (Scénario B)
+
+```
+Don: 100€ (10000 centimes) | Contribution: 10€ (1000 centimes)
+
+1. totalDonateur = 10000 + 1000 = 11000 (110€)
+2. fraisStripeEstimes = round(11000 × 0.015) + 25 = 165 + 25 = 190 (1.90€)
+3. commissionDonaction = 10000 × 0.04 = 400 (4€)
+4. applicationFee = 400 + 190 = 590 (5.90€)
+5. netAssociation = 10000 - 590 = 9410 (94.10€)
+6. montantRecuFiscal = 9410 (94.10€)
+
+Vérification côté DONACTION:
+- DONACTION reçoit brut = contribution + applicationFee = 1000 + 590 = 1590 (15.90€)
+- Stripe prélève = 190 (1.90€)
+- DONACTION net = 1590 - 190 = 1400 (14.00€) ✅
+- Commission effective = 400/10000 = 4% ✅
+```
+
+---
+
+## 🧪 Tests Unitaires
+
+```typescript
+describe('calculateFees', () => {
+  describe('Scénario A - Donor Pays Fee = TRUE', () => {
+    it('should add fees on top of donation amount', () => {
+      const result = calculateFees({
+        montantDon: 10000, // 100€
+        contribution: 1000, // 10€
+        donorPaysFee: true,
+        tradePolicy: { fee_model: 'percentage_only', commissionPercentage: 0.04, stripe_connect: true }
+      });
+      
+      expect(result.netAssociation).toBe(10000); // 100€
+      expect(result.commissionDonaction).toBe(400); // 4€
+      expect(result.montantRecuFiscal).toBe(10000); // 100€
+    });
+  });
+  
+  describe('Scénario B - Donor Pays Fee = FALSE (CORRIGÉ)', () => {
+    it('should include Stripe fees in application_fee to maintain 4% commission', () => {
+      const result = calculateFees({
+        montantDon: 10000, // 100€
+        contribution: 1000, // 10€
+        donorPaysFee: false,
+        tradePolicy: { fee_model: 'percentage_only', commissionPercentage: 0.04, stripe_connect: true }
+      });
+      
+      // application_fee = commission (400) + frais Stripe estimés (190) = 590
+      expect(result.applicationFee).toBe(590);
+      
+      // Association reçoit don - application_fee = 10000 - 590 = 9410
+      expect(result.netAssociation).toBe(9410);
+      
+      // Reçu fiscal = montant net reçu par l'association
+      expect(result.montantRecuFiscal).toBe(9410);
+      
+      // Vérification: DONACTION net après déduction Stripe
+      // contribution (1000) + applicationFee (590) - fraisStripe (190) = 1400 (14€)
+      const netDonaction = result.contribution + result.applicationFee - result.fraisStripeEstimes;
+      expect(netDonaction).toBe(1400); // 14€ = 10€ contribution + 4€ commission
+    });
+    
+    it('should ensure DONACTION always receives 4% net commission', () => {
+      const testCases = [
+        { don: 5000, contribution: 500 },   // 50€ + 5€
+        { don: 10000, contribution: 1000 }, // 100€ + 10€
+        { don: 50000, contribution: 2500 }, // 500€ + 25€
+      ];
+      
+      testCases.forEach(({ don, contribution }) => {
+        const result = calculateFees({
+          montantDon: don,
+          contribution,
+          donorPaysFee: false,
+          tradePolicy: { fee_model: 'percentage_only', commissionPercentage: 0.04, stripe_connect: true }
+        });
+        
+        const netDonaction = contribution + result.applicationFee - result.fraisStripeEstimes;
+        const expectedCommission = don * 0.04;
+        
+        // DONACTION doit recevoir contribution + 4% du don
+        expect(netDonaction).toBeCloseTo(contribution + expectedCommission, 0);
+      });
+    });
+  });
+  
+  describe('Mode Legacy', () => {
+    it('should use legacy calculation when stripe_connect is false', () => {
+      const result = calculateFees({
+        montantDon: 10000,
+        contribution: 1000,
+        donorPaysFee: false,
+        tradePolicy: { fee_model: 'percentage_only', commissionPercentage: 0.04, stripe_connect: false }
+      });
+      
+      // Vérifier que le calcul Legacy est utilisé
+      expect(result.applicationFee).toBe(0); // Pas d'application_fee en mode Legacy
+    });
+  });
+});
+```
+
+---
+
+## 🔗 Dépendances
+
+- **Prérequis**: US-PAY-001 (determineDonorPaysFee)
+- **Bloque**: US-PAY-004 (createPaymentIntent), US-FORM-002, US-DOC-003
+
+---
+
+## ✅ Definition of Done
+
+- [ ] Fonction `calculateFees()` implémentée avec les 3 modes
+- [ ] Scénario B corrigé pour inclure frais Stripe dans application_fee
+- [ ] Condition de garde `stripe_connect === true` présente
+- [ ] Tests unitaires couvrant les 2 scénarios × 3 modes = 6 cas
+- [ ] Test de non-régression du mode Legacy
+- [ ] Vérification que DONACTION maintient 4% net dans tous les cas
+- [ ] Documentation des formules ajoutée
+- [ ] PR approuvée et mergée

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-03-backend-paiement/US-PAY-003-donor-pays-fee-field.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-03-backend-paiement/US-PAY-003-donor-pays-fee-field.md
@@ -1,0 +1,44 @@
+# US-PAY-003 : Champ `donor_pays_fee` sur klub-don
+
+> **Epic**: 3 - Backend Paiement | **Priorité**: P0 | **Estimation**: 2 points
+
+## 📋 Description
+
+**En tant que** système,
+**Je veux** enregistrer le choix du donateur sur chaque don,
+**Afin de** pouvoir recalculer les montants et générer les documents corrects.
+
+## 🎯 Critères d'Acceptation
+
+```gherkin
+Scenario: Enregistrement du choix
+  Given un don en cours de création
+  When le donateur choisit donorPaysFee = false
+  Then le champ est sauvegardé sur l'entité klub-don
+  And il est immuable après paiement
+
+Scenario: Valeurs calculées stockées
+  Given donorPaysFee = false
+  When le paiement est confirmé
+  Then netAssociationAmount est calculé et stocké
+  And applicationFeeAmount est stocké
+  And ces valeurs sont utilisées pour le reçu fiscal
+```
+
+## 📐 Spécifications Techniques
+
+```json
+{
+  "donorPaysFee": { "type": "boolean" },
+  "netAssociationAmount": { "type": "integer" },
+  "applicationFeeAmount": { "type": "integer" },
+  "stripeFeesEstimate": { "type": "integer" }
+}
+```
+
+## ✅ Definition of Done
+
+- [ ] Schéma klub-don mis à jour
+- [ ] Migration créée
+- [ ] Valeurs calculées lors du paiement
+- [ ] Champs immuables après confirmation

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-03-backend-paiement/US-PAY-004-payment-intent-creation.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-03-backend-paiement/US-PAY-004-payment-intent-creation.md
@@ -1,0 +1,62 @@
+# US-PAY-004 : Création PaymentIntent avec application_fee_amount
+
+> **Epic**: 3 - Backend Paiement | **Priorité**: P0 | **Estimation**: 6 points
+
+## ⚠️ Condition de Garde
+
+```typescript
+if (klubr.trade_policy.stripe_connect === true) {
+  // Créer avec transfer_data et application_fee_amount
+} else {
+  // Comportement Legacy
+}
+```
+
+## 📋 Description
+
+**En tant que** système backend,
+**Je veux** créer le PaymentIntent avec les bons paramètres Stripe Connect,
+**Afin que** le paiement soit correctement routé vers l'association.
+
+## 🎯 Critères d'Acceptation
+
+```gherkin
+Scenario: Création PaymentIntent Stripe Connect
+  Given stripe_connect = true
+  And un compte connecté valide
+  When je crée le PaymentIntent
+  Then les paramètres incluent :
+    | Paramètre | Valeur |
+    | transfer_data.destination | acct_XXXXX |
+    | application_fee_amount | calculé selon US-PAY-002 |
+    | on_behalf_of | acct_XXXXX |
+
+Scenario: Mode Legacy
+  Given stripe_connect = false
+  When je crée le PaymentIntent
+  Then aucun transfer_data n'est inclus
+  And le paiement va sur le compte Fond Klubr
+```
+
+## 📐 Code clé
+
+```typescript
+const paymentIntentParams: Stripe.PaymentIntentCreateParams = {
+  amount: fees.totalDonateur,
+  currency: 'eur',
+  ...(tradePolicy.stripe_connect && connectedAccount && {
+    transfer_data: {
+      destination: connectedAccount.stripeAccountId,
+    },
+    application_fee_amount: fees.applicationFee,
+    on_behalf_of: connectedAccount.stripeAccountId,
+  }),
+};
+```
+
+## ✅ Definition of Done
+
+- [ ] Création PaymentIntent adaptée
+- [ ] Condition de garde implémentée
+- [ ] Tests avec Stripe CLI
+- [ ] Webhook payment_intent.succeeded vérifie le routage

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-04-webhooks-audit/US-WH-001-webhook-log.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-04-webhooks-audit/US-WH-001-webhook-log.md
@@ -1,0 +1,19 @@
+# US-WH-001 : Content-type webhook-log
+
+> **Epic**: 4 - Webhooks | **Priorité**: P1 | **Estimation**: 2 points
+
+## 📋 Description
+
+Créer une entité pour logger tous les événements webhook reçus (audit trail).
+
+## 📐 Schéma
+
+```json
+{
+  "eventId": { "type": "string", "unique": true },
+  "eventType": { "type": "string" },
+  "payload": { "type": "json" },
+  "processedAt": { "type": "datetime" },
+  "status": { "type": "enumeration", "enum": ["pending", "processed", "failed"] }
+}
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-04-webhooks-audit/US-WH-002-connect-webhook-endpoint.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-04-webhooks-audit/US-WH-002-connect-webhook-endpoint.md
@@ -1,0 +1,20 @@
+# US-WH-002 : Endpoint /stripe-connect/webhook
+
+> **Epic**: 4 - Webhooks | **Priorité**: P0 | **Estimation**: 5 points
+
+## 📋 Description
+
+Créer l'endpoint dédié aux événements des comptes connectés.
+
+## 🎯 Événements gérés
+
+- `account.updated`
+- `account.application.deauthorized`
+- `payout.failed`
+- `charge.dispute.created`
+- `charge.dispute.updated`
+- `charge.dispute.closed`
+
+## 📐 Configuration
+
+Secret distinct : `STRIPE_WEBHOOK_SECRET_CONNECT`

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-04-webhooks-audit/US-WH-003-account-updated.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-04-webhooks-audit/US-WH-003-account-updated.md
@@ -1,0 +1,17 @@
+# US-WH-003 : Handler account.updated
+
+> **Epic**: 4 - Webhooks | **Priorité**: P0 | **Estimation**: 3 points
+
+## 📋 Description
+
+Synchroniser le statut KYC lors des mises à jour du compte connecté.
+
+```gherkin
+Scenario: KYC complété
+  Given un événement account.updated
+  And capabilities.card_payments = active
+  And capabilities.transfers = active
+  When je traite l'événement
+  Then connected_account.status = "active"
+  And l'association peut recevoir des dons
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-04-webhooks-audit/US-WH-004-account-deauthorized.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-04-webhooks-audit/US-WH-004-account-deauthorized.md
@@ -1,0 +1,16 @@
+# US-WH-004 : Handler account.application.deauthorized
+
+> **Epic**: 4 - Webhooks | **Priorité**: P1 | **Estimation**: 2 points
+
+## 📋 Description
+
+Gérer la déconnexion d'un compte Express.
+
+```gherkin
+Scenario: Compte déconnecté
+  Given un événement account.application.deauthorized
+  When je traite l'événement
+  Then connected_account.status = "disconnected"
+  And l'association ne peut plus recevoir de dons
+  And une alerte admin est envoyée
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-04-webhooks-audit/US-WH-005-dispute-handlers.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-04-webhooks-audit/US-WH-005-dispute-handlers.md
@@ -1,0 +1,13 @@
+# US-WH-005 : Handlers disputes
+
+> **Epic**: 4 - Webhooks | **Priorité**: P1 | **Estimation**: 5 points
+
+## 📋 Description
+
+Gérer les événements de litige (charge.dispute.*).
+
+## Événements
+
+- `charge.dispute.created` → Marquer le don, reverser le transfert
+- `charge.dispute.updated` → Mettre à jour le statut
+- `charge.dispute.closed` → Finaliser (won/lost)

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-04-webhooks-audit/US-WH-006-payout-failed.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-04-webhooks-audit/US-WH-006-payout-failed.md
@@ -1,0 +1,16 @@
+# US-WH-006 : Handler payout.failed
+
+> **Epic**: 4 - Webhooks | **Priorité**: P2 | **Estimation**: 3 points
+
+## 📋 Description
+
+Alerter en cas d'échec de virement vers l'association.
+
+```gherkin
+Scenario: Payout échoué
+  Given un événement payout.failed
+  When je traite l'événement
+  Then une alerte Slack est envoyée
+  And un email est envoyé au responsable de l'association
+  And le statut payout est mis à jour
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-05-onboarding-association/US-ONB-001-manager-signature.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-05-onboarding-association/US-ONB-001-manager-signature.md
@@ -1,0 +1,17 @@
+# US-ONB-001 : Champ managerSignature
+
+> **Epic**: 5 - Onboarding | **Priorité**: P0 | **Estimation**: 2 points
+
+## 📋 Description
+
+Ajouter le champ pour stocker la signature du responsable.
+
+```json
+{
+  "managerSignature": {
+    "type": "media",
+    "allowedTypes": ["images"],
+    "required": false
+  }
+}
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-05-onboarding-association/US-ONB-002-create-connected-account.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-05-onboarding-association/US-ONB-002-create-connected-account.md
@@ -1,0 +1,32 @@
+# US-ONB-002 : createConnectedAccount()
+
+> **Epic**: 5 - Onboarding | **Priorité**: P0 | **Estimation**: 5 points
+
+## ⚠️ Condition de Garde
+
+```typescript
+if (klubr.trade_policy.stripe_connect === true) {
+  await createConnectedAccount(klubr);
+}
+```
+
+## 📋 Description
+
+Créer un compte Stripe Express pour l'association.
+
+```typescript
+const account = await stripe.accounts.create({
+  type: 'express',
+  country: 'FR',
+  email: klubr.leaderEmail,
+  capabilities: {
+    card_payments: { requested: true },
+    transfers: { requested: true },
+  },
+  business_type: 'non_profit',
+  business_profile: {
+    name: klubr.name,
+    mcc: '8398', // Charitable organizations
+  },
+});
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-05-onboarding-association/US-ONB-003-onboarding-link.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-05-onboarding-association/US-ONB-003-onboarding-link.md
@@ -1,0 +1,16 @@
+# US-ONB-003 : generateOnboardingLink()
+
+> **Epic**: 5 - Onboarding | **Priorité**: P0 | **Estimation**: 3 points
+
+## 📋 Description
+
+Générer le lien d'onboarding Stripe hébergé.
+
+```typescript
+const accountLink = await stripe.accountLinks.create({
+  account: connectedAccount.stripeAccountId,
+  refresh_url: `${FRONTEND_URL}/dashboard/onboarding/refresh`,
+  return_url: `${FRONTEND_URL}/dashboard/onboarding/complete`,
+  type: 'account_onboarding',
+});
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-05-onboarding-association/US-ONB-004-can-accept-donations.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-05-onboarding-association/US-ONB-004-can-accept-donations.md
@@ -1,0 +1,23 @@
+# US-ONB-004 : canAcceptDonations()
+
+> **Epic**: 5 - Onboarding | **Priorité**: P0 | **Estimation**: 3 points
+
+## ⚠️ Condition de Garde
+
+Vérification complète avant d'accepter un don Stripe Connect.
+
+```typescript
+function canAcceptDonations(klubr: Klubr): { can: boolean; reason?: string } {
+  if (!klubr.trade_policy.stripe_connect) {
+    return { can: true }; // Mode Legacy
+  }
+  
+  const ca = klubr.connected_account;
+  if (!ca) return { can: false, reason: 'no_connected_account' };
+  if (ca.status !== 'active') return { can: false, reason: 'account_not_active' };
+  if (!ca.chargesEnabled) return { can: false, reason: 'charges_disabled' };
+  if (!ca.payoutsEnabled) return { can: false, reason: 'payouts_disabled' };
+  
+  return { can: true };
+}
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-05-onboarding-association/US-ONB-005-business-profile.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-05-onboarding-association/US-ONB-005-business-profile.md
@@ -1,0 +1,18 @@
+# US-ONB-005 : Champ business_profile
+
+> **Epic**: 5 - Onboarding | **Priorité**: P2 | **Estimation**: 3 points
+
+## 📋 Description
+
+Ajouter les infos métier au connected-account.
+
+```json
+{
+  "businessProfile": {
+    "mcc": "string",
+    "url": "string",
+    "supportEmail": "string",
+    "supportPhone": "string"
+  }
+}
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-05-onboarding-association/US-ONB-006-dashboard-ui.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-05-onboarding-association/US-ONB-006-dashboard-ui.md
@@ -1,0 +1,11 @@
+# US-ONB-006 : Interface Angular onboarding
+
+> **Epic**: 5 - Onboarding | **Priorité**: P1 | **Estimation**: 8 points
+
+## 📋 Description
+
+Interface dashboard avec :
+- Progression onboarding (étapes visuelles)
+- Statut compte Stripe
+- Bouton "Compléter l'inscription"
+- Upload signature responsable

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-05-onboarding-association/US-ONB-007-reminder-email.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-05-onboarding-association/US-ONB-007-reminder-email.md
@@ -1,0 +1,16 @@
+# US-ONB-007 : Email relance onboarding
+
+> **Epic**: 5 - Onboarding | **Priorité**: P2 | **Estimation**: 2 points
+
+## 📋 Description
+
+Cron job pour relancer les associations avec onboarding incomplet.
+
+```gherkin
+Scenario: Relance après 7 jours
+  Given un compte avec status = "pending"
+  And créé il y a plus de 7 jours
+  When le cron s'exécute
+  Then un email de relance est envoyé
+  And max 3 relances par compte
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-06-documents-fiscaux/US-DOC-001-receipt-association-name.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-06-documents-fiscaux/US-DOC-001-receipt-association-name.md
@@ -1,0 +1,26 @@
+# US-DOC-001 : Reçu fiscal au nom de l'association
+
+> **Epic**: 6 - Documents Fiscaux | **Priorité**: P0 | **Estimation**: 5 points
+
+## ⚠️ Condition de Garde
+
+```typescript
+if (klubr.trade_policy.stripe_connect === true) {
+  // Émetteur = Association
+} else {
+  // Émetteur = DONACTION (Legacy)
+}
+```
+
+## 📋 Description
+
+Le reçu fiscal doit être émis au nom de l'association bénéficiaire.
+
+## Changements
+
+| Champ | Legacy | Stripe Connect |
+|-------|--------|----------------|
+| Émetteur | DONACTION | Nom de l'association |
+| SIREN | DONACTION | SIREN de l'association |
+| Adresse | DONACTION | Adresse de l'association |
+| Signature | DONACTION | Responsable de l'association |

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-06-documents-fiscaux/US-DOC-002-manager-signature-on-receipt.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-06-documents-fiscaux/US-DOC-002-manager-signature-on-receipt.md
@@ -1,0 +1,19 @@
+# US-DOC-002 : Signature responsable sur reçu
+
+> **Epic**: 6 - Documents Fiscaux | **Priorité**: P0 | **Estimation**: 3 points
+
+## 📋 Description
+
+Intégrer la signature uploadée sur le reçu fiscal.
+
+```typescript
+const templateData = {
+  managerSignature: klubr.managerSignature?.url,
+  managerName: klubr.managerName,
+  managerTitle: klubr.managerTitle || 'Président(e)',
+};
+```
+
+## Fallback
+
+Si pas de signature uploadée → Utiliser signature par défaut DONACTION.

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-06-documents-fiscaux/US-DOC-003-receipt-amount-calculation.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-06-documents-fiscaux/US-DOC-003-receipt-amount-calculation.md
@@ -1,0 +1,363 @@
+# US-DOC-003 : Calculer le montant du reçu fiscal selon `donorPaysFee`
+
+> **Epic**: 6 - Documents Fiscaux | **Priorité**: P0 | **Estimation**: 3 points
+
+---
+
+## ⚠️ Condition de Garde
+
+```typescript
+// Ce calcul ne s'applique QUE si :
+klubr.trade_policy.stripe_connect === true
+// Sinon, utiliser le calcul Legacy
+```
+
+---
+
+## 📋 Description
+
+**En tant que** système de génération de documents,
+**Je veux** calculer correctement le montant du reçu fiscal selon le mode de prise en charge des frais,
+**Afin que** le reçu soit conforme aux exigences Cerfa et reflète exactement ce que l'association a réellement reçu.
+
+---
+
+## 🚨 Règle Fiscale Fondamentale
+
+> **Le reçu fiscal doit TOUJOURS correspondre au montant effectivement reçu par l'association.**
+
+Cette règle est imposée par l'administration fiscale française pour les reçus Cerfa. Un reçu ne peut pas mentionner un montant supérieur à ce que l'association a réellement encaissé.
+
+---
+
+## 🎯 Critères d'Acceptation
+
+```gherkin
+Feature: Calcul du montant du reçu fiscal
+
+  Background:
+    Given un klubr avec stripe_connect = true
+    And le don a été validé par Stripe
+
+  # SCÉNARIO A : Donor Pays Fee = TRUE
+  
+  Scenario: Reçu fiscal = montant intentionnel (Scénario A)
+    Given un don de 100€
+    And donorPaysFee = true
+    And l'association a reçu 100€ (100% du don)
+    When je génère le reçu fiscal
+    Then le montant indiqué est 100,00 €
+    And la mention "Montant du don" apparaît
+    And le donateur peut déduire 66€ (particulier) ou 60€ (entreprise)
+
+  # SCÉNARIO B : Donor Pays Fee = FALSE (FORMULE CORRIGÉE)
+  
+  Scenario: Reçu fiscal = montant net reçu (Scénario B)
+    Given un don de 100€
+    And contribution = 10€
+    And donorPaysFee = false
+    And les frais déduits sont de 5,90€ (4€ commission + 1,90€ Stripe)
+    And l'association a reçu 94,10€
+    When je génère le reçu fiscal
+    Then le montant indiqué est 94,10 €
+    And la mention "Montant net reçu par l'association" apparaît
+    And le donateur peut déduire 62,11€ (particulier)
+
+  Scenario: Vérification cohérence avec Stripe
+    Given un don finalisé avec PaymentIntent.status = "succeeded"
+    And transfer.amount = 9410 (94,10€)
+    When je génère le reçu fiscal
+    Then le montant du reçu = transfer.amount
+    And une incohérence génère une alerte
+
+  # VALIDATION
+  
+  Scenario: Blocage si montant incohérent
+    Given un don avec donorPaysFee = false
+    And montant calculé reçu fiscal = 94,10€
+    And montant transfer Stripe = 95,00€
+    When je tente de générer le reçu fiscal
+    Then une erreur est levée "Incohérence montant reçu fiscal"
+    And le reçu n'est pas généré
+    And une alerte admin est envoyée
+
+  # MODE LEGACY
+  
+  Scenario: Mode Legacy préservé
+    Given klubr.trade_policy.stripe_connect = false
+    When je calcule le montant du reçu fiscal
+    Then le calcul utilise l'ancien algorithme
+```
+
+---
+
+## 📐 Spécifications Techniques
+
+### Fonction de calcul
+
+```typescript
+// helpers/fiscal-receipt-helper.ts
+
+interface ReceiptAmountInput {
+  klubDon: KlubDon;
+  klubr: Klubr;
+  paymentIntent?: Stripe.PaymentIntent;
+  transfer?: Stripe.Transfer;
+}
+
+interface ReceiptAmountOutput {
+  montantRecuFiscal: number;  // En centimes
+  label: string;              // Label pour le PDF
+  deductionParticulier: number;
+  deductionEntreprise: number;
+}
+
+export function calculateReceiptAmount(input: ReceiptAmountInput): ReceiptAmountOutput {
+  const { klubDon, klubr, transfer } = input;
+  const tradePolicy = klubr.trade_policy;
+  
+  // ⚠️ CONDITION DE GARDE
+  if (!tradePolicy.stripe_connect) {
+    return calculateLegacyReceiptAmount(input);
+  }
+  
+  let montantRecuFiscal: number;
+  let label: string;
+  
+  if (klubDon.donorPaysFee) {
+    // SCÉNARIO A : Le donateur a payé les frais séparément
+    // L'association reçoit 100% du montant intentionnel
+    montantRecuFiscal = klubDon.amount; // Montant du don en centimes
+    label = "Montant du don";
+  } else {
+    // SCÉNARIO B : Les frais ont été déduits du don
+    // L'association reçoit le montant net après déduction
+    montantRecuFiscal = klubDon.netAssociationAmount;
+    label = "Montant net reçu par l'association";
+  }
+  
+  // Vérification de cohérence avec Stripe
+  if (transfer && transfer.amount !== montantRecuFiscal) {
+    throw new FiscalInconsistencyError(
+      `Incohérence montant reçu fiscal: calculé=${montantRecuFiscal}, transfer=${transfer.amount}`,
+      { klubDonId: klubDon.id, expected: montantRecuFiscal, actual: transfer.amount }
+    );
+  }
+  
+  // Calcul des déductions fiscales
+  const deductionParticulier = Math.round(montantRecuFiscal * 0.66);
+  const deductionEntreprise = Math.round(montantRecuFiscal * 0.60);
+  
+  return {
+    montantRecuFiscal,
+    label,
+    deductionParticulier,
+    deductionEntreprise,
+  };
+}
+```
+
+### Mise à jour du schéma `klub-don`
+
+```json
+// api/klub-don/content-types/klub-don/schema.json
+{
+  "attributes": {
+    // ... champs existants ...
+    
+    "netAssociationAmount": {
+      "type": "integer",
+      "description": "Montant net reçu par l'association (en centimes). Calculé lors du paiement."
+    },
+    "receiptAmount": {
+      "type": "integer", 
+      "description": "Montant figurant sur le reçu fiscal (en centimes). = netAssociationAmount"
+    },
+    "receiptLabel": {
+      "type": "string",
+      "enum": ["Montant du don", "Montant net reçu par l'association"],
+      "description": "Label affiché sur le reçu fiscal"
+    }
+  }
+}
+```
+
+### Intégration dans le générateur PDF
+
+```typescript
+// helpers/generateCertificate.ts
+
+export async function generateFiscalReceipt(klubDon: KlubDon, klubr: Klubr): Promise<Buffer> {
+  const tradePolicy = klubr.trade_policy;
+  
+  // ⚠️ CONDITION DE GARDE
+  if (!tradePolicy.stripe_connect) {
+    return generateLegacyFiscalReceipt(klubDon, klubr);
+  }
+  
+  const { montantRecuFiscal, label, deductionParticulier } = calculateReceiptAmount({
+    klubDon,
+    klubr,
+  });
+  
+  const templateData = {
+    // Informations association (émetteur)
+    associationName: klubr.name,
+    associationAddress: formatAddress(klubr.address),
+    associationSiren: klubr.siren,
+    managerName: klubr.managerName,
+    managerSignature: klubr.managerSignature?.url,
+    
+    // Informations donateur
+    donorName: formatDonorName(klubDon.klubDonateur),
+    donorAddress: formatAddress(klubDon.klubDonateur.address),
+    
+    // Montants
+    amount: formatCurrency(montantRecuFiscal),
+    amountLabel: label,
+    amountInWords: numberToWords(montantRecuFiscal / 100),
+    
+    // Déductions
+    deductionInfo: `Soit une réduction d'impôt de ${formatCurrency(deductionParticulier)}`,
+    
+    // Métadonnées
+    receiptNumber: generateReceiptNumber(klubDon),
+    receiptDate: formatDate(new Date()),
+    donationDate: formatDate(klubDon.paymentDate),
+    
+    // Mentions légales
+    legalMentions: CERFA_LEGAL_MENTIONS,
+  };
+  
+  return renderPdfTemplate('fiscal-receipt-cerfa', templateData);
+}
+```
+
+### Exemple de reçu généré (Scénario B)
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│                    REÇU AU TITRE DES DONS                      │
+│              À DES ORGANISMES D'INTÉRÊT GÉNÉRAL               │
+├────────────────────────────────────────────────────────────────┤
+│                                                                │
+│  ORGANISME BÉNÉFICIAIRE                                        │
+│  ───────────────────────                                       │
+│  FC Lyon - Association sportive loi 1901                       │
+│  12 rue du Stade, 69000 Lyon                                   │
+│  SIREN : 123 456 789                                           │
+│                                                                │
+│  DONATEUR                                                      │
+│  ────────                                                      │
+│  M. Jean DUPONT                                                │
+│  45 avenue de la République, 69001 Lyon                        │
+│                                                                │
+├────────────────────────────────────────────────────────────────┤
+│                                                                │
+│  MONTANT NET REÇU PAR L'ASSOCIATION                           │
+│                                                                │
+│           94,10 € (quatre-vingt-quatorze euros                │
+│                    et dix centimes)                            │
+│                                                                │
+│  Date du don : 11/01/2026                                      │
+│  Numéro de reçu : 2026-FC-LYON-00042                          │
+│                                                                │
+├────────────────────────────────────────────────────────────────┤
+│                                                                │
+│  Ce don ouvre droit à une réduction d'impôt de 62,11 €        │
+│  (66% du montant pour un particulier)                          │
+│                                                                │
+│  Le présent reçu est établi conformément aux articles          │
+│  200 et 238 bis du Code général des impôts.                   │
+│                                                                │
+│                                                                │
+│  Fait à Lyon, le 11/01/2026                                    │
+│                                                                │
+│  Le responsable de l'association,                              │
+│  [Signature]                                                   │
+│  Pierre MARTIN, Président                                      │
+│                                                                │
+└────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 🧪 Tests
+
+```typescript
+describe('calculateReceiptAmount', () => {
+  describe('Scénario A - Donor Pays Fee = TRUE', () => {
+    it('should use donation amount as receipt amount', () => {
+      const result = calculateReceiptAmount({
+        klubDon: { amount: 10000, donorPaysFee: true },
+        klubr: { trade_policy: { stripe_connect: true } },
+      });
+      
+      expect(result.montantRecuFiscal).toBe(10000);
+      expect(result.label).toBe("Montant du don");
+    });
+  });
+  
+  describe('Scénario B - Donor Pays Fee = FALSE', () => {
+    it('should use net association amount as receipt amount', () => {
+      const result = calculateReceiptAmount({
+        klubDon: { 
+          amount: 10000, 
+          donorPaysFee: false,
+          netAssociationAmount: 9410 
+        },
+        klubr: { trade_policy: { stripe_connect: true } },
+      });
+      
+      expect(result.montantRecuFiscal).toBe(9410);
+      expect(result.label).toBe("Montant net reçu par l'association");
+    });
+    
+    it('should throw error if transfer amount does not match', () => {
+      expect(() => calculateReceiptAmount({
+        klubDon: { 
+          amount: 10000, 
+          donorPaysFee: false,
+          netAssociationAmount: 9410 
+        },
+        klubr: { trade_policy: { stripe_connect: true } },
+        transfer: { amount: 9500 }, // Incohérence!
+      })).toThrow('Incohérence montant reçu fiscal');
+    });
+  });
+  
+  describe('Mode Legacy', () => {
+    it('should use legacy calculation when stripe_connect is false', () => {
+      const result = calculateReceiptAmount({
+        klubDon: { amount: 10000 },
+        klubr: { trade_policy: { stripe_connect: false } },
+      });
+      
+      // Le comportement Legacy doit être préservé
+      expect(result).toBeDefined();
+    });
+  });
+});
+```
+
+---
+
+## 🔗 Dépendances
+
+- **Prérequis**: US-PAY-002 (calcul netAssociationAmount), US-DOC-001 (émission au nom association)
+- **Bloque**: US-DOC-004 (attestation annulation)
+
+---
+
+## ✅ Definition of Done
+
+- [ ] Fonction `calculateReceiptAmount()` implémentée
+- [ ] Condition de garde `stripe_connect === true` présente
+- [ ] Scénario A : reçu = montant du don (100%)
+- [ ] Scénario B : reçu = montant net (~94%)
+- [ ] Vérification de cohérence avec transfer Stripe
+- [ ] Champ `netAssociationAmount` ajouté au schéma klub-don
+- [ ] Template PDF mis à jour avec le bon label
+- [ ] Tests unitaires passants
+- [ ] Validation juridique du format Cerfa
+- [ ] PR approuvée et mergée

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-06-documents-fiscaux/US-DOC-004-cancellation-attestation.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-06-documents-fiscaux/US-DOC-004-cancellation-attestation.md
@@ -1,0 +1,15 @@
+# US-DOC-004 : Template attestation d'annulation
+
+> **Epic**: 6 - Documents Fiscaux | **Priorité**: P2 | **Estimation**: 5 points
+
+## 📋 Description
+
+Pour les remboursements exceptionnels après émission du reçu fiscal.
+
+## Contenu
+
+- Référence au reçu original
+- Mention "ANNULATION"
+- Raison de l'annulation
+- Nouveau montant déductible (0€)
+- Signatures responsable association + DONACTION

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-07-remboursement/US-REF-001-receipt-cancellation-schema.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-07-remboursement/US-REF-001-receipt-cancellation-schema.md
@@ -1,0 +1,14 @@
+# US-REF-001 : Schéma receipt_cancellations
+
+> **Epic**: 7 - Remboursement | **Priorité**: P2 | **Estimation**: 3 points
+
+```json
+{
+  "klubDon": { "type": "relation", "target": "api::klub-don.klub-don" },
+  "originalReceiptId": { "type": "string" },
+  "reason": { "type": "text" },
+  "status": { "type": "enumeration", "enum": ["awaiting_declaration", "completed", "rejected"] },
+  "approvedBy": { "type": "relation", "target": "admin::user" },
+  "declarationSignedAt": { "type": "datetime" }
+}
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-07-remboursement/US-REF-002-multi-step-workflow.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-07-remboursement/US-REF-002-multi-step-workflow.md
@@ -1,0 +1,11 @@
+# US-REF-002 : Workflow multi-étapes remboursement
+
+> **Epic**: 7 - Remboursement | **Priorité**: P2 | **Estimation**: 5 points
+
+## États
+
+1. `initiated` - Demande créée
+2. `awaiting_declaration` - Attente déclaration sur l'honneur
+3. `declaration_signed` - Déclaration signée
+4. `refund_processing` - Remboursement en cours
+5. `completed` - Terminé

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-07-remboursement/US-REF-003-cancellation-pdf.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-07-remboursement/US-REF-003-cancellation-pdf.md
@@ -1,0 +1,5 @@
+# US-REF-003 : PDF attestation d'annulation
+
+> **Epic**: 7 - Remboursement | **Priorité**: P2 | **Estimation**: 3 points
+
+Générer le PDF complémentaire qui annule le reçu fiscal original.

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-07-remboursement/US-REF-004-stripe-refund.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-07-remboursement/US-REF-004-stripe-refund.md
@@ -1,0 +1,11 @@
+# US-REF-004 : Appel stripe.refunds.create()
+
+> **Epic**: 7 - Remboursement | **Priorité**: P2 | **Estimation**: 5 points
+
+```typescript
+const refund = await stripe.refunds.create({
+  payment_intent: klubDon.stripePaymentIntentId,
+  reverse_transfer: true, // Annuler aussi le transfert vers l'association
+  refund_application_fee: true, // Rembourser l'application_fee
+});
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-07-remboursement/US-REF-005-admin-interface.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-07-remboursement/US-REF-005-admin-interface.md
@@ -1,0 +1,5 @@
+# US-REF-005 : Interface admin remboursements
+
+> **Epic**: 7 - Remboursement | **Priorité**: P3 | **Estimation**: 5 points
+
+Dashboard Angular pour gérer les demandes de remboursement exceptionnelles.

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-08-erreurs-reconciliation/US-ERR-001-instant-retry.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-08-erreurs-reconciliation/US-ERR-001-instant-retry.md
@@ -1,0 +1,5 @@
+# US-ERR-001 : Retry instantané côté donateur
+
+> **Epic**: 8 - Erreurs | **Priorité**: P1 | **Estimation**: 3 points
+
+Réutiliser le `client_secret` du PaymentIntent existant pour permettre un retry sans créer de nouveau don.

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-08-erreurs-reconciliation/US-ERR-002-reconciliation-cron.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-08-erreurs-reconciliation/US-ERR-002-reconciliation-cron.md
@@ -1,0 +1,13 @@
+# US-ERR-002 : Cron réconciliation PaymentIntents
+
+> **Epic**: 8 - Erreurs | **Priorité**: P1 | **Estimation**: 5 points
+
+Identifier les PaymentIntents orphelins (status mismatch avec klub-don).
+
+```typescript
+// Exécution toutes les heures
+const orphans = await findOrphanPaymentIntents();
+for (const pi of orphans) {
+  await reconcile(pi);
+}
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-08-erreurs-reconciliation/US-ERR-003-error-messages-fr.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-08-erreurs-reconciliation/US-ERR-003-error-messages-fr.md
@@ -1,0 +1,14 @@
+# US-ERR-003 : Messages d'erreur FR
+
+> **Epic**: 8 - Erreurs | **Priorité**: P2 | **Estimation**: 5 points
+
+Mapper les codes erreur Stripe en messages utilisateur-friendly en français.
+
+```typescript
+const STRIPE_ERROR_MESSAGES: Record<string, string> = {
+  'card_declined': 'Votre carte a été refusée. Essayez une autre carte.',
+  'insufficient_funds': 'Fonds insuffisants sur votre carte.',
+  'expired_card': 'Votre carte a expiré.',
+  // ...
+};
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-09-reporting/US-REP-001-fee-statement-schema.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-09-reporting/US-REP-001-fee-statement-schema.md
@@ -1,0 +1,5 @@
+# US-REP-001 : Content-type fee-statement
+
+> **Epic**: 9 - Reporting | **Priorité**: P2 | **Estimation**: 3 points
+
+Relevé mensuel des commissions pour chaque association.

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-09-reporting/US-REP-002-fee-statement-pdf.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-09-reporting/US-REP-002-fee-statement-pdf.md
@@ -1,0 +1,9 @@
+# US-REP-002 : PDF Relevé de frais
+
+> **Epic**: 9 - Reporting | **Priorité**: P2 | **Estimation**: 5 points
+
+Générer le PDF mensuel récapitulatif :
+- Nombre de dons
+- Total collecté
+- Commissions prélevées
+- Net versé

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-09-reporting/US-REP-003-email-statement.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-09-reporting/US-REP-003-email-statement.md
@@ -1,0 +1,5 @@
+# US-REP-003 : Email envoi relevé
+
+> **Epic**: 9 - Reporting | **Priorité**: P2 | **Estimation**: 5 points
+
+Envoyer le relevé automatiquement aux leaders du club chaque 1er du mois.

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-10-disputes/US-DIS-001-dispute-fields.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-10-disputes/US-DIS-001-dispute-fields.md
@@ -1,0 +1,13 @@
+# US-DIS-001 : Champs disputes sur klub-don
+
+> **Epic**: 10 - Disputes | **Priorité**: P1 | **Estimation**: 2 points
+
+```json
+{
+  "disputeStatus": { "type": "enumeration", "enum": ["none", "open", "won", "lost"] },
+  "disputeId": { "type": "string" },
+  "disputeOpenedAt": { "type": "datetime" },
+  "disputeClosedAt": { "type": "datetime" },
+  "disputeReason": { "type": "string" }
+}
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-10-disputes/US-DIS-002-reverse-transfer.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-10-disputes/US-DIS-002-reverse-transfer.md
@@ -1,0 +1,12 @@
+# US-DIS-002 : reverseTransferForDispute()
+
+> **Epic**: 10 - Disputes | **Priorité**: P2 | **Estimation**: 5 points
+
+Annuler le transfert vers l'association lors d'un litige.
+
+```typescript
+const reversal = await stripe.transfers.createReversal(
+  transfer.id,
+  { amount: transfer.amount }
+);
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-10-disputes/US-DIS-003-admin-section.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-10-disputes/US-DIS-003-admin-section.md
@@ -1,0 +1,9 @@
+# US-DIS-003 : Dashboard admin - Litiges
+
+> **Epic**: 10 - Disputes | **Priorité**: P2 | **Estimation**: 3 points
+
+Section dédiée aux litiges en cours :
+- Liste des disputes ouvertes
+- Détails du litige
+- Actions possibles
+- Historique

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-10-disputes/US-DIS-004-dispute-alerts.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-10-disputes/US-DIS-004-dispute-alerts.md
@@ -1,0 +1,13 @@
+# US-DIS-004 : Alertes Slack/Discord disputes
+
+> **Epic**: 10 - Disputes | **Priorité**: P2 | **Estimation**: 3 points
+
+Notification immédiate lors d'un nouveau litige.
+
+```typescript
+await sendSlackAlert({
+  channel: '#donaction-alerts',
+  text: `🚨 Nouveau litige sur le don ${klubDon.id}`,
+  blocks: [/* ... */]
+});
+```

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-11-configuration-rollout/US-CFG-001-webhook-endpoints.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-11-configuration-rollout/US-CFG-001-webhook-endpoints.md
@@ -1,0 +1,20 @@
+# US-CFG-001 : Configuration endpoints webhook
+
+> **Epic**: 11 - Configuration | **Priorité**: P0 | **Estimation**: 2 points
+
+## Dashboard Stripe
+
+Configurer 2 endpoints :
+1. **Account-level** : `/api/stripe/webhook` (événements standards)
+2. **Connect** : `/api/stripe-connect/webhook` (événements comptes connectés)
+
+## Événements Account-level
+- `payment_intent.succeeded`
+- `payment_intent.payment_failed`
+- `charge.refunded`
+
+## Événements Connect
+- `account.updated`
+- `account.application.deauthorized`
+- `payout.failed`
+- `charge.dispute.*`

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-11-configuration-rollout/US-CFG-002-env-variables.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-11-configuration-rollout/US-CFG-002-env-variables.md
@@ -1,0 +1,15 @@
+# US-CFG-002 : Variables d'environnement
+
+> **Epic**: 11 - Configuration | **Priorité**: P0 | **Estimation**: 1 point
+
+## Nouvelles variables
+
+```env
+STRIPE_WEBHOOK_SECRET_CONNECT=whsec_xxx
+STRIPE_CONNECT_ENABLED=true
+```
+
+## GitHub Secrets (staging + prod)
+
+- `STRIPE_WEBHOOK_SECRET_CONNECT_STAGING`
+- `STRIPE_WEBHOOK_SECRET_CONNECT_PROD`

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-11-configuration-rollout/US-CFG-003-feature-flag.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-11-configuration-rollout/US-CFG-003-feature-flag.md
@@ -1,0 +1,17 @@
+# US-CFG-003 : Feature flag STRIPE_CONNECT_ENABLED
+
+> **Epic**: 11 - Configuration | **Priorité**: P1 | **Estimation**: 2 points
+
+## Description
+
+Kill switch global pour désactiver Stripe Connect en cas de problème.
+
+```typescript
+const isStripeConnectGloballyEnabled = process.env.STRIPE_CONNECT_ENABLED === 'true';
+
+function shouldUseStripeConnect(klubr: Klubr): boolean {
+  return isStripeConnectGloballyEnabled && klubr.trade_policy.stripe_connect;
+}
+```
+
+Si `false` → Toutes les associations retombent en mode Legacy.

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-11-configuration-rollout/US-CFG-004-stripe-branding.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/epic-11-configuration-rollout/US-CFG-004-stripe-branding.md
@@ -1,0 +1,18 @@
+# US-CFG-004 : Branding DONACTION sur Stripe Connect
+
+> **Epic**: 11 - Configuration | **Priorité**: P2 | **Estimation**: 3 points
+
+## Dashboard Stripe > Settings > Branding
+
+```
+Business name: DONACTION
+Icon: logo-donaction-icon.png (512x512)
+Logo: logo-donaction.png (600x200)
+Primary color: #2563eb
+```
+
+## Assets à fournir
+
+- [ ] Logo icône 512x512 PNG
+- [ ] Logo horizontal 600x200 PNG
+- [ ] Favicon 32x32 PNG

--- a/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/strategie-collecte-dons-donaction-stripe-connect-v2.md
+++ b/docs/roadmap/2026-01-stripe-connect-migration-user-stories-v2/strategie-collecte-dons-donaction-stripe-connect-v2.md
@@ -1,0 +1,3086 @@
+# StratÃ©gie de Collecte de Dons DONACTION â€” Stripe Connect
+
+> **Version**: 2.0.0 | **Date**: 2026-01-11 | **Statut**: Document StratÃ©gique Final
+
+---
+
+## 1. Executive Summary
+
+DONACTION migre d'un modÃ¨le Stripe Standard (compte unique Fond Klubr) vers **Stripe Connect Express** pour permettre aux associations sportives franÃ§aises de recevoir les dons directement sur leurs comptes connectÃ©s. Cette transformation apporte :
+
+- **Transparence financiÃ¨re** : Les associations reÃ§oivent 100% du montant intentionnel du don
+- **ConformitÃ© fiscale** : ReÃ§us Ã©mis au nom de l'association (non plus DONACTION)
+- **ModÃ¨le "Donor Pays Fee"** : Le donateur prend en charge les frais Stripe (~1.5% + 0.25â‚¬) et la commission plateforme (4%)
+- **Automatisation** : PrÃ©lÃ¨vement automatique via `application_fee_amount`
+- **Simplification KYC** : Onboarding hÃ©bergÃ© par Stripe (Express accounts)
+
+L'implÃ©mentation backend est dÃ©jÃ  rÃ©alisÃ©e (Phases 1-3). Ce document consolide la stratÃ©gie complÃ¨te et identifie les ajustements nÃ©cessaires pour garantir la cohÃ©rence du systÃ¨me.
+
+---
+
+## 2. Architecture du Flux de Paiement
+
+### 2.1 Parcours Donateur (5 Ã©tapes)
+
+```mermaid
+flowchart TB
+    subgraph Step1["ðŸ“Š Step 1: Choix du Montant"]
+        A1[SÃ©lection montant<br/>Min 10â‚¬ / Max 100kâ‚¬]
+        A2[Avec rÃ©duction fiscale ?<br/>Oui/Non]
+        A3[Particulier ou Entreprise ?]
+        A4[Projet spÃ©cifique ?<br/>ou Don au club]
+        A1 --> A2 --> A3 --> A4
+    end
+
+    subgraph Step2["ðŸ‘¤ Step 2: Informations Donateur"]
+        B1{Type donateur}
+        B2[Particulier<br/>Nom, PrÃ©nom, Email<br/>Date naissance, Adresse]
+        B3[Entreprise<br/>Raison sociale, SIREN<br/>Forme juridique, Logo]
+        B1 -->|Particulier| B2
+        B1 -->|Organisme| B3
+    end
+
+    subgraph Step3["ðŸ“‹ Step 3: RÃ©capitulatif"]
+        C1[Montant du don]
+        C2[Contribution DONACTION<br/>optionnelle max 25â‚¬]
+        C3[DÃ©composition des frais<br/>transparent]
+        C4[Total Ã  payer]
+        C5[âœ… Acceptation CGU]
+        C1 --> C2 --> C3 --> C4 --> C5
+    end
+
+    subgraph Step4["ðŸ’³ Step 4: Paiement Stripe"]
+        D1[Stripe Elements<br/>Card / Apple Pay / Google Pay]
+        D2[Confirmation paiement]
+        D3{RÃ©sultat}
+        D4[âœ… SuccÃ¨s]
+        D5[âŒ Ã‰chec + Retry]
+        D1 --> D2 --> D3
+        D3 -->|succeeded| D4
+        D3 -->|failed| D5
+    end
+
+    subgraph Step5["ðŸŽ‰ Step 5: Confirmation"]
+        E1[Message remerciement]
+        E2[ðŸ“„ Attestation PDF]
+        E3[ðŸ“„ ReÃ§u fiscal PDF<br/>si applicable]
+        E4[Invitation crÃ©er compte]
+        E1 --> E2 --> E3 --> E4
+    end
+
+    Step1 --> Step2 --> Step3 --> Step4 --> Step5
+```
+
+### 2.2 Calcul des Frais â€” ModÃ¨le "Donor Pays Fee"
+
+#### 2.2.1 ParamÃ¨tres de Configuration
+
+BasÃ© sur le schÃ©ma `trade_policy` existant, **avec Ã©volutions** :
+
+| ParamÃ¨tre | Type | Valeur par dÃ©faut | Description |
+|-----------|------|-------------------|-------------|
+| `fee_model` | enum | `percentage_only` | Mode de calcul des frais |
+| `commissionPercentage` | decimal | 6% â†’ **4%** | Commission plateforme DONACTION |
+| `fixed_amount` | decimal | 0â‚¬ | Montant fixe par transaction |
+| ~~`donor_pays_fee`~~ | ~~boolean~~ | ~~false~~ | **REMPLACÃ‰** par les 2 champs ci-dessous |
+| `donor_pays_fee_project` | boolean | **`true`** | **NOUVEAU** - DÃ©faut pour dons Ã  un projet |
+| `donor_pays_fee_club` | boolean | **`false`** | **NOUVEAU** - DÃ©faut pour dons au club |
+| `allow_donor_fee_choice` | boolean | **`true`** | **NOUVEAU** - Autoriser le donateur Ã  choisir |
+| `stripe_connect` | boolean | `true` | Utiliser Stripe Connect |
+
+**Ã‰volutions clÃ©s :**
+1. **DiffÃ©renciation projet/club** : Deux paramÃ¨tres distincts permettent de configurer des comportements diffÃ©rents selon le type de don
+2. **Choix donateur** : Si `allow_donor_fee_choice = true`, le donateur peut modifier le comportement par dÃ©faut Ã  l'Ã©tape 3
+
+**Note importante** : La commission actuelle de 6% doit Ãªtre revue Ã  **4%** selon les spÃ©cifications du nouveau modÃ¨le.
+
+#### 2.2.2 Logique de DÃ©termination du `donorPaysFee`
+
+```typescript
+// helpers/fee-calculation-helper.ts
+interface FeeContext {
+    tradePolicy: TradePolicyEntity;
+    isProjectDonation: boolean;       // true si don Ã  un projet
+    donorChoice: boolean | null;      // Choix explicite du donateur (null = pas de choix)
+}
+
+function determineDonorPaysFee(context: FeeContext): boolean {
+    const { tradePolicy, isProjectDonation, donorChoice } = context;
+    
+    // 1. Si le donateur a fait un choix explicite ET que c'est autorisÃ©
+    if (donorChoice !== null && tradePolicy.allow_donor_fee_choice) {
+        return donorChoice;
+    }
+    
+    // 2. Sinon, utiliser la valeur par dÃ©faut selon le type de don
+    return isProjectDonation 
+        ? tradePolicy.donor_pays_fee_project 
+        : tradePolicy.donor_pays_fee_club;
+}
+```
+
+**Exemples de configurations :**
+
+| ScÃ©nario | `donor_pays_fee_project` | `donor_pays_fee_club` | `allow_donor_fee_choice` | RÃ©sultat |
+|----------|--------------------------|----------------------|--------------------------|----------|
+| **Standard** | `true` | `false` | `true` | Projet: donateur paie (modifiable) / Club: frais dÃ©duits (modifiable) |
+| **Tout transparent** | `true` | `true` | `false` | Tous les dons: donateur paie (non modifiable) |
+| **Tout intÃ©grÃ©** | `false` | `false` | `false` | Tous les dons: frais dÃ©duits (non modifiable) |
+| **Flexible total** | `true` | `false` | `true` | DÃ©fauts diffÃ©rents, donateur choisit toujours |
+
+#### 2.2.3 Formules de Calcul
+
+**Variables :**
+- `MONTANT_SAISI` = Montant saisi par le donateur dans le formulaire
+- `CONTRIBUTION_DONACTION` = Contribution optionnelle Ã  la plateforme (0-25â‚¬)
+- `TAUX_COMMISSION` = 4% (commission DONACTION)
+- `TAUX_STRIPE` = 1.5% + 0.25â‚¬ (frais Stripe standard EU)
+
+---
+
+**ScÃ©nario A : Donor Pays Fee = TRUE** (dÃ©faut projets)
+> *"Je donne 100â‚¬, l'association reÃ§oit 100â‚¬, je paie les frais en plus"*
+
+```
+MONTANT_DON_REEL = MONTANT_SAISI (inchangÃ©)
+Commission DONACTION = MONTANT_DON_REEL Ã— 4%
+Frais Stripe estimÃ©s = (MONTANT_DON_REEL + CONTRIBUTION) Ã— 1.5% + 0.25â‚¬
+Application Fee = Commission + Frais Stripe
+
+TOTAL_PRELEVE = MONTANT_DON_REEL + CONTRIBUTION + Application Fee
+NET_ASSOCIATION = MONTANT_DON_REEL (100%)
+MONTANT_RECU_FISCAL = MONTANT_DON_REEL (100â‚¬)
+```
+
+**Exemple (Don 100â‚¬ + Contribution 10â‚¬, Donor Pays Fee = TRUE) :**
+
+```
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚  ðŸ’³ CE QUE LE DONATEUR PAIE                                 â”‚
+â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
+â”‚  Montant du don                    : 100,00 â‚¬               â”‚
+â”‚  Contribution DONACTION            :  10,00 â‚¬               â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€              â”‚
+â”‚  Sous-total                        : 110,00 â‚¬               â”‚
+â”‚                                                             â”‚
+â”‚  + Frais de traitement (4% + Stripe)                        â”‚
+â”‚    Commission plateforme (4%)      :   4,00 â‚¬               â”‚
+â”‚    Frais bancaires (~1.5% + 0.25â‚¬) :   1,90 â‚¬               â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€              â”‚
+â”‚  TOTAL DÃ‰BITÃ‰                      : 115,90 â‚¬               â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚  ðŸ“Š RÃ‰PARTITION                                             â”‚
+â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
+â”‚  â†’ Association reÃ§oit     : 100,00 â‚¬ (100% de votre don)    â”‚
+â”‚  â†’ DONACTION reÃ§oit       :  14,00 â‚¬ (contribution + comm.) â”‚
+â”‚  â†’ Stripe prÃ©lÃ¨ve         :  ~1,90 â‚¬ (frais bancaires)      â”‚
+â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
+â”‚  ðŸ“„ REÃ‡U FISCAL           : 100,00 â‚¬                        â”‚
+â”‚     RÃ©duction d'impÃ´ts    :  66,00 â‚¬ (particulier)          â”‚
+â”‚     CoÃ»t rÃ©el du don      :  49,90 â‚¬ (115,90 - 66)          â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+```
+
+---
+
+**Scénario B : Donor Pays Fee = FALSE** (défaut club)
+> *"Je donne 100€ tout compris, l'association reçoit le net après frais"*
+
+**⚠️ Point technique critique : Gestion des frais Stripe**
+
+Avec Stripe Connect en mode **Destination Charges**, les frais Stripe sont toujours déduits du solde de la **plateforme** (DONACTION), pas du compte connecté. Pour que DONACTION maintienne sa commission de 4% net, l'`application_fee_amount` doit inclure les frais Stripe estimés.
+
+```
+MONTANT_DON_BRUT = MONTANT_SAISI
+Commission DONACTION = MONTANT_DON_BRUT × 4%
+Frais Stripe estimés = (TOTAL_PRELEVE × 1.5%) + 0.25€
+
+// L'application_fee inclut commission + frais Stripe pour garantir 4% net à DONACTION
+Application Fee = Commission + Frais Stripe estimés
+
+TOTAL_PRELEVE = MONTANT_DON_BRUT + CONTRIBUTION
+NET_ASSOCIATION = MONTANT_DON_BRUT - Application Fee
+MONTANT_RECU_FISCAL = NET_ASSOCIATION
+```
+
+**Exemple (Don 100€ + Contribution 10€, Donor Pays Fee = FALSE) :**
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  💳 CE QUE LE DONATEUR PAIE                                 │
+├─────────────────────────────────────────────────────────────┤
+│  Montant du don (frais inclus)     : 100,00 €               │
+│  Contribution DONACTION            :  10,00 €               │
+│  ─────────────────────────────────────────────              │
+│  TOTAL DÉBITÉ                      : 110,00 €               │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  📊 CALCUL DE L'APPLICATION FEE                             │
+├─────────────────────────────────────────────────────────────┤
+│  Commission DONACTION (4%)         :   4,00 €               │
+│  Frais Stripe estimés              :   1,90 €               │
+│  (110€ × 1.5% + 0.25€)                                      │
+│  ─────────────────────────────────────────────              │
+│  application_fee_amount            :   5,90 €               │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  📊 RÉPARTITION FINALE                                      │
+├─────────────────────────────────────────────────────────────┤
+│  → Association reçoit     :  94,10 € (100 - 5,90€)          │
+│  → DONACTION reçoit brut  :  15,90 € (contribution + 5,90€) │
+│  → Stripe prélève         :  ~1,90 € (sur DONACTION)        │
+│  → DONACTION net          :  14,00 € (4€ commission + 10€)  │
+├─────────────────────────────────────────────────────────────┤
+│  📄 REÇU FISCAL           :  94,10 € (montant net reçu)     │
+│     Réduction d'impôts    :  62,11 € (particulier)          │
+│     Coût réel du don      :  47,89 € (110 - 62,11)          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Note importante** : Dans ce scénario, l'association reçoit moins (94,10€ au lieu de 96€) mais DONACTION garantit sa commission de 4% net. Le reçu fiscal reflète exactement ce que l'association reçoit réellement.
+
+
+---
+
+**âš ï¸ Point clÃ© : Impact sur le ReÃ§u Fiscal**
+
+| ScÃ©nario | Montant reÃ§u fiscal | Justification |
+|----------|---------------------|---------------|
+| **Donor Pays Fee = TRUE** | 100% du montant saisi | L'association reÃ§oit l'intÃ©gralitÃ© |
+| **Donor Pays Fee = FALSE** | Montant net (~94%) | Le reÃ§u doit reflÃ©ter ce que l'association reÃ§oit rÃ©ellement |
+
+Le reÃ§u fiscal doit **toujours** correspondre au montant effectivement reÃ§u par l'association pour Ãªtre conforme aux exigences Cerfa.
+
+### 2.3 UX Formulaire â€” Choix Donor Pays Fee (Step 3)
+
+#### 2.3.1 Condition d'Affichage
+
+Le choix n'est affichÃ© que si `trade_policy.allow_donor_fee_choice = true`. Sinon, la valeur par dÃ©faut (projet ou club) s'applique automatiquement.
+
+#### 2.3.2 Maquette UI
+
+```
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚  ðŸ“‹ RÃ‰CAPITULATIF DE VOTRE DON                                      â”‚
+â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
+â”‚                                                                     â”‚
+â”‚  BÃ©nÃ©ficiaire : FC Lyon                                             â”‚
+â”‚  Projet : Nouveau terrain synthÃ©tique (ou "Fonctionnement gÃ©nÃ©ral") â”‚
+â”‚                                                                     â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€  â”‚
+â”‚                                                                     â”‚
+â”‚  Montant de votre don                              100,00 â‚¬         â”‚
+â”‚  Contribution Ã  DONACTION (optionnel)        [â”â”â”â”â—‹â”â”] 10,00 â‚¬      â”‚
+â”‚                                                                     â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€  â”‚
+â”‚                                                                     â”‚
+â”‚  ðŸ’¡ COMMENT SOUHAITEZ-VOUS GÃ‰RER LES FRAIS DE TRAITEMENT ?          â”‚
+â”‚                                                                     â”‚
+â”‚  â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”    â”‚
+â”‚  â”‚ â—‰ Je paie les frais en plus de mon don                      â”‚    â”‚
+â”‚  â”‚   â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€     â”‚    â”‚
+â”‚  â”‚   L'association reÃ§oit 100% de votre don (100,00â‚¬)          â”‚    â”‚
+â”‚  â”‚   Frais de traitement : +4,00â‚¬                              â”‚    â”‚
+â”‚  â”‚   â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”     â”‚    â”‚
+â”‚  â”‚   â”‚ ReÃ§u fiscal : 100,00â‚¬ â€¢ Total dÃ©bitÃ© : 114,00â‚¬   â”‚     â”‚    â”‚
+â”‚  â”‚   â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜     â”‚    â”‚
+â”‚  â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜    â”‚
+â”‚                                                                     â”‚
+â”‚  â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”    â”‚
+â”‚  â”‚ â—‹ J'intÃ¨gre les frais au montant de mon don                 â”‚    â”‚
+â”‚  â”‚   â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€     â”‚    â”‚
+â”‚  â”‚   L'association reÃ§oit votre don moins les frais (96,00â‚¬)   â”‚    â”‚
+â”‚  â”‚   Frais de traitement : -4,00â‚¬ (dÃ©duits)                    â”‚    â”‚
+â”‚  â”‚   â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”     â”‚    â”‚
+â”‚  â”‚   â”‚ ReÃ§u fiscal : 96,00â‚¬ â€¢ Total dÃ©bitÃ© : 110,00â‚¬    â”‚     â”‚    â”‚
+â”‚  â”‚   â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜     â”‚    â”‚
+â”‚  â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜    â”‚
+â”‚                                                                     â”‚
+â”‚  â„¹ï¸  Les frais (4%) couvrent les coÃ»ts bancaires et le             â”‚
+â”‚     fonctionnement de la plateforme DONACTION.                      â”‚
+â”‚                                                                     â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€  â”‚
+â”‚                                                                     â”‚
+â”‚  â˜‘ï¸ J'accepte les CGU                                               â”‚
+â”‚  â˜‘ï¸ Je comprends que mon don sera versÃ© au Fonds de dotation        â”‚
+â”‚                                                                     â”‚
+â”‚  â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•    â”‚
+â”‚  â”‚ TOTAL Ã€ PAYER                                      114,00â‚¬ â”‚    â”‚
+â”‚  â”‚ RÃ©duction d'impÃ´ts (66%)                           -66,00â‚¬ â”‚    â”‚
+â”‚  â”‚ COÃ›T RÃ‰EL DE VOTRE DON                              48,00â‚¬ â”‚    â”‚
+â”‚  â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•    â”‚
+â”‚                                                                     â”‚
+â”‚                    [ â† Retour ]      [ Payer 114,00â‚¬ â†’ ]            â”‚
+â”‚                                                                     â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+```
+
+#### 2.3.3 ImplÃ©mentation Svelte (Step 3)
+
+```svelte
+<!-- step3.svelte -->
+<script lang="ts">
+    import { DEFAULT_VALUES, SUBSCRIPTION } from '../logic/useSponsorshipForm.svelte';
+    
+    // DÃ©terminer si c'est un don projet ou club
+    $: isProjectDonation = SUBSCRIPTION.project?.uuid 
+        && SUBSCRIPTION.project.uuid !== SUBSCRIPTION.klubr.uuid;
+    
+    // RÃ©cupÃ©rer la trade policy
+    $: tradePolicy = SUBSCRIPTION.klubr?.trade_policy;
+    
+    // Valeur par dÃ©faut selon type de don
+    $: defaultDonorPaysFee = isProjectDonation 
+        ? tradePolicy?.donor_pays_fee_project ?? true
+        : tradePolicy?.donor_pays_fee_club ?? false;
+    
+    // Choix du donateur (initialisÃ© au dÃ©faut)
+    let donorPaysFee = $state(defaultDonorPaysFee);
+    
+    // Afficher le choix ?
+    $: showFeeChoice = tradePolicy?.allow_donor_fee_choice ?? true;
+    
+    // Calculs dynamiques
+    $: commission = DEFAULT_VALUES.montant * 0.04;
+    
+    $: feeBreakdown = {
+        commission,
+        totalWithFee: DEFAULT_VALUES.montant + DEFAULT_VALUES.contributionAKlubr + commission,
+        totalWithoutFee: DEFAULT_VALUES.montant + DEFAULT_VALUES.contributionAKlubr,
+        receiptWithFee: DEFAULT_VALUES.montant,
+        receiptWithoutFee: DEFAULT_VALUES.montant - commission,
+    };
+    
+    $: totalToPay = donorPaysFee 
+        ? feeBreakdown.totalWithFee 
+        : feeBreakdown.totalWithoutFee;
+    
+    $: receiptAmount = donorPaysFee 
+        ? feeBreakdown.receiptWithFee 
+        : feeBreakdown.receiptWithoutFee;
+    
+    // Exporter le choix pour le paiement
+    $: DEFAULT_VALUES.donorPaysFee = donorPaysFee;
+</script>
+
+{#if showFeeChoice}
+    <div class="fee-choice-section">
+        <h4>ðŸ’¡ Comment souhaitez-vous gÃ©rer les frais de traitement ?</h4>
+        
+        <label class="fee-option" class:selected={donorPaysFee}>
+            <input type="radio" bind:group={donorPaysFee} value={true} />
+            <div class="fee-option-content">
+                <strong>Je paie les frais en plus de mon don</strong>
+                <p>L'association reÃ§oit 100% de votre don ({feeBreakdown.receiptWithFee.toFixed(2)}â‚¬)</p>
+                <div class="fee-summary">
+                    <span>ReÃ§u fiscal : {feeBreakdown.receiptWithFee.toFixed(2)}â‚¬</span>
+                    <span>Total dÃ©bitÃ© : {feeBreakdown.totalWithFee.toFixed(2)}â‚¬</span>
+                </div>
+            </div>
+        </label>
+        
+        <label class="fee-option" class:selected={!donorPaysFee}>
+            <input type="radio" bind:group={donorPaysFee} value={false} />
+            <div class="fee-option-content">
+                <strong>J'intÃ¨gre les frais au montant de mon don</strong>
+                <p>L'association reÃ§oit votre don moins les frais ({feeBreakdown.receiptWithoutFee.toFixed(2)}â‚¬)</p>
+                <div class="fee-summary">
+                    <span>ReÃ§u fiscal : {feeBreakdown.receiptWithoutFee.toFixed(2)}â‚¬</span>
+                    <span>Total dÃ©bitÃ© : {feeBreakdown.totalWithoutFee.toFixed(2)}â‚¬</span>
+                </div>
+            </div>
+        </label>
+        
+        <p class="fee-info">
+            â„¹ï¸ Les frais (4%) couvrent les coÃ»ts bancaires et le fonctionnement de DONACTION.
+        </p>
+    </div>
+{/if}
+```
+
+#### 2.3.4 Mise Ã  jour du SchÃ©ma `klub-don`
+
+Ajouter le champ pour stocker le choix du donateur :
+
+```typescript
+// api/klub-don/content-types/klub-don/schema.json
+{
+    "donor_pays_fee": {
+        "type": "boolean",
+        "required": false,
+        "default": null  // null = utiliser la valeur par dÃ©faut de trade_policy
+    }
+}
+```
+
+#### 2.3.5 ImplÃ©mentation Backend (ContrÃ´leur mis Ã  jour)
+
+Le code dans `klub-don-payment.controller.ts` doit Ãªtre mis Ã  jour pour gÃ©rer la nouvelle logique :
+
+```typescript
+// helpers/stripe-connect-helper.ts
+
+/**
+ * DÃ©termine si le donateur paie les frais
+ * Prend en compte : choix explicite du donateur > dÃ©faut selon type de don
+ */
+export function determineDonorPaysFee(
+    klubDon: KlubDonEntity,
+    tradePolicy: TradePolicyEntity
+): boolean {
+    // 1. Si le donateur a fait un choix explicite (stockÃ© dans klub_don)
+    if (klubDon.donor_pays_fee !== null && klubDon.donor_pays_fee !== undefined) {
+        // VÃ©rifier que le choix est autorisÃ©
+        if (tradePolicy.allow_donor_fee_choice) {
+            return klubDon.donor_pays_fee;
+        }
+    }
+    
+    // 2. Sinon, utiliser la valeur par dÃ©faut selon le type de don
+    const isProjectDonation = klubDon.klub_projet !== null;
+    
+    return isProjectDonation 
+        ? tradePolicy.donor_pays_fee_project 
+        : tradePolicy.donor_pays_fee_club;
+}
+
+export function calculateApplicationFee(
+    amountInCents: number,
+    tradePolicy: TradePolicyEntity
+): number {
+    const { fee_model, commissionPercentage, fixed_amount } = tradePolicy;
+    
+    switch (fee_model) {
+        case 'percentage_only':
+            return Math.round(amountInCents * (commissionPercentage / 100));
+            
+        case 'fixed_only':
+            return Math.round((fixed_amount || 0) * 100);
+            
+        case 'percentage_plus_fixed':
+            const percentageFee = amountInCents * (commissionPercentage / 100);
+            const fixedFee = (fixed_amount || 0) * 100;
+            return Math.round(percentageFee + fixedFee);
+            
+        default:
+            return Math.round(amountInCents * 0.04); // Fallback 4%
+    }
+}
+```
+
+```typescript
+// klub-don-payment.controller.ts - createPaymentIntent() mis Ã  jour
+async createPaymentIntent() {
+    const ctx = strapi.requestContext.get();
+    try {
+        const { price, metadata, idempotencyKey } = ctx.request.body;
+        // Note: donorPaysFee n'est plus passÃ© directement, on le rÃ©cupÃ¨re du don
+
+        // ... validations existantes ...
+
+        // RÃ©cupÃ©rer le don avec son choix donor_pays_fee
+        const klubDon = await strapi.db.query('api::klub-don.klub-don').findOne({
+            where: { uuid: metadata.donUuid },
+            populate: { klub_projet: true },
+        });
+
+        // Fetch klubr with trade_policy and connected_account
+        const klubr: KlubrEntity = await strapi.db.query('api::klubr.klubr').findOne({
+            where: { uuid: metadata.klubUuid },
+            populate: { trade_policy: true, connected_account: true },
+        });
+
+        const tradePolicy = klubr.trade_policy as TradePolicyEntity;
+        const connectedAccount = klubr.connected_account as ConnectedAccountEntity;
+
+        // DÃ©terminer le donor_pays_fee effectif
+        const actualDonorPaysFee = determineDonorPaysFee(klubDon, tradePolicy);
+
+        // Calculate base amount in cents
+        let amountInCents = Number(price) * 100;
+        let applicationFeeAmount = 0;
+
+        if (tradePolicy?.stripe_connect && connectedAccount?.charges_enabled) {
+            // Calculate application fee
+            applicationFeeAmount = calculateApplicationFee(amountInCents, tradePolicy);
+
+            // If donor pays fee, add it to total amount
+            if (actualDonorPaysFee) {
+                amountInCents += applicationFeeAmount;
+            }
+
+            console.log('\nðŸ’³ â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•');
+            console.log('ðŸ’³ CRÃ‰ATION PAYMENT INTENT (STRIPE CONNECT)');
+            console.log(`ðŸ’³ Montant base: ${price}â‚¬`);
+            console.log(`ðŸ’³ Type don: ${klubDon.klub_projet ? 'Projet' : 'Club'}`);
+            console.log(`ðŸ’³ Donor pays fee: ${actualDonorPaysFee}`);
+            console.log(`ðŸ’³ Application fee: ${applicationFeeAmount / 100}â‚¬`);
+            console.log(`ðŸ’³ Total prÃ©levÃ©: ${amountInCents / 100}â‚¬`);
+            console.log('ðŸ’³ â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•\n');
+
+            // Create PaymentIntent
+            const paymentIntentParams: Stripe.PaymentIntentCreateParams = {
+                amount: amountInCents,
+                currency: 'eur',
+                metadata: {
+                    ...metadata,
+                    payment_method: 'stripe_connect',
+                    donor_pays_fee: String(actualDonorPaysFee),
+                    is_project_donation: String(!!klubDon.klub_projet),
+                },
+                on_behalf_of: connectedAccount.stripe_account_id,
+                transfer_data: {
+                    destination: connectedAccount.stripe_account_id,
+                },
+                application_fee_amount: applicationFeeAmount,
+            };
+
+            const paymentIntent = await stripe.paymentIntents.create(
+                paymentIntentParams,
+                { idempotencyKey: idempotencyKey || undefined }
+            );
+
+            // ... reste du code ...
+        }
+    }
+}
+```
+
+### 2.4 Organisation des Champs `trade_policy`
+
+Le champ `stripe_connect` dÃ©termine deux modes de fonctionnement radicalement diffÃ©rents :
+
+| Mode | `stripe_connect` | Flux Financier | Facturation |
+|------|------------------|----------------|-------------|
+| **Stripe Connect** | `true` | Paiement direct vers association, frais prÃ©levÃ©s automatiquement via `application_fee_amount` | **Aucune** - RelevÃ© de frais informatif uniquement |
+| **Stripe Classic (Legacy)** | `false` | Paiement vers compte unique DONACTION, redistribution mensuelle | **Facturation mensuelle** aux associations |
+
+#### 2.4.1 Champs COMMUNS (les deux modes)
+
+| Champ | Type | DÃ©faut | Description |
+|-------|------|--------|-------------|
+| `uuid` | UUID | auto | Identifiant unique |
+| `tradePolicyLabel` | string | - | Nom de la politique (ex: "Standard", "Partenaire", "Premium") |
+| `defaultTradePolicy` | boolean | `false` | Politique par dÃ©faut pour les nouveaux clubs |
+| `allowKlubrContribution` | boolean | `true` | Autoriser la contribution optionnelle Ã  DONACTION (0-25â‚¬) |
+| `stripe_connect` | boolean | `true` | **Switch principal** : `true` = Connect, `false` = Classic |
+
+#### 2.4.2 Champs STRIPE CONNECT (`stripe_connect = true`)
+
+Ces champs gÃ¨rent le prÃ©lÃ¨vement automatique des frais via Stripe.
+
+| Champ | Type | DÃ©faut | Description |
+|-------|------|--------|-------------|
+| `fee_model` | enum | `percentage_only` | Mode de calcul : `percentage_only`, `fixed_only`, `percentage_plus_fixed` |
+| `commissionPercentage` | decimal | 4 | % de commission DONACTION (utilisÃ© si fee_model inclut percentage) |
+| `fixed_amount` | decimal | 0 | Montant fixe en â‚¬ (utilisÃ© si fee_model inclut fixed) |
+| `donor_pays_fee_project` | boolean | `true` | **NOUVEAU** - DÃ©faut pour dons projet : donateur paie les frais |
+| `donor_pays_fee_club` | boolean | `false` | **NOUVEAU** - DÃ©faut pour dons club : frais dÃ©duits du don |
+| `allow_donor_fee_choice` | boolean | `true` | **NOUVEAU** - Autoriser le donateur Ã  modifier le dÃ©faut |
+
+**Logique Stripe Connect :**
+- Les frais sont calculÃ©s selon `fee_model` + `commissionPercentage` + `fixed_amount`
+- Le mode `donor_pays_fee` est dÃ©terminÃ© par : choix donateur > dÃ©faut projet/club
+- Pas de facturation : Stripe prÃ©lÃ¨ve automatiquement via `application_fee_amount`
+- RelevÃ© de frais mensuel **informatif** (pas une facture)
+
+#### 2.4.3 Champs STRIPE CLASSIC / LEGACY (`stripe_connect = false`)
+
+Ces champs gÃ¨rent la facturation mensuelle traditionnelle.
+
+| Champ | Type | DÃ©faut | Description |
+|-------|------|--------|-------------|
+| `noBilling` | boolean | `false` | Si `true`, pas de facturation (club exonÃ©rÃ©) |
+| `commissionPercentage` | decimal | 6 | % de commission sur les dons (pour facturation) |
+| `VATPercentage` | decimal | 20 | % TVA appliquÃ©e sur la commission |
+| `reference` | string | - | RÃ©fÃ©rence affichÃ©e sur la facture |
+| `billingDescription` | string | - | Description ligne de facturation |
+| `perDonationCost` | decimal | 0 | CoÃ»t fixe par don (en plus du %) |
+| `klubDonationReference` | string | - | RÃ©fÃ©rence pour la ligne contribution Klubr |
+| `klubDonationDescription` | string | - | Description ligne contribution Klubr |
+| `klubDonationPercentage` | decimal | 0 | % spÃ©cifique pour contributions Klubr |
+
+**Logique Stripe Classic :**
+- DONACTION collecte tous les paiements sur son compte unique
+- Facture mensuelle gÃ©nÃ©rÃ©e pour chaque club
+- Redistribution aprÃ¨s paiement de la facture
+
+#### 2.4.4 Champ PartagÃ© avec Usage DiffÃ©rent
+
+| Champ | Stripe Connect | Stripe Classic |
+|-------|----------------|----------------|
+| `commissionPercentage` | UtilisÃ© pour `application_fee_amount` (prÃ©lÃ¨vement auto, dÃ©faut 4%) | UtilisÃ© pour calcul facture mensuelle (dÃ©faut 6%) |
+
+#### 2.4.5 SchÃ©ma Visuel
+
+```
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚                        TRADE POLICY SCHEMA                              â”‚
+â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
+â”‚                                                                         â”‚
+â”‚  â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”    â”‚
+â”‚  â”‚                    COMMUNS (tous modes)                         â”‚    â”‚
+â”‚  â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤    â”‚
+â”‚  â”‚  uuid, tradePolicyLabel, defaultTradePolicy,                    â”‚    â”‚
+â”‚  â”‚  allowKlubrContribution, stripe_connect                         â”‚    â”‚
+â”‚  â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜    â”‚
+â”‚                              â”‚                                          â”‚
+â”‚               â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”´â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”                           â”‚
+â”‚               â–¼                              â–¼                          â”‚
+â”‚  â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”    â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”    â”‚
+â”‚  â”‚   STRIPE CONNECT        â”‚    â”‚      STRIPE CLASSIC (Legacy)    â”‚    â”‚
+â”‚  â”‚   stripe_connect=true   â”‚    â”‚      stripe_connect=false       â”‚    â”‚
+â”‚  â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤    â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤    â”‚
+â”‚  â”‚  fee_model              â”‚    â”‚  noBilling                      â”‚    â”‚
+â”‚  â”‚  commissionPercentage*  â”‚    â”‚  commissionPercentage*          â”‚    â”‚
+â”‚  â”‚  fixed_amount           â”‚    â”‚  VATPercentage                  â”‚    â”‚
+â”‚  â”‚  donor_pays_fee_project â”‚    â”‚  reference                      â”‚    â”‚
+â”‚  â”‚  donor_pays_fee_club    â”‚    â”‚  billingDescription             â”‚    â”‚
+â”‚  â”‚  allow_donor_fee_choice â”‚    â”‚  perDonationCost                â”‚    â”‚
+â”‚  â”‚                         â”‚    â”‚  klubDonationReference          â”‚    â”‚
+â”‚  â”‚                         â”‚    â”‚  klubDonationDescription        â”‚    â”‚
+â”‚  â”‚                         â”‚    â”‚  klubDonationPercentage         â”‚    â”‚
+â”‚  â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜    â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜    â”‚
+â”‚                                                                         â”‚
+â”‚  * commissionPercentage : usage diffÃ©rent selon le mode                 â”‚
+â”‚                                                                         â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+```
+
+#### 2.4.6 Recommandations d'ImplÃ©mentation
+
+1. **Conserver tous les champs legacy** pour la rÃ©trocompatibilitÃ© (clubs non migrÃ©s vers Connect)
+2. **Supprimer l'ancien `donor_pays_fee`** unique et le remplacer par les 3 nouveaux champs
+3. **Dashboard Admin** : Masquer dynamiquement les champs non pertinents selon `stripe_connect`
+4. **Valeur par dÃ©faut** : Nouveaux clubs crÃ©Ã©s avec `stripe_connect = true`
+5. **Migration** : Script pour migrer les `trade_policy` existantes (voir section 9.5)
+
+---
+
+### 2.5 Configuration Stripe Connect
+
+#### 2.5.1 Type de Charge : Destination Charges
+
+**Choix retenu : Destination Charges** (confirmÃ© par l'implÃ©mentation actuelle)
+
+| Type | Avantages | InconvÃ©nients |
+|------|-----------|---------------|
+| **Direct Charges** | Association gÃ¨re tout | Complexe pour non-tech |
+| **Destination Charges** âœ… | Simple, DONACTION contrÃ´le | Moins de flexibilitÃ© |
+| **Separate Charges & Transfers** | ContrÃ´le total | Plus complexe Ã  implÃ©menter |
+
+**Justification du choix :**
+1. DONACTION reste le "merchant of record" (responsable lÃ©gal)
+2. L'`application_fee_amount` est prÃ©levÃ© automatiquement
+3. Stripe gÃ¨re les soldes nÃ©gatifs (paramÃ¨tre `controller.losses.payments`)
+4. Simplification du reporting et de la rÃ©conciliation
+
+#### 2.5.2 ParamÃ¨tres de l'appel API PaymentIntent.create()
+
+```typescript
+// ImplÃ©mentation confirmÃ©e dans klub-don-payment.controller.ts
+const paymentIntentParams: Stripe.PaymentIntentCreateParams = {
+    amount: amountInCents, // Montant total (avec frais si donorPaysFee)
+    currency: 'eur',
+    metadata: {
+        donUuid: metadata.donUuid,
+        klubUuid: metadata.klubUuid,
+        projectUuid: metadata.projectUuid || null,
+        donorUuid: metadata.donorUuid,
+        payment_method: 'stripe_connect',
+        donor_pays_fee: String(actualDonorPaysFee),
+    },
+    // Destination Charges parameters
+    on_behalf_of: connectedAccount.stripe_account_id,
+    transfer_data: {
+        destination: connectedAccount.stripe_account_id,
+    },
+    application_fee_amount: applicationFeeAmount,
+};
+
+const paymentIntent = await stripe.paymentIntents.create(
+    paymentIntentParams,
+    {
+        idempotencyKey: idempotencyKey || undefined,
+    }
+);
+```
+
+#### 2.5.3 Gestion des Soldes NÃ©gatifs
+
+Lors de la crÃ©ation du compte Express, configurer :
+
+```typescript
+// Lors de account.create
+const account = await stripe.accounts.create({
+    type: 'express',
+    country: 'FR',
+    capabilities: {
+        card_payments: { requested: true },
+        transfers: { requested: true },
+    },
+    business_type: 'non_profit', // ou 'company' selon le cas
+    settings: {
+        payouts: {
+            schedule: {
+                interval: 'manual', // ou 'weekly'
+            },
+        },
+    },
+    controller: {
+        losses: {
+            payments: 'stripe', // Stripe supporte les pertes
+        },
+        fees: {
+            payer: 'application', // DONACTION paie les frais Stripe
+        },
+        stripe_dashboard: {
+            type: 'express',
+        },
+    },
+});
+```
+
+---
+
+## 3. Webhooks et Idempotence
+
+### 3.1 Matrice des Ã‰vÃ©nements Webhook
+
+#### 3.1.1 Ã‰vÃ©nements Compte ConnectÃ©
+
+| Ã‰vÃ©nement | Source | Action Backend | CriticitÃ© | Retry |
+|-----------|--------|----------------|-----------|-------|
+| `account.updated` | Connect | Sync statut KYC, `charges_enabled`, `payouts_enabled` | **Haute** | Oui |
+| `account.application.deauthorized` | Connect | DÃ©sactiver compte, notifier admin | **Haute** | Oui |
+| `capability.updated` | Connect | Mettre Ã  jour `capabilities` JSON | Moyenne | Oui |
+| `person.created` | Connect | Log audit (KYC progression) | Basse | Non |
+| `person.updated` | Connect | Log audit | Basse | Non |
+
+#### 3.1.2 Ã‰vÃ©nements Paiement
+
+| Ã‰vÃ©nement | Source | Action Backend | CriticitÃ© | Retry |
+|-----------|--------|----------------|-----------|-------|
+| `payment_intent.created` | Plateforme | Update `klub_don_payment` status â†’ `pending` | Moyenne | Oui |
+| `payment_intent.succeeded` | Plateforme | **CRITIQUE** : Update status â†’ `success`, gÃ©nÃ©rer PDFs, envoyer emails | **Critique** | Oui |
+| `payment_intent.payment_failed` | Plateforme | Update status â†’ `error`, stocker `error_code` | **Haute** | Oui |
+| `charge.refunded` | Plateforme | **CRITIQUE** : Workflow remboursement exceptionnel | **Critique** | Oui |
+| `charge.dispute.created` | Plateforme | Alerter admin, geler remboursement | **Haute** | Oui |
+| `transfer.created` | Connect | Log transfert vers association | Moyenne | Non |
+| `payout.paid` | Connect | Log virement bancaire association | Moyenne | Non |
+| `payout.failed` | Connect | Alerter admin + association | **Haute** | Oui |
+
+### 3.2 StratÃ©gie d'Idempotence
+
+#### 3.2.1 Format de la ClÃ© d'Idempotence
+
+**Pattern recommandÃ© :**
+
+```
+{donUuid}-{timestamp}-{action}
+```
+
+**Exemples :**
+- `abc123-1704812400000-create` (crÃ©ation initiale)
+- `abc123-1704812400000-retry-1` (premiÃ¨re tentative retry)
+- `abc123-1704812400000-retry-2` (deuxiÃ¨me tentative retry)
+
+#### 3.2.2 ImplÃ©mentation
+
+```typescript
+// helpers/idempotency-helper.ts
+
+export function generateIdempotencyKey(
+    donUuid: string,
+    action: 'create' | 'retry' = 'create',
+    retryCount: number = 0
+): string {
+    const timestamp = Date.now();
+    const base = `${donUuid}-${timestamp}-${action}`;
+    return retryCount > 0 ? `${base}-${retryCount}` : base;
+}
+
+export function isValidIdempotencyKey(key: string): boolean {
+    // Format: uuid-timestamp-action(-retryCount)?
+    const pattern = /^[a-f0-9-]{36}-\d{13}-(create|retry)(-\d+)?$/;
+    return pattern.test(key);
+}
+
+export async function findExistingPaymentByIdempotencyKey(
+    idempotencyKey: string
+): Promise<KlubDonPaymentEntity | null> {
+    return await strapi.db
+        .query('api::klub-don-payment.klub-don-payment')
+        .findOne({
+            where: { idempotency_key: idempotencyKey },
+            select: ['client_secret', 'status', 'intent_id'],
+        });
+}
+```
+
+#### 3.2.3 DurÃ©e de ValiditÃ©
+
+- **PaymentIntent** : 24 heures (durÃ©e standard Stripe)
+- **RÃ©utilisation du `client_secret`** : AutorisÃ©e si PaymentIntent non expirÃ©
+- **ClÃ© d'idempotence Stripe** : 24 heures (limite Stripe)
+
+### 3.3 SchÃ©ma de la Table `webhook_logs`
+
+```typescript
+// Nouveau content-type Ã  crÃ©er: api::webhook-log.webhook-log
+
+// schema.json
+{
+  "kind": "collectionType",
+  "collectionName": "webhook_logs",
+  "info": {
+    "singularName": "webhook-log",
+    "pluralName": "webhook-logs",
+    "displayName": "Webhook Log"
+  },
+  "options": {
+    "draftAndPublish": false
+  },
+  "attributes": {
+    "event_id": {
+      "type": "string",
+      "required": true,
+      "unique": true
+    },
+    "event_type": {
+      "type": "string",
+      "required": true
+    },
+    "source": {
+      "type": "enumeration",
+      "enum": ["platform", "connect"],
+      "required": true
+    },
+    "stripe_account_id": {
+      "type": "string"
+    },
+    "payload": {
+      "type": "json",
+      "required": true
+    },
+    "status": {
+      "type": "enumeration",
+      "enum": ["received", "processing", "processed", "failed", "ignored"],
+      "default": "received"
+    },
+    "processing_error": {
+      "type": "text"
+    },
+    "retry_count": {
+      "type": "integer",
+      "default": 0
+    },
+    "processed_at": {
+      "type": "datetime"
+    },
+    "related_don": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::klub-don.klub-don"
+    },
+    "related_klubr": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::klubr.klubr"
+    }
+  }
+}
+```
+
+**Index recommandÃ©s :**
+```sql
+CREATE INDEX idx_webhook_logs_event_id ON webhook_logs(event_id);
+CREATE INDEX idx_webhook_logs_event_type ON webhook_logs(event_type);
+CREATE INDEX idx_webhook_logs_status ON webhook_logs(status);
+CREATE INDEX idx_webhook_logs_created ON webhook_logs(created_at);
+```
+
+### 3.4 Endpoint Webhook Connect
+
+CrÃ©er un nouvel endpoint dÃ©diÃ© aux webhooks des comptes connectÃ©s :
+
+```typescript
+// api/stripe-connect/routes/stripe-connect-custom.ts
+export default {
+    routes: [
+        {
+            method: 'POST',
+            path: '/stripe-connect/webhook',
+            handler: 'stripe-connect.handleWebhook',
+            config: {
+                auth: false,
+            },
+        },
+    ],
+};
+
+// api/stripe-connect/controllers/stripe-connect.ts
+async handleWebhook() {
+    const ctx = strapi.requestContext.get();
+    const sig = ctx.request.headers['stripe-signature'];
+    
+    let event;
+    try {
+        event = stripe.webhooks.constructEvent(
+            ctx.request.body[Symbol.for('unparsedBody')],
+            sig,
+            process.env.STRIPE_WEBHOOK_SECRET_CONNECT
+        );
+    } catch (err) {
+        console.error('âš ï¸ Webhook signature verification failed:', err.message);
+        return ctx.badRequest(`Webhook Error: ${err.message}`);
+    }
+
+    // Log webhook
+    await strapi.documents('api::webhook-log.webhook-log').create({
+        data: {
+            event_id: event.id,
+            event_type: event.type,
+            source: 'connect',
+            stripe_account_id: event.account,
+            payload: event.data.object,
+            status: 'received',
+        },
+    });
+
+    // Handle event
+    switch (event.type) {
+        case 'account.updated':
+            await this.handleAccountUpdated(event);
+            break;
+        case 'account.application.deauthorized':
+            await this.handleAccountDeauthorized(event);
+            break;
+        // ... autres Ã©vÃ©nements
+    }
+
+    ctx.send({ received: true });
+}
+```
+
+---
+
+## 4. Onboarding Association
+
+### 4.1 Parcours en 3 Phases
+
+```mermaid
+flowchart TB
+    subgraph PhaseA["ðŸ“‹ Phase A: Informations Association"]
+        A1[Inscription initiale<br/>Next.js Frontend]
+        A2[CrÃ©ation User + Klubr<br/>+ Connected Account]
+        A3[Email avec lien activation]
+        A4[Connexion Dashboard Angular]
+        A5[ComplÃ©ter infos obligatoires]
+        A6[requiredFieldsCompletion = 100%]
+        A1 --> A2 --> A3 --> A4 --> A5 --> A6
+    end
+
+    subgraph PhaseB["ðŸ“ Phase B: Documents Juridiques"]
+        B1[Upload statuts association]
+        B2[Upload rÃ©cÃ©pissÃ© prÃ©fecture]
+        B3[Upload RIB association]
+        B4[Upload signature responsable]
+        B5[Validation manuelle DONACTION]
+        B6[requiredDocsValidatedCompletion = 100%]
+        B1 --> B2 --> B3 --> B4 --> B5 --> B6
+    end
+
+    subgraph PhaseC["ðŸ’³ Phase C: Activation Stripe"]
+        C1[Clic 'Activer compte paiement']
+        C2[GÃ©nÃ©ration lien onboarding Stripe]
+        C3[Onboarding hÃ©bergÃ© Stripe<br/>KYC, coordonnÃ©es bancaires]
+        C4[Webhook account.updated]
+        C5{charges_enabled?}
+        C6[âœ… COMPTE ACTIF<br/>Collecte possible]
+        C7[âš ï¸ KYC incomplet<br/>Relancer onboarding]
+        C1 --> C2 --> C3 --> C4 --> C5
+        C5 -->|true| C6
+        C5 -->|false| C7 --> C2
+    end
+
+    PhaseA --> PhaseB --> PhaseC
+```
+
+### 4.2 Phase A â€” Informations Association
+
+#### 4.2.1 Champs Requis pour `requiredFieldsCompletion = 100%`
+
+| Champ | Type | Obligatoire | Validation |
+|-------|------|-------------|------------|
+| `denomination` | string | âœ… | Min 3 caractÃ¨res |
+| `acronyme` | string | âŒ | - |
+| `adresse` | string | âœ… | Adresse complÃ¨te |
+| `codePostal` | string | âœ… | Format FR (5 chiffres) |
+| `ville` | string | âœ… | - |
+| `pays` | string | âœ… | Default: France |
+| `numeroRNA` | string | âœ… | Format W + 9 chiffres |
+| `SIREN` | string | âœ… | 9 chiffres, validÃ© via API |
+| `legalStatus` | enum | âœ… | Association loi 1901, etc. |
+| `sportType` | relation | âœ… | Type de sport |
+| `email` | email | âœ… | Email de contact |
+| `telephone` | string | âœ… | Format FR |
+| `objetAssociation` | text | âœ… | Min 50 caractÃ¨res |
+| `logo` | media | âœ… | Image (PNG, JPG) |
+
+#### 4.2.2 Calcul du Pourcentage de ComplÃ©tion
+
+```typescript
+// klubr.service.ts
+function calculateRequiredFieldsCompletion(klubr: KlubrEntity): number {
+    const requiredFields = [
+        'denomination',
+        'adresse',
+        'codePostal',
+        'ville',
+        'pays',
+        'numeroRNA',
+        'SIREN',
+        'legalStatus',
+        'sportType',
+        'email',
+        'telephone',
+        'objetAssociation',
+        'logo',
+    ];
+    
+    const filledFields = requiredFields.filter(field => {
+        const value = klubr[field];
+        return value !== null && value !== undefined && value !== '';
+    });
+    
+    return Math.round((filledFields.length / requiredFields.length) * 100);
+}
+```
+
+### 4.3 Phase B â€” Documents Juridiques
+
+#### 4.3.1 Liste des Documents Requis
+
+| Document | Champ | Format | Validation |
+|----------|-------|--------|------------|
+| Statuts Ã  jour | `statutsDocument` | PDF | Signature + date |
+| RÃ©cÃ©pissÃ© prÃ©fecture | `recepisseDocument` | PDF | NumÃ©ro RNA lisible |
+| RIB association | `ribDocument` | PDF/Image | IBAN FR valide |
+| **Signature responsable** | `managerSignature` | PNG/JPG | **NOUVEAU** - Pour reÃ§u fiscal |
+| PV derniÃ¨re AG | `pvAgDocument` | PDF | Date < 2 ans |
+
+#### 4.3.2 Nouveau Champ : `managerSignature`
+
+```typescript
+// klubr/content-types/klubr/schema.json - Ã€ AJOUTER
+{
+    "managerSignature": {
+        "type": "media",
+        "allowedTypes": ["images"],
+        "required": false
+    }
+}
+```
+
+**SpÃ©cifications :**
+- Format : PNG ou JPG avec fond transparent recommandÃ©
+- Taille : Max 500x200 pixels
+- Usage : Incrustation sur le reÃ§u fiscal Cerfa
+
+#### 4.3.3 Processus de Validation Manuelle
+
+1. Association uploade les documents
+2. Notification email Ã  l'admin DONACTION
+3. Admin vÃ©rifie dans `/admin/klub/listing`
+4. Actions possibles :
+   - âœ… Valider â†’ `requiredDocsValidatedCompletion = 100%`
+   - âŒ Rejeter â†’ Email avec motif + demande nouvelle version
+   - â³ En attente â†’ Demande de complÃ©ment
+
+### 4.4 Phase C â€” Activation Compte Stripe
+
+#### 4.4.1 CrÃ©ation du Compte Express
+
+```typescript
+// api/stripe-connect/services/stripe-connect.ts
+async createConnectedAccount(klubr: KlubrEntity): Promise<ConnectedAccountEntity> {
+    // VÃ©rifier prÃ©-requis
+    if (klubr.requiredFieldsCompletion < 100) {
+        throw new Error('Informations association incomplÃ¨tes');
+    }
+
+    // CrÃ©er compte Stripe Express
+    const account = await stripe.accounts.create({
+        type: 'express',
+        country: 'FR',
+        email: klubr.email,
+        capabilities: {
+            card_payments: { requested: true },
+            transfers: { requested: true },
+        },
+        business_type: 'non_profit',
+        business_profile: {
+            name: klubr.denomination,
+            url: `https://donaction.fr/${klubr.slug}`,
+            mcc: '8398', // Charitable organizations
+        },
+        metadata: {
+            klubr_uuid: klubr.uuid,
+            klubr_siren: klubr.SIREN,
+        },
+    });
+
+    // CrÃ©er entrÃ©e connected_account
+    const connectedAccount = await strapi.documents('api::connected-account.connected-account').create({
+        data: {
+            stripe_account_id: account.id,
+            klubr: klubr.id,
+            account_status: 'pending',
+            verification_status: 'unverified',
+            onboarding_completed: false,
+            charges_enabled: false,
+            payouts_enabled: false,
+            country: 'FR',
+            business_type: 'non_profit',
+            created_at_stripe: new Date(account.created * 1000),
+            last_sync: new Date(),
+        },
+    });
+
+    return connectedAccount;
+}
+```
+
+#### 4.4.2 GÃ©nÃ©ration du Lien d'Onboarding
+
+```typescript
+// api/stripe-connect/controllers/stripe-connect.ts
+async generateOnboardingLink() {
+    const ctx = strapi.requestContext.get();
+    const { klubrId } = ctx.params;
+
+    const klubr = await strapi.documents('api::klubr.klubr').findOne({
+        documentId: klubrId,
+        populate: ['connected_account'],
+    });
+
+    if (!klubr.connected_account) {
+        return ctx.badRequest('Compte Stripe non crÃ©Ã©');
+    }
+
+    const accountLink = await stripe.accountLinks.create({
+        account: klubr.connected_account.stripe_account_id,
+        refresh_url: `${process.env.ADMIN_URL}/payment-setup?refresh=true`,
+        return_url: `${process.env.ADMIN_URL}/payment-setup?success=true`,
+        type: 'account_onboarding',
+    });
+
+    return { url: accountLink.url };
+}
+```
+
+### 4.5 Checklist d'Activation ComplÃ¨te
+
+**Conditions pour activer la collecte de dons :**
+
+```typescript
+function canAcceptDonations(klubr: KlubrEntity): {
+    eligible: boolean;
+    reasons: string[];
+} {
+    const reasons: string[] = [];
+
+    // VÃ©rifications klubr
+    if (klubr.requiredFieldsCompletion < 100) {
+        reasons.push(`Informations incomplÃ¨tes (${klubr.requiredFieldsCompletion}%)`);
+    }
+    if (klubr.requiredDocsValidatedCompletion < 100) {
+        reasons.push(`Documents non validÃ©s (${klubr.requiredDocsValidatedCompletion}%)`);
+    }
+    if (!klubr.donationEligible) {
+        reasons.push('Collecte de dons non activÃ©e par admin');
+    }
+    if (klubr.status !== 'published') {
+        reasons.push('Profil non publiÃ©');
+    }
+
+    // VÃ©rifications Stripe Connect
+    const connectedAccount = klubr.connected_account;
+    if (!connectedAccount) {
+        reasons.push('Compte Stripe non crÃ©Ã©');
+    } else {
+        if (!connectedAccount.charges_enabled) {
+            reasons.push('Paiements non activÃ©s sur Stripe');
+        }
+        if (connectedAccount.account_status === 'restricted') {
+            reasons.push('Compte Stripe restreint');
+        }
+        if (connectedAccount.account_status === 'disabled') {
+            reasons.push('Compte Stripe dÃ©sactivÃ©');
+        }
+    }
+
+    return {
+        eligible: reasons.length === 0,
+        reasons,
+    };
+}
+```
+
+### 4.6 Widget de Progression Dashboard
+
+**Composant Angular pour `/dashboard`** :
+
+```typescript
+// admin/routes/dashboard/ui/completion-widget.component.ts
+interface CompletionStatus {
+    klubInfo: {
+        percentage: number;
+        missingFields: string[];
+    };
+    documents: {
+        percentage: number;
+        pendingDocs: string[];
+    };
+    stripe: {
+        status: 'not_started' | 'pending' | 'active' | 'restricted';
+        chargesEnabled: boolean;
+        payoutsEnabled: boolean;
+    };
+    overall: {
+        canAcceptDonations: boolean;
+        nextAction: string;
+    };
+}
+```
+
+**Affichage :**
+```
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚  ðŸ“Š Statut d'Activation                                 â”‚
+â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
+â”‚  Informations Klub    â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‘â–‘â–‘â–‘  75%   [â†’]       â”‚
+â”‚  Documents            â–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–ˆâ–‘â–‘â–‘â–‘â–‘â–‘  60%   [â†’]       â”‚
+â”‚  Compte Paiement      â³ En attente KYC       [â†’]       â”‚
+â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
+â”‚  âš ï¸ Action requise: ComplÃ©ter les informations          â”‚
+â”‚     [ComplÃ©ter mon profil]                              â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+```
+
+---
+
+## 5. Documents Fiscaux
+
+### 5.1 ReÃ§u Fiscal Cerfa
+
+#### 5.1.1 Changements Majeurs
+
+| Aspect | Ancien ModÃ¨le | Nouveau ModÃ¨le |
+|--------|---------------|----------------|
+| **Ã‰metteur** | DONACTION (Fond Klubr) | Association bÃ©nÃ©ficiaire |
+| **Signature** | Signature DONACTION | `managerSignature` de l'association |
+| **Montant** | Montant brut | Montant net reÃ§u (= intentionnel si donorPaysFee) |
+| **NumÃ©ro SIREN** | SIREN DONACTION | SIREN Association |
+
+#### 5.1.2 Structure du ReÃ§u
+
+```
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚                    REÃ‡U AU TITRE DES DONS                       â”‚
+â”‚            Ã€ UN ORGANISME D'INTÃ‰RÃŠT GÃ‰NÃ‰RAL                     â”‚
+â”‚                    (Article 200-1 du CGI)                       â”‚
+â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
+â”‚                                                                 â”‚
+â”‚  BÃ‰NÃ‰FICIAIRE DU DON                                            â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€                                          â”‚
+â”‚  Nom: [klubr.denomination]                                      â”‚
+â”‚  Adresse: [klubr.adresse], [klubr.codePostal] [klubr.ville]     â”‚
+â”‚  SIREN: [klubr.SIREN]                                           â”‚
+â”‚  Objet: [klubr.objetAssociation]                                â”‚
+â”‚                                                                 â”‚
+â”‚  DONATEUR                                                       â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€                                                       â”‚
+â”‚  [Si particulier]                                               â”‚
+â”‚  CivilitÃ©: [donateur.civilite]                                  â”‚
+â”‚  Nom: [donateur.nom] [donateur.prenom]                          â”‚
+â”‚  Adresse: [donateur.adresse], [donateur.cp] [donateur.ville]    â”‚
+â”‚                                                                 â”‚
+â”‚  [Si organisme]                                                 â”‚
+â”‚  Raison sociale: [donateur.raisonSocial]                        â”‚
+â”‚  SIREN: [donateur.SIREN]                                        â”‚
+â”‚  Adresse: [donateur.adresse], [donateur.cp] [donateur.ville]    â”‚
+â”‚                                                                 â”‚
+â”‚  DON                                                            â”‚
+â”‚  â”€â”€â”€                                                            â”‚
+â”‚  Date: [don.datePaiment]                                        â”‚
+â”‚  Montant: [montant_en_chiffres] â‚¬ ([montant_en_lettres] euros)  â”‚
+â”‚  Mode de versement: Paiement en ligne (carte bancaire)          â”‚
+â”‚  Nature du don: NumÃ©raire                                       â”‚
+â”‚                                                                 â”‚
+â”‚  â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•    â”‚
+â”‚  Le bÃ©nÃ©ficiaire certifie que le don n'ouvre droit Ã  aucune     â”‚
+â”‚  contrepartie directe ou indirecte au profit du donateur.       â”‚
+â”‚                                                                 â”‚
+â”‚  Signature du responsable:                                      â”‚
+â”‚  [Image: klubr.managerSignature]                                â”‚
+â”‚                                                                 â”‚
+â”‚  NumÃ©ro d'ordre: R-[attestationNumber]                          â”‚
+â”‚  Date d'Ã©mission: [date_generation]                             â”‚
+â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
+â”‚  [Si particulier] Article 200 du CGI - RÃ©duction 66%            â”‚
+â”‚  [Si organisme]   Article 238 bis du CGI - RÃ©duction 60%        â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+```
+
+#### 5.1.3 Calcul du Montant sur le ReÃ§u
+
+```typescript
+function getReceiptAmount(don: KlubDonEntity, tradePolicy: TradePolicyEntity): number {
+    // Si Donor Pays Fee : le montant du reÃ§u = montant intentionnel
+    if (tradePolicy.donor_pays_fee) {
+        return don.montant; // Montant original sans frais
+    }
+    
+    // Si frais dÃ©duits : montant = ce que l'association reÃ§oit vraiment
+    const applicationFee = calculateApplicationFee(don.montant * 100, tradePolicy) / 100;
+    return don.montant - applicationFee;
+}
+```
+
+**Important :** Avec le modÃ¨le "Donor Pays Fee", le reÃ§u fiscal correspond exactement au montant que le donateur a voulu donner, ce qui est plus transparent et cohÃ©rent.
+
+#### 5.1.4 GÃ©nÃ©ration PDF
+
+```typescript
+// helpers/klubrPDF/generateInvoice/index.ts - Ã€ MODIFIER
+async function generateRecuFiscal(don: KlubDonEntity): Promise<string> {
+    const klubr = don.klubr;
+    const donateur = don.klubDonateur;
+    const tradePolicy = klubr.trade_policy;
+    
+    // Charger le template appropriÃ©
+    const templatePath = donateur.donateurType === 'Organisme'
+        ? 'templates/recu-pro-template.pdf'
+        : 'templates/recu-template.pdf';
+    
+    // Calculer le montant Ã  afficher
+    const montantRecu = getReceiptAmount(don, tradePolicy);
+    
+    // Charger la signature du responsable
+    const signatureImage = await loadImage(klubr.managerSignature?.url);
+    
+    // GÃ©nÃ©rer le PDF avec les donnÃ©es de l'ASSOCIATION (pas DONACTION)
+    const pdfDoc = await PDFDocument.load(fs.readFileSync(templatePath));
+    const form = pdfDoc.getForm();
+    
+    // DonnÃ©es Ã©metteur = Association
+    form.getTextField('emetteur_nom').setText(klubr.denomination);
+    form.getTextField('emetteur_adresse').setText(
+        `${klubr.adresse}, ${klubr.codePostal} ${klubr.ville}`
+    );
+    form.getTextField('emetteur_siren').setText(klubr.SIREN);
+    form.getTextField('emetteur_objet').setText(klubr.objetAssociation);
+    
+    // DonnÃ©es donateur
+    if (donateur.donateurType === 'Organisme') {
+        form.getTextField('donateur_raison').setText(donateur.raisonSocial);
+        form.getTextField('donateur_siren').setText(donateur.SIREN);
+    } else {
+        form.getTextField('donateur_nom').setText(
+            `${donateur.civilite} ${donateur.prenom} ${donateur.nom}`
+        );
+    }
+    form.getTextField('donateur_adresse').setText(
+        `${donateur.adresse}, ${donateur.cp} ${donateur.ville}`
+    );
+    
+    // Montant
+    form.getTextField('montant_chiffres').setText(`${montantRecu.toFixed(2)} â‚¬`);
+    form.getTextField('montant_lettres').setText(numberToWords(montantRecu));
+    form.getTextField('date_don').setText(formatDate(don.datePaiment));
+    
+    // Signature
+    if (signatureImage) {
+        const signaturePage = pdfDoc.getPages()[0];
+        signaturePage.drawImage(signatureImage, {
+            x: 350,
+            y: 100,
+            width: 150,
+            height: 60,
+        });
+    }
+    
+    // NumÃ©ro et date d'Ã©mission
+    form.getTextField('numero_recu').setText(`R-${don.attestationNumber}`);
+    form.getTextField('date_emission').setText(formatDate(new Date()));
+    
+    // Sauvegarder
+    const pdfBytes = await pdfDoc.save();
+    const outputPath = `private-pdf/recus/R-${don.attestationNumber}.pdf`;
+    fs.writeFileSync(outputPath, pdfBytes);
+    
+    return outputPath;
+}
+```
+
+### 5.2 Workflow Remboursement Exceptionnel
+
+#### 5.2.1 Principe Fondamental
+
+> **Un reÃ§u fiscal Ã©mis est IMMUABLE.** En cas de remboursement, on ne modifie jamais le reÃ§u original â€” on crÃ©e une attestation d'annulation sÃ©parÃ©e.
+
+#### 5.2.2 Cas DÃ©clencheurs
+
+| Cas | PrioritÃ© | Workflow SpÃ©cifique |
+|-----|----------|---------------------|
+| **Fraude avÃ©rÃ©e** | P0 | Signalement TRACFIN si > 10kâ‚¬, blocage donateur |
+| **Litige juridique** | P1 | Gel jusqu'Ã  dÃ©cision, conservation preuves |
+| **Erreur de paiement** | P2 | Fast-track si reÃ§u non gÃ©nÃ©rÃ© |
+| **Demande donateur** | P3 | Circuit standard avec dÃ©claration |
+| **RÃ©tractation 14j** | P3 | SimplifiÃ© si reÃ§u non gÃ©nÃ©rÃ© |
+
+#### 5.2.3 Diagramme du Workflow
+
+```mermaid
+sequenceDiagram
+    participant D as Donateur
+    participant S as Support
+    participant AL as Association Leader
+    participant Admin as Dashboard Admin
+    participant Sys as SystÃ¨me
+    participant Stripe as Stripe
+    participant Tax as Fisc (si applicable)
+
+    Note over D,Tax: Phase 1: Demande de Remboursement
+    D->>S: Email demande remboursement
+    S->>AL: Transmission demande
+    AL->>Admin: CrÃ©er requÃªte /refunds
+    Admin->>Sys: Submit (type, raison, montant)
+    Sys->>Sys: Status: awaiting_declaration
+    Sys->>D: Email: "Merci de signer la dÃ©claration"
+
+    Note over D,Tax: Phase 2: DÃ©claration Donateur
+    D->>D: TÃ©lÃ©charge, signe PDF
+    D->>S: Renvoie dÃ©claration signÃ©e
+    S->>AL: Transmet
+    AL->>Admin: Upload dÃ©claration
+    Admin->>Sys: Stocke fichier
+    Sys->>Sys: Status: pending_approval
+    Sys->>AL: Notification: "PrÃªt pour approbation"
+
+    Note over D,Tax: Phase 3: Approbation
+    AL->>Admin: Revue demande complÃ¨te
+    
+    alt ApprouvÃ©
+        AL->>Admin: Clic "Approuver"
+        Admin->>Sys: Approbation
+        Sys->>Sys: CrÃ©e ReceiptCancellation
+        Sys->>Sys: GÃ©nÃ¨re attestation annulation PDF
+        Sys->>Stripe: stripe.refunds.create()
+        Stripe-->>Sys: Refund ID
+        Sys->>Sys: Update don.refund_status = completed
+        Sys->>Sys: Log FinancialAuditLog
+        Sys->>D: Email: "Remboursement effectuÃ©" + PDF
+        Sys->>AL: Email: "Remboursement traitÃ©"
+        
+        alt Montant > Seuil fiscal
+            Sys->>Tax: Notification autoritÃ© fiscale
+        end
+    else RefusÃ©
+        AL->>Admin: Clic "Refuser" + motif
+        Admin->>Sys: Refus enregistrÃ©
+        Sys->>D: Email: "Remboursement refusÃ©" + motif
+    end
+```
+
+#### 5.2.4 Structure de l'Attestation d'Annulation
+
+```
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚            ATTESTATION D'ANNULATION DE REÃ‡U FISCAL              â”‚
+â”‚                                                                 â”‚
+â”‚  NumÃ©ro du reÃ§u annulÃ©: R-[attestationNumber]                   â”‚
+â”‚  Date d'Ã©mission du reÃ§u: [date_recu_original]                  â”‚
+â”‚                                                                 â”‚
+â”‚  MOTIF DE L'ANNULATION                                          â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€                                          â”‚
+â”‚  [X] Demande du donateur                                        â”‚
+â”‚  [ ] Erreur de paiement                                         â”‚
+â”‚  [ ] Fraude dÃ©tectÃ©e                                            â”‚
+â”‚  [ ] Litige juridique                                           â”‚
+â”‚                                                                 â”‚
+â”‚  REMBOURSEMENT                                                  â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€                                                   â”‚
+â”‚  Montant remboursÃ©: [montant] â‚¬                                 â”‚
+â”‚  Date du remboursement: [date_remboursement]                    â”‚
+â”‚  RÃ©fÃ©rence Stripe: [refund_id]                                  â”‚
+â”‚                                                                 â”‚
+â”‚  DÃ‰CLARATION DU DONATEUR                                        â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€                                        â”‚
+â”‚  Le donateur soussignÃ© dÃ©clare:                                 â”‚
+â”‚  - Ne pas avoir utilisÃ© le reÃ§u annulÃ© pour dÃ©duction fiscale   â”‚
+â”‚  - S'engager Ã  ne pas utiliser le reÃ§u annulÃ© ultÃ©rieurement    â”‚
+â”‚                                                                 â”‚
+â”‚  Document de dÃ©claration signÃ©: [RÃ©fÃ©rence piÃ¨ce jointe]        â”‚
+â”‚                                                                 â”‚
+â”‚  Ã‰METTEUR                                                       â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€                                                       â”‚
+â”‚  [klubr.denomination]                                           â”‚
+â”‚  SIREN: [klubr.SIREN]                                           â”‚
+â”‚                                                                 â”‚
+â”‚  Fait le [date], par [admin_name]                               â”‚
+â”‚  NumÃ©ro d'annulation: ANN-[attestationNumber]                   â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+```
+
+#### 5.2.5 Table `receipt_cancellations` (Mise Ã  jour)
+
+```typescript
+// SchÃ©ma existant Ã  complÃ©ter
+{
+    "attributes": {
+        // Existants
+        "original_receipt_number": { "type": "string", "required": true },
+        "cancellation_reason": {
+            "type": "enumeration",
+            "enum": ["donor_request", "payment_error", "fraud", "legal_dispute"],
+            "required": true
+        },
+        "donor_declaration_path": { "type": "string" },
+        "cancellation_attestation_path": { "type": "string" },
+        "refund_amount": { "type": "decimal", "required": true },
+        "stripe_refund_id": { "type": "string" },
+        
+        // Ã€ AJOUTER
+        "status": {
+            "type": "enumeration",
+            "enum": ["awaiting_declaration", "pending_approval", "approved", "denied", "processing", "completed"],
+            "default": "awaiting_declaration",
+            "required": true
+        },
+        "approved_by": {
+            "type": "relation",
+            "relation": "manyToOne",
+            "target": "plugin::users-permissions.user"
+        },
+        "approved_at": { "type": "datetime" },
+        "denied_by": {
+            "type": "relation",
+            "relation": "manyToOne",
+            "target": "plugin::users-permissions.user"
+        },
+        "denied_at": { "type": "datetime" },
+        "denial_reason": { "type": "text" },
+        "tax_authority_notified": { "type": "boolean", "default": false },
+        "tax_notification_date": { "type": "datetime" },
+        
+        // Relations
+        "klub_don": {
+            "type": "relation",
+            "relation": "oneToOne",
+            "target": "api::klub-don.klub-don"
+        },
+        "klubr": {
+            "type": "relation",
+            "relation": "manyToOne",
+            "target": "api::klubr.klubr"
+        }
+    }
+}
+```
+
+---
+
+## 6. Gestion des Erreurs
+
+### 6.1 Matrice des ScÃ©narios d'Erreur
+
+| ScÃ©nario | DÃ©tection | Action Automatique | Action Manuelle | Impact UX |
+|----------|-----------|-------------------|-----------------|-----------|
+| **Compte association inactif** | `charges_enabled: false` avant PaymentIntent | Bloquer formulaire don, afficher message | Admin relance onboarding Stripe | Donateur ne peut pas donner |
+| **KYC incomplet** | `verification_status !== 'verified'` | Griser bouton "Finaliser", afficher statut | Association complÃ¨te KYC | Association ne peut pas recevoir |
+| **Paiement Ã©chouÃ© (carte)** | Webhook `payment_failed` | Retry button + email relance | Support contacte si rÃ©current | Donateur peut rÃ©essayer |
+| **Double paiement** | ClÃ© idempotence existante | Retourner `client_secret` existant | - | Transparent pour donateur |
+| **Remboursement post-reÃ§u** | Demande manuelle | Workflow approbation | Validation admin + dÃ©claration | Processus long |
+| **Webhook perdu** | Cron vÃ©rifie PaymentIntents orphelins | RÃ©conciliation automatique | Alerte si > 24h | Retard gÃ©nÃ©ration PDF |
+| **Compte dÃ©connectÃ©** | Webhook `account.application.deauthorized` | DÃ©sactiver collecte, notifier | Admin contacte association | Collecte suspendue |
+| **Solde nÃ©gatif** | Stripe Dashboard alert | Stripe gÃ¨re (controller.losses) | Monitoring admin | Aucun (Stripe absorbe) |
+| **Fraude suspectÃ©e** | Analyse patterns manuels | Gel compte | Investigation + signalement | Blocage prÃ©ventif |
+
+### 6.2 StratÃ©gie de Retry
+
+#### 6.2.1 Retry InstantanÃ© (CÃ´tÃ© Donateur)
+
+```typescript
+// donaction-saas/src/components/sponsorshipForm/components/step4.svelte
+async function handlePaymentError(error: StripeError) {
+    paymentError = error.message;
+    
+    // Afficher bouton retry
+    showRetryButton = true;
+    
+    // Si le PaymentIntent est encore valide (< 24h)
+    if (currentPaymentIntent && !isExpired(currentPaymentIntent)) {
+        // RÃ©utiliser le mÃªme client_secret
+        canRetryWithSameIntent = true;
+    } else {
+        // CrÃ©er un nouveau PaymentIntent
+        canRetryWithSameIntent = false;
+    }
+}
+
+async function retryPayment() {
+    if (canRetryWithSameIntent) {
+        // RÃ©utiliser l'intent existant
+        const result = await stripe.confirmPayment({
+            elements,
+            confirmParams: {},
+            redirect: 'if_required',
+        });
+    } else {
+        // Nouveau PaymentIntent avec nouvelle clÃ© idempotence
+        const newKey = generateIdempotencyKey(donUuid, 'retry', retryCount++);
+        const { intent } = await createPaymentIntent(price, newKey, donorPaysFee);
+        currentClientSecret = intent;
+        // Puis confirmer...
+    }
+}
+```
+
+#### 6.2.2 Cron Job de Backup
+
+```typescript
+// api/klub-don-payment/services/klub-don-payment.ts
+async reconcilePendingPayments() {
+    // Trouver les paiements "pending" depuis plus de 30 minutes
+    const pendingPayments = await strapi.db
+        .query('api::klub-don-payment.klub-don-payment')
+        .findMany({
+            where: {
+                status: 'pending',
+                updatedAt: { $lt: new Date(Date.now() - 30 * 60 * 1000) },
+            },
+            populate: { klub_don: true },
+        });
+
+    for (const payment of pendingPayments) {
+        try {
+            // VÃ©rifier le statut rÃ©el sur Stripe
+            const paymentIntent = await stripe.paymentIntents.retrieve(payment.intent_id);
+            
+            if (paymentIntent.status === 'succeeded') {
+                // Webhook manquÃ© - traiter maintenant
+                await this.updateDonAndDonPayment({
+                    status: 'success',
+                    donUuid: payment.klub_don.uuid,
+                    intent: paymentIntent,
+                });
+                
+                console.log(`âœ… RÃ©conciliation: ${payment.intent_id} marquÃ© succÃ¨s`);
+            } else if (['canceled', 'requires_payment_method'].includes(paymentIntent.status)) {
+                // Marquer comme Ã©chouÃ©
+                await strapi.documents('api::klub-don-payment.klub-don-payment').update({
+                    documentId: payment.documentId,
+                    data: { status: 'error' },
+                });
+            }
+        } catch (err) {
+            console.error(`âŒ Erreur rÃ©conciliation ${payment.intent_id}:`, err);
+        }
+    }
+}
+
+// Cron config
+// 0 */15 * * * * - Toutes les 15 minutes
+```
+
+#### 6.2.3 Politique de RÃ©utilisation du `client_secret`
+
+| Situation | Action | Raison |
+|-----------|--------|--------|
+| PaymentIntent < 24h, status `requires_payment_method` | RÃ©utiliser | Ã‰conomise crÃ©ation |
+| PaymentIntent < 24h, status `requires_confirmation` | RÃ©utiliser | Paiement en cours |
+| PaymentIntent > 24h | Nouveau PaymentIntent | Expiration Stripe |
+| PaymentIntent status `succeeded` | Ne pas rÃ©utiliser | DÃ©jÃ  payÃ© |
+| PaymentIntent status `canceled` | Nouveau PaymentIntent | AnnulÃ© |
+
+### 6.3 Messages d'Erreur Utilisateur
+
+```typescript
+// Mapping erreurs Stripe â†’ Messages FR
+const STRIPE_ERROR_MESSAGES: Record<string, string> = {
+    'card_declined': 'Votre carte a Ã©tÃ© refusÃ©e. Veuillez essayer une autre carte.',
+    'insufficient_funds': 'Fonds insuffisants. Veuillez vÃ©rifier votre solde.',
+    'expired_card': 'Votre carte a expirÃ©. Veuillez utiliser une autre carte.',
+    'incorrect_cvc': 'Le code de sÃ©curitÃ© (CVC) est incorrect.',
+    'processing_error': 'Une erreur technique est survenue. Veuillez rÃ©essayer.',
+    'account_inactive': 'Cette association ne peut temporairement pas recevoir de dons. Veuillez rÃ©essayer plus tard.',
+    'account_kyc_incomplete': 'Le compte de l\'association est en cours de vÃ©rification. Veuillez rÃ©essayer ultÃ©rieurement.',
+};
+
+function getErrorMessage(error: StripeError): string {
+    return STRIPE_ERROR_MESSAGES[error.code] 
+        || 'Une erreur est survenue lors du paiement. Veuillez rÃ©essayer.';
+}
+```
+
+---
+
+## 7. Reporting et Monitoring
+
+### 7.1 Dashboard Superadmin
+
+#### 7.1.1 MÃ©triques Temps RÃ©el
+
+| MÃ©trique | Source | RafraÃ®chissement | Alerte si |
+|----------|--------|------------------|-----------|
+| Dons en cours (pending) | `klub_don_payment.status` | 1 min | > 50 |
+| Dons Ã©chouÃ©s (24h) | `klub_don_payment.status = error` | 5 min | > 10% |
+| Volume total (jour) | `klub_don.montant` agrÃ©gÃ© | 5 min | - |
+| Commissions (jour) | `application_fee_amount` | 5 min | - |
+| Webhooks en erreur | `webhook_logs.status = failed` | 1 min | > 5 |
+| Comptes restreints | `connected_account.account_status` | 1h | > 0 |
+| KYC incomplets | `connected_account.charges_enabled = false` | 1h | - |
+
+#### 7.1.2 Ã‰cran `/admin/monitoring`
+
+```
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚  ðŸ“Š DONACTION - Monitoring Temps RÃ©el                               â”‚
+â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
+â”‚                                                                     â”‚
+â”‚  ðŸ’° AUJOURD'HUI                    ðŸ“ˆ TENDANCE (7j)                 â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€                  â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€                â”‚
+â”‚  Dons rÃ©ussis: 47                  [Graphique sparkline]            â”‚
+â”‚  Volume: 3 450 â‚¬                   +12% vs semaine derniÃ¨re         â”‚
+â”‚  Commissions: 138 â‚¬                                                 â”‚
+â”‚                                                                     â”‚
+â”‚  âš ï¸ ALERTES                        ðŸ”„ WEBHOOKS                      â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€                          â”€â”€â”€â”€â”€â”€â”€â”€â”€                        â”‚
+â”‚  [!] 2 paiements pending > 30min   ReÃ§us (1h): 156                  â”‚
+â”‚  [!] 1 compte restreint            TraitÃ©s: 154                     â”‚
+â”‚      â†’ FC Lyon (voir)              Erreurs: 2 (1.3%)                â”‚
+â”‚                                                                     â”‚
+â”‚  ðŸ¦ COMPTES STRIPE                                                  â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€                                                   â”‚
+â”‚  Actifs: 145 | Pending KYC: 12 | Restreints: 1 | Total: 158        â”‚
+â”‚                                                                     â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+```
+
+#### 7.1.3 Alertes Automatiques
+
+```typescript
+// Notifications Slack/Discord + Email
+interface AlertConfig {
+    type: 'slack' | 'discord' | 'email';
+    conditions: {
+        pending_payments_count?: number;      // Alerte si > X
+        failed_payments_percentage?: number;  // Alerte si > X%
+        restricted_accounts_count?: number;   // Alerte si > 0
+        webhook_failures_count?: number;      // Alerte si > X
+    };
+    recipients: string[];
+}
+
+const ALERT_CONFIG: AlertConfig[] = [
+    {
+        type: 'slack',
+        conditions: {
+            pending_payments_count: 50,
+            webhook_failures_count: 5,
+        },
+        recipients: ['#donaction-alerts'],
+    },
+    {
+        type: 'email',
+        conditions: {
+            restricted_accounts_count: 1,
+        },
+        recipients: ['admin@donaction.fr'],
+    },
+];
+```
+
+### 7.2 RelevÃ© de Frais Mensuel Association
+
+#### 7.2.1 Contenu du Document
+
+```
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚                     RELEVÃ‰ DE FRAIS MENSUEL                         â”‚
+â”‚                         Janvier 2025                                â”‚
+â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
+â”‚                                                                     â”‚
+â”‚  ASSOCIATION                                                        â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€                                                        â”‚
+â”‚  FC Lyon                                                            â”‚
+â”‚  SIREN: 123 456 789                                                 â”‚
+â”‚  12 rue du Stade, 69001 Lyon                                        â”‚
+â”‚                                                                     â”‚
+â”‚  PÃ‰RIODE                                                            â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€                                                            â”‚
+â”‚  Du 01/01/2025 au 31/01/2025                                        â”‚
+â”‚                                                                     â”‚
+â”‚  RÃ‰CAPITULATIF                                                      â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€                                                      â”‚
+â”‚  Nombre de dons reÃ§us: 47                                           â”‚
+â”‚  Montant total collectÃ©: 3 450,00 â‚¬                                 â”‚
+â”‚                                                                     â”‚
+â”‚  DÃ‰TAIL DES FRAIS                                                   â”‚
+â”‚  â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€                                                    â”‚
+â”‚  â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¬â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¬â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¬â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¬â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â” â”‚
+â”‚  â”‚ Date     â”‚ Donateur   â”‚ Montant    â”‚ Commission â”‚ Mode frais   â”‚ â”‚
+â”‚  â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¼â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¼â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¼â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¼â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤ â”‚
+â”‚  â”‚ 02/01/25 â”‚ J. Dupont  â”‚ 100,00 â‚¬   â”‚ 4,00 â‚¬     â”‚ Donor Pays   â”‚ â”‚
+â”‚  â”‚ 05/01/25 â”‚ SAS Martin â”‚ 500,00 â‚¬   â”‚ 20,00 â‚¬    â”‚ Donor Pays   â”‚ â”‚
+â”‚  â”‚ ...      â”‚ ...        â”‚ ...        â”‚ ...        â”‚ ...          â”‚ â”‚
+â”‚  â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”´â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”´â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”´â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”´â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜ â”‚
+â”‚                                                                     â”‚
+â”‚  TOTAL COMMISSIONS: 138,00 â‚¬                                        â”‚
+â”‚  Mode de prÃ©lÃ¨vement: PrÃ©levÃ© au donateur (Donor Pays Fee)          â”‚
+â”‚                                                                     â”‚
+â”‚  â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•    â”‚
+â”‚  Ce document est un relevÃ© d'information.                           â”‚
+â”‚  Il ne constitue pas une facture.                                   â”‚
+â”‚  Les commissions ont Ã©tÃ© prÃ©levÃ©es automatiquement lors de chaque   â”‚
+â”‚  transaction via Stripe Connect.                                    â”‚
+â”‚                                                                     â”‚
+â”‚  GÃ©nÃ©rÃ© le: 01/02/2025                                              â”‚
+â”‚  RÃ©fÃ©rence: REL-2025-01-FCLYON                                      â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+```
+
+#### 7.2.2 GÃ©nÃ©ration et Distribution
+
+```typescript
+// api/fee-statement/services/fee-statement.ts
+async generateMonthlyStatements(month: number, year: number) {
+    // RÃ©cupÃ©rer tous les klubrs avec dons ce mois
+    const klubrsWithDons = await strapi.db.query('api::klubr.klubr').findMany({
+        where: {
+            klub_dons: {
+                statusPaiment: 'success',
+                datePaiment: {
+                    $gte: new Date(year, month - 1, 1),
+                    $lt: new Date(year, month, 1),
+                },
+            },
+        },
+        populate: {
+            klub_dons: {
+                filters: {
+                    statusPaiment: 'success',
+                    datePaiment: {
+                        $gte: new Date(year, month - 1, 1),
+                        $lt: new Date(year, month, 1),
+                    },
+                },
+                populate: ['klubDonateur', 'klub_don_payments'],
+            },
+            trade_policy: true,
+            leaders: true,
+        },
+    });
+
+    for (const klubr of klubrsWithDons) {
+        // Calculer les totaux
+        const summary = calculateStatementSummary(klubr.klub_dons, klubr.trade_policy);
+        
+        // GÃ©nÃ©rer PDF
+        const pdfPath = await generateStatementPDF({
+            klubr,
+            month,
+            year,
+            dons: klubr.klub_dons,
+            summary,
+        });
+
+        // Sauvegarder l'enregistrement
+        await strapi.documents('api::fee-statement.fee-statement').create({
+            data: {
+                klubr: klubr.id,
+                period: `${year}-${String(month).padStart(2, '0')}`,
+                total_donations: summary.totalDonations,
+                total_commissions: summary.totalCommissions,
+                pdf_path: pdfPath,
+            },
+        });
+
+        // Envoyer par email aux leaders
+        for (const leader of klubr.leaders) {
+            await sendBrevoTransacEmail({
+                to: [{ email: leader.email }],
+                templateId: BREVO_TEMPLATES.FEE_STATEMENT,
+                params: {
+                    LEADER_NAME: `${leader.prenom} ${leader.nom}`,
+                    CLUB_NAME: klubr.denomination,
+                    PERIOD: `${getMonthName(month)} ${year}`,
+                    TOTAL_DONATIONS: formatCurrency(summary.totalDonations),
+                    TOTAL_COMMISSIONS: formatCurrency(summary.totalCommissions),
+                },
+                attachment: [{ content: pdfPath, name: `releve-${year}-${month}.pdf` }],
+            });
+        }
+    }
+}
+```
+
+---
+
+## 8. Plan de Migration
+
+### 8.1 Phases de DÃ©ploiement
+
+```mermaid
+gantt
+    title Plan de Migration Stripe Connect
+    dateFormat  YYYY-MM-DD
+    section Phase 0
+    Revue code existant (Phases 1-3)    :done, p0, 2026-01-11, 3d
+    Tests unitaires                      :active, p0t, after p0, 5d
+    
+    section Phase 1 - Pilote
+    SÃ©lection 5 associations pilotes    :p1a, after p0t, 2d
+    Onboarding pilotes                  :p1b, after p1a, 7d
+    Tests en production                 :p1c, after p1b, 14d
+    Collecte feedback                   :p1d, after p1b, 14d
+    
+    section Phase 2 - Rollout
+    Communication gÃ©nÃ©rale              :p2a, after p1c, 3d
+    Onboarding par vagues (10/semaine)  :p2b, after p2a, 28d
+    Support renforcÃ©                    :p2c, after p2a, 35d
+    
+    section Phase 3 - DÃ©prÃ©ciation
+    DÃ©sactivation ancien systÃ¨me        :p3a, after p2b, 7d
+    Migration donnÃ©es legacy            :p3b, after p3a, 14d
+    Archivage                           :p3c, after p3b, 7d
+```
+
+### 8.2 DÃ©tail des Phases
+
+#### Phase 0 : PrÃ©paration (Semaine 1-2)
+
+| TÃ¢che | Responsable | Livrable |
+|-------|-------------|----------|
+| Revue du code Phases 1-3 | Tech Lead | Liste corrections |
+| Ajout tests unitaires | Dev Backend | Coverage > 80% |
+| Test intÃ©gration Stripe sandbox | Dev Backend | Rapport tests |
+| CrÃ©ation environnement staging | DevOps | Env fonctionnel |
+| Documentation API interne | Dev Backend | OpenAPI spec |
+| Formation Ã©quipe support | Product Owner | Guide support |
+
+#### Phase 1 : Pilote (Semaine 3-6)
+
+**CritÃ¨res de sÃ©lection des pilotes :**
+- Association avec volume > 10 dons/mois
+- Leader technophile et rÃ©actif
+- ReprÃ©sentativitÃ© : 1 grand club, 2 moyens, 2 petits
+- Accord de participation au pilote
+
+**Actions :**
+1. Contact personnalisÃ© des 5 associations
+2. Session d'onboarding individuelle (visio)
+3. Suivi quotidien pendant 2 semaines
+4. Collecte de feedback structurÃ©
+5. Correction des bugs identifiÃ©s
+
+#### Phase 2 : Rollout (Semaine 7-14)
+
+**Communication :**
+- Email d'annonce Ã  toutes les associations
+- FAQ dÃ©diÃ©e sur le site
+- Webinaire de prÃ©sentation (enregistrÃ©)
+- Tutoriel vidÃ©o Ã©tape par Ã©tape
+
+**Rythme d'onboarding :**
+- Semaine 7-8 : 10 associations
+- Semaine 9-10 : 20 associations
+- Semaine 11-12 : 30 associations
+- Semaine 13-14 : Reste des associations
+
+#### Phase 3 : DÃ©prÃ©ciation (Semaine 15-18)
+
+**DÃ©sactivation de l'ancien systÃ¨me :**
+1. Blocage des nouveaux dons via ancien systÃ¨me
+2. Migration des dons en cours vers nouveau systÃ¨me
+3. Archivage des donnÃ©es legacy
+4. Redirection des webhooks
+
+### 8.3 KPIs de SuccÃ¨s
+
+| KPI | Cible | Mesure |
+|-----|-------|--------|
+| **Taux d'onboarding** | > 90% associations actives en 8 semaines | `connected_accounts.charges_enabled / klubrs.donationEligible` |
+| **Taux de conversion formulaire** | â‰¥ taux actuel (-2% max) | Dons rÃ©ussis / Formulaires ouverts |
+| **Temps moyen onboarding** | < 48h | CrÃ©ation compte â†’ charges_enabled |
+| **Taux d'erreur paiement** | < 5% | Erreurs / Total tentatives |
+| **NPS Associations** | > 40 | EnquÃªte post-onboarding |
+| **Volume dons** | Pas de baisse | Comparaison M-1, M-12 |
+| **Tickets support** | < 10/semaine aprÃ¨s rollout | Zendesk/Email |
+
+### 8.4 Plan de Rollback
+
+En cas de problÃ¨me critique :
+
+```typescript
+// Configuration feature flag
+const STRIPE_CONNECT_ENABLED = process.env.STRIPE_CONNECT_ENABLED === 'true';
+
+// Dans le contrÃ´leur
+async createPaymentIntent() {
+    const klubr = await getKlubr(klubrUuid);
+    const useStripeConnect = STRIPE_CONNECT_ENABLED 
+        && klubr.trade_policy?.stripe_connect 
+        && klubr.connected_account?.charges_enabled;
+    
+    if (useStripeConnect) {
+        // Nouveau flow Stripe Connect
+        return this.createConnectPaymentIntent(...);
+    } else {
+        // Fallback ancien flow
+        return this.createClassicPaymentIntent(...);
+    }
+}
+```
+
+**ProcÃ©dure de rollback :**
+1. DÃ©sactiver `STRIPE_CONNECT_ENABLED` en variable d'environnement
+2. RedÃ©ployer l'API
+3. Communiquer aux associations impactÃ©es
+4. Investiguer et corriger
+5. RÃ©activer progressivement
+
+---
+
+## 9. Annexes
+
+### 9.1 Exemples de Payloads API
+
+#### 9.1.1 CrÃ©ation PaymentIntent (Stripe Connect)
+
+**Request :**
+```json
+POST /api/klub-don-payments/create-payment-intent
+Content-Type: application/json
+
+{
+    "price": 100,
+    "idempotencyKey": "abc123-1704812400000-create",
+    "donorPaysFee": true,
+    "metadata": {
+        "donUuid": "abc123",
+        "klubUuid": "def456",
+        "projectUuid": "ghi789",
+        "donorUuid": "jkl012"
+    }
+}
+```
+
+**Response (succÃ¨s) :**
+```json
+{
+    "intent": "pi_3QfXXXXXXXXXXXXX_secret_XXXXXXXXX",
+    "reused": false
+}
+```
+
+**Response (rÃ©utilisation idempotence) :**
+```json
+{
+    "intent": "pi_3QfXXXXXXXXXXXXX_secret_XXXXXXXXX",
+    "reused": true
+}
+```
+
+#### 9.1.2 Webhook `payment_intent.succeeded`
+
+```json
+{
+    "id": "evt_1234567890",
+    "object": "event",
+    "type": "payment_intent.succeeded",
+    "data": {
+        "object": {
+            "id": "pi_3QfXXXXXXXXXXXXX",
+            "object": "payment_intent",
+            "amount": 10590,
+            "currency": "eur",
+            "status": "succeeded",
+            "metadata": {
+                "donUuid": "abc123",
+                "klubUuid": "def456",
+                "projectUuid": "ghi789",
+                "donorUuid": "jkl012",
+                "payment_method": "stripe_connect",
+                "donor_pays_fee": "true"
+            },
+            "on_behalf_of": "acct_1234567890",
+            "transfer_data": {
+                "destination": "acct_1234567890"
+            },
+            "application_fee_amount": 590
+        }
+    }
+}
+```
+
+#### 9.1.3 CrÃ©ation Compte Express
+
+**Request :**
+```json
+POST /api/stripe-connect/create-account
+Content-Type: application/json
+
+{
+    "klubrId": "abc123"
+}
+```
+
+**Response :**
+```json
+{
+    "stripeAccountId": "acct_1234567890",
+    "onboardingUrl": "https://connect.stripe.com/express/onboarding/..."
+}
+```
+
+### 9.2 Templates de Documents
+
+#### 9.2.1 Email Template : Confirmation Don
+
+**ID Brevo : 8** (Ã  mettre Ã  jour)
+
+```html
+Objet : Merci pour votre don Ã  {{CLUB_DENOMINATION}} ðŸŽ‰
+
+Bonjour {{RECEIVER_FULLNAME}},
+
+Nous avons le plaisir de vous confirmer la rÃ©ception de votre don.
+
+ðŸ“‹ RÃ©capitulatif :
+â€¢ Association : {{CLUB_DENOMINATION}}
+{{#if PROJECT_TITLE}}â€¢ Projet : {{PROJECT_TITLE}}{{/if}}
+â€¢ Montant du don : {{DONATION_AMOUNT}} â‚¬
+{{#if DONATION_CONTRIBUTION}}â€¢ Contribution DONACTION : {{DONATION_CONTRIBUTION}} â‚¬{{/if}}
+â€¢ Date : {{DONATION_DATE}}
+
+ðŸ“Ž Vos documents sont joints Ã  cet email :
+â€¢ Attestation de paiement
+{{#if WITH_TAX_REDUCTION}}â€¢ ReÃ§u fiscal (Ã  conserver pour votre dÃ©claration d'impÃ´ts){{/if}}
+
+ðŸ’¡ Votre don permet Ã  {{CLUB_DENOMINATION}} de poursuivre ses activitÃ©s d'intÃ©rÃªt gÃ©nÃ©ral.
+
+Sportivement,
+L'Ã©quipe DONACTION
+```
+
+#### 9.2.2 Email Template : Relance Onboarding
+
+**ID Brevo : Nouveau**
+
+```html
+Objet : Finalisez votre compte de collecte {{CLUB_NAME}}
+
+Bonjour {{LEADER_NAME}},
+
+Votre association {{CLUB_NAME}} a commencÃ© son inscription sur DONACTION, mais l'activation du compte de paiement n'est pas terminÃ©e.
+
+ðŸ“Š Statut actuel :
+â€¢ Informations association : {{CLUB_INFO_PERCENT}}%
+â€¢ Documents : {{DOCS_PERCENT}}%
+â€¢ Compte paiement : En attente
+
+âž¡ï¸ Pour finaliser et commencer Ã  recevoir des dons :
+{{ONBOARDING_LINK}}
+
+Cette Ã©tape prend environ 5 minutes et nÃ©cessite :
+â€¢ Un justificatif d'identitÃ© du responsable
+â€¢ Les coordonnÃ©es bancaires de l'association
+
+Besoin d'aide ? RÃ©pondez Ã  cet email.
+
+L'Ã©quipe DONACTION
+```
+
+### 9.3 Glossaire
+
+| Terme | DÃ©finition |
+|-------|------------|
+| **Application Fee** | Commission prÃ©levÃ©e par DONACTION sur chaque transaction |
+| **Connected Account** | Compte Stripe Express d'une association, liÃ© Ã  la plateforme DONACTION |
+| **Destination Charges** | Type de flux Stripe oÃ¹ le paiement arrive sur le compte plateforme puis est transfÃ©rÃ© |
+| **Donor Pays Fee** | ModÃ¨le oÃ¹ le donateur prend en charge les frais (Stripe + commission) |
+| **Express Account** | Type de compte Stripe avec onboarding hÃ©bergÃ© par Stripe |
+| **Idempotency Key** | ClÃ© unique empÃªchant les double-facturations |
+| **KYC** | Know Your Customer - VÃ©rification d'identitÃ© |
+| **PaymentIntent** | Objet Stripe reprÃ©sentant une intention de paiement |
+| **ReÃ§u Fiscal** | Document Cerfa permettant la dÃ©duction fiscale |
+| **Trade Policy** | Configuration des frais et commissions par association |
+| **Webhook** | Notification HTTP envoyÃ©e par Stripe lors d'un Ã©vÃ©nement |
+
+### 9.4 Points d'Attention IdentifiÃ©s dans le Code Actuel
+
+AprÃ¨s analyse du code fourni (Documents 14, 16, 33, 37), voici les ajustements recommandÃ©s :
+
+| Fichier | Constat | Recommandation |
+|---------|---------|----------------|
+| `trade_policy/schema.json` | `commissionPercentage` default = 6% | Ajuster Ã  4% pour nouveau modÃ¨le |
+| `trade_policy/schema.json` | Champ unique `donor_pays_fee` | **REMPLACER** par `donor_pays_fee_project` + `donor_pays_fee_club` + `allow_donor_fee_choice` |
+| `klub-don/schema.json` | Pas de champ `donor_pays_fee` | **AJOUTER** pour stocker le choix du donateur |
+| `klub-don-payment.controller.ts` | Calcul frais ne gÃ¨re pas tous les `fee_model` | ImplÃ©menter les 3 modes |
+| `connected-account/schema.json` | Pas de champ `business_profile` | Ajouter pour enrichir donnÃ©es |
+| `api.ts` (Svelte) | Pas de gestion erreur dÃ©taillÃ©e | Ajouter mapping erreurs FR |
+| - | Manque `webhook_logs` content-type | CrÃ©er pour audit trail |
+| - | Manque `receipt_cancellations` complet | ComplÃ©ter schÃ©ma |
+| - | Manque endpoint webhook Connect | CrÃ©er `/stripe-connect/webhook` |
+
+### 9.5 Ã‰volution du SchÃ©ma `trade_policy`
+
+**Modifications Ã  apporter au fichier `trade_policy/schema.json` :**
+
+```json
+{
+  "kind": "collectionType",
+  "collectionName": "trade_policies",
+  "info": {
+    "singularName": "trade-policy",
+    "pluralName": "trade-policies",
+    "displayName": "Trade policy"
+  },
+  "attributes": {
+    // ... attributs existants ...
+    
+    // SUPPRIMER ce champ
+    // "donor_pays_fee": { ... }
+    
+    // AJOUTER ces 3 nouveaux champs
+    "donor_pays_fee_project": {
+      "type": "boolean",
+      "default": true,
+      "required": true
+    },
+    "donor_pays_fee_club": {
+      "type": "boolean",
+      "default": false,
+      "required": true
+    },
+    "allow_donor_fee_choice": {
+      "type": "boolean",
+      "default": true,
+      "required": true
+    }
+  }
+}
+```
+
+**Migration de donnÃ©es (si des trade_policies existantes) :**
+
+```typescript
+// Script de migration
+async function migrateDonorPaysFeeFields() {
+    const tradePolicies = await strapi.db.query('api::trade-policy.trade-policy').findMany();
+    
+    for (const policy of tradePolicies) {
+        await strapi.db.query('api::trade-policy.trade-policy').update({
+            where: { id: policy.id },
+            data: {
+                donor_pays_fee_project: policy.donor_pays_fee ?? true,
+                donor_pays_fee_club: policy.donor_pays_fee ?? false,
+                allow_donor_fee_choice: true,
+            },
+        });
+    }
+    
+    console.log(`âœ… MigrÃ© ${tradePolicies.length} trade policies`);
+}
+```
+
+### 9.6 Ã‰volution du SchÃ©ma `klub-don`
+
+**Ajout du champ pour stocker le choix du donateur :**
+
+```json
+// Ã€ ajouter dans klub-don/schema.json
+{
+  "donor_pays_fee": {
+    "type": "boolean",
+    "required": false
+  }
+}
+```
+
+**Note :** Si `null`, le systÃ¨me utilisera la valeur par dÃ©faut de la `trade_policy` selon le type de don (projet ou club).
+
+---
+
+## 10. Checklist de Validation
+
+### Avant Mise en Production
+
+- [ ] Tests unitaires coverage > 80%
+- [ ] Tests d'intÃ©gration Stripe sandbox OK
+- [ ] Calcul des frais validÃ© avec comptable
+- [ ] Templates PDF reÃ§u fiscal validÃ©s
+- [ ] Webhooks testÃ©s (tous les Ã©vÃ©nements)
+- [ ] StratÃ©gie d'idempotence testÃ©e
+- [ ] Rollback testÃ© en staging
+- [ ] Documentation support rÃ©digÃ©e
+- [ ] Ã‰quipe support formÃ©e
+- [ ] KPIs de monitoring configurÃ©s
+- [ ] Alertes Slack/Discord configurÃ©es
+- [ ] Feature flag fonctionnel
+- [ ] Plan de communication prÃªt
+
+### Pour Chaque Association OnboardÃ©e
+
+- [ ] `requiredFieldsCompletion` = 100%
+- [ ] `requiredDocsValidatedCompletion` = 100%
+- [ ] `managerSignature` uploadÃ©e
+- [ ] Connected Account crÃ©Ã©
+- [ ] `charges_enabled` = true
+- [ ] `payouts_enabled` = true
+- [ ] Premier don test rÃ©ussi
+- [ ] ReÃ§u fiscal gÃ©nÃ©rÃ© correctement
+- [ ] Email confirmation reÃ§u
+
+---
+
+## 11. Configuration du Compte Stripe pour Connect
+
+### 11.1 PrÃ©requis
+
+Avant de configurer Stripe Connect, vÃ©rifiez que vous disposez de :
+
+| Ã‰lÃ©ment | Statut | Description |
+|---------|--------|-------------|
+| Compte Stripe activÃ© | âœ… Requis | Compte live avec vÃ©rification d'identitÃ© complÃ¨te |
+| Entreprise en France | âœ… Requis | DONACTION doit Ãªtre une entitÃ© franÃ§aise |
+| Site web HTTPS | âœ… Requis | URLs de production accessibles en HTTPS |
+| Conditions d'utilisation | âœ… Requis | CGU mentionnant Stripe (sous-traitant de paiement) |
+
+### 11.2 AccÃ¨s aux ParamÃ¨tres Connect
+
+**Chemin :** Dashboard Stripe â†’ Plus (+) â†’ Connect
+
+Si Connect n'est pas visible :
+1. Aller dans **Settings** â†’ **Product settings** â†’ **Connect**
+2. Activer Connect pour votre compte
+3. ComplÃ©ter le **Platform Profile** (questionnaire sur votre modÃ¨le)
+
+### 11.3 Configuration du Platform Profile
+
+Lors de la premiÃ¨re activation, Stripe pose des questions pour configurer votre plateforme :
+
+| Question | RÃ©ponse pour DONACTION |
+|----------|------------------------|
+| **Type de plateforme** | Marketplace / Plateforme de dons |
+| **Qui sont vos utilisateurs ?** | Associations / Non-profits |
+| **Comment collectez-vous les paiements ?** | Au nom des associations |
+| **Qui gÃ¨re les remboursements ?** | La plateforme (DONACTION) |
+| **Pays des comptes connectÃ©s** | France (FR) uniquement pour v1 |
+
+### 11.4 ParamÃ¨tres Connect Settings
+
+**Chemin :** Dashboard â†’ Connect â†’ Settings
+
+#### 11.4.1 Account Types (Types de comptes)
+
+```
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚  âš™ï¸ CONFIGURATION DES COMPTES CONNECTÃ‰S                     â”‚
+â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
+â”‚                                                             â”‚
+â”‚  Type de compte : â—‰ Express  â—‹ Custom  â—‹ Standard           â”‚
+â”‚                                                             â”‚
+â”‚  â–¸ Express = Stripe gÃ¨re l'onboarding KYC                   â”‚
+â”‚  â–¸ Associations redirigÃ©es vers formulaire Stripe           â”‚
+â”‚  â–¸ Express Dashboard pour voir leurs paiements              â”‚
+â”‚                                                             â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+```
+
+**Choix recommandÃ© : Express**
+- Stripe gÃ¨re la vÃ©rification d'identitÃ© (KYC)
+- Onboarding hÃ©bergÃ© par Stripe (moins de dÃ©veloppement)
+- Associations ont accÃ¨s Ã  l'Express Dashboard
+- ConformitÃ© automatique aux Ã©volutions rÃ©glementaires
+
+#### 11.4.2 Capabilities (FonctionnalitÃ©s)
+
+**Chemin :** Connect â†’ Settings â†’ Capabilities
+
+Activer les capabilities suivantes pour les nouveaux comptes :
+
+| Capability | Activer | Description |
+|------------|---------|-------------|
+| `card_payments` | âœ… Oui | Accepter les paiements par carte |
+| `transfers` | âœ… Oui | Recevoir des transferts de la plateforme |
+| `cartes_bancaires` | âš ï¸ Optionnel | Cartes Bancaires franÃ§aises (ajoute des vÃ©rifications) |
+
+> **Note France :** Pour accepter Cartes Bancaires, l'association doit fournir son numÃ©ro SIREN dans le formulaire d'onboarding.
+
+#### 11.4.3 Payout Settings (Virements)
+
+**Chemin :** Connect â†’ Settings â†’ Payouts
+
+| ParamÃ¨tre | Valeur recommandÃ©e | Description |
+|-----------|-------------------|-------------|
+| **Payout schedule** | `daily` ou `weekly` | FrÃ©quence des virements |
+| **Delay days** | `7` (minimum lÃ©gal FR) | DÃ©lai avant virement |
+| **Allow manual payouts** | âœ… ActivÃ© | Associations peuvent dÃ©clencher un virement |
+| **Debit negative balances** | âœ… ActivÃ© | DÃ©biter le compte en cas de solde nÃ©gatif |
+
+#### 11.4.4 Branding (Personnalisation)
+
+**Chemin :** Connect â†’ Settings â†’ Branding
+
+```
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚  ðŸŽ¨ BRANDING DE LA PLATEFORME                               â”‚
+â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
+â”‚                                                             â”‚
+â”‚  Business name :  DONACTION                                 â”‚
+â”‚  Icon :           [ðŸ“¤ Upload logo 512x512 PNG]              â”‚
+â”‚  Primary color :  #73cfa8 (vert DONACTION)                  â”‚
+â”‚  Secondary color: #fb9289 (corail)                          â”‚
+â”‚                                                             â”‚
+â”‚  âœ… Copy platform branding to connected accounts            â”‚
+â”‚                                                             â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+```
+
+Ce branding apparaÃ®t :
+- Sur le formulaire d'onboarding Stripe des associations
+- Dans l'Express Dashboard des associations
+- Sur les emails envoyÃ©s par Stripe aux associations
+
+### 11.5 Configuration des Webhooks
+
+Stripe Connect nÃ©cessite **2 types de webhooks** distincts :
+
+#### 11.5.1 Webhook Account (Paiements)
+
+**Chemin :** Developers â†’ Webhooks â†’ Add endpoint
+
+| ParamÃ¨tre | Valeur |
+|-----------|--------|
+| **Endpoint URL** | `https://www.donaction.fr/service/api/klub-don-payments/stripe-web-hooks` |
+| **Listen to** | â—‰ Events on your account |
+| **Events** | `payment_intent.succeeded`, `payment_intent.payment_failed`, `charge.refunded` |
+
+#### 11.5.2 Webhook Connect (Comptes connectÃ©s)
+
+**Chemin :** Developers â†’ Webhooks â†’ Add endpoint
+
+| ParamÃ¨tre | Valeur |
+|-----------|--------|
+| **Endpoint URL** | `https://www.donaction.fr/service/api/stripe-connect/webhook` |
+| **Listen to** | â—‰ Events on Connected accounts |
+| **Events sÃ©lectionnÃ©s** | Voir liste ci-dessous |
+
+**Ã‰vÃ©nements Connect Ã  Ã©couter :**
+
+| Ã‰vÃ©nement | Description |
+|-----------|-------------|
+| `account.updated` | Statut KYC mis Ã  jour |
+| `account.application.deauthorized` | Association dÃ©connectÃ©e |
+| `capability.updated` | Capability activÃ©e/dÃ©sactivÃ©e |
+| `person.created` | ReprÃ©sentant lÃ©gal ajoutÃ© |
+| `person.updated` | Infos reprÃ©sentant mises Ã  jour |
+| `payout.created` | Virement initiÃ© |
+| `payout.paid` | Virement effectuÃ© |
+| `payout.failed` | Ã‰chec virement |
+| `charge.dispute.created` | **Litige ouvert** |
+| `charge.dispute.updated` | **Litige mis Ã  jour** |
+| `charge.dispute.closed` | **Litige fermÃ©** |
+
+#### 11.5.3 RÃ©cupÃ©ration des Webhook Secrets
+
+AprÃ¨s crÃ©ation de chaque webhook :
+
+1. Cliquer sur le webhook crÃ©Ã©
+2. Dans **Signing secret**, cliquer **Reveal**
+3. Copier la clÃ© `whsec_...`
+
+```bash
+# Variables d'environnement Ã  configurer
+STRIPE_WEBHOOK_SECRET=whsec_xxx...      # Webhook Account (paiements)
+STRIPE_WEBHOOK_SECRET_CONNECT=whsec_yyy... # Webhook Connect (comptes)
+```
+
+### 11.6 ClÃ©s API
+
+**Chemin :** Developers â†’ API keys
+
+#### 11.6.1 ClÃ©s Disponibles
+
+| Type | Format | Usage |
+|------|--------|-------|
+| **Publishable key** | `pk_live_...` | Frontend (Svelte, Next.js) |
+| **Secret key** | `sk_live_...` | Backend (Strapi) - âš ï¸ NE JAMAIS EXPOSER |
+
+#### 11.6.2 Variables d'Environnement
+
+```bash
+# Backend (donaction-api/.env.prod)
+STRIPE_SECRET_KEY=sk_live_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+STRIPE_WEBHOOK_SECRET_CONNECT=whsec_...
+
+# Frontend (donaction-frontend/.env.prod)
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_...
+
+# SaaS Widget (donaction-saas/.env.prod)
+VITE_STRIPE_PUBLISHABLE_KEY=pk_live_...
+```
+
+#### 11.6.3 ClÃ©s de Test (Sandbox)
+
+Pour l'environnement staging (`re7.donaction.fr`), utiliser les clÃ©s test :
+
+| Type | Format |
+|------|--------|
+| **Publishable key** | `pk_test_...` |
+| **Secret key** | `sk_test_...` |
+
+> **Basculer Test/Live :** Toggle en haut Ã  droite du Dashboard Stripe
+
+### 11.7 Configuration Onboarding Express
+
+**Chemin :** Connect â†’ Settings â†’ Express
+
+#### 11.7.1 Onboarding Interface
+
+| ParamÃ¨tre | Configuration |
+|-----------|---------------|
+| **Countries** | âœ… France uniquement |
+| **Business types** | âœ… Non-profit, âœ… Company |
+| **Individual accounts** | âŒ DÃ©sactivÃ© (associations uniquement) |
+
+#### 11.7.2 Information Collection
+
+| Information | Requis | Description |
+|-------------|--------|-------------|
+| **External account** | âœ… Oui | IBAN pour les virements |
+| **Statement descriptor** | âœ… Oui | Nom affichÃ© sur relevÃ©s bancaires donateurs |
+| **Support info** | âœ… Oui | Email/tÃ©lÃ©phone support association |
+
+#### 11.7.3 Express Dashboard Features
+
+| Feature | Activer | Description |
+|---------|---------|-------------|
+| **View transactions** | âœ… | Voir les paiements reÃ§us |
+| **View payouts** | âœ… | Voir les virements |
+| **Manage payout schedule** | âš ï¸ Optionnel | Laisser associations changer frÃ©quence |
+| **Issue refunds** | âŒ Non | DONACTION gÃ¨re les remboursements |
+| **View disputes** | âœ… | Voir les litiges |
+
+### 11.8 Tarification Stripe Connect
+
+#### 11.8.1 Frais de Traitement des Paiements (France)
+
+| Type de carte | Frais Stripe | Notes |
+|---------------|--------------|-------|
+| **Cartes europÃ©ennes** | 1.5% + 0.25â‚¬ | Visa, Mastercard, CB domestiques |
+| **Cartes UK post-Brexit** | 2.5% + 0.25â‚¬ | Cartes Ã©mises au Royaume-Uni |
+| **Cartes internationales** | 2.9% + 0.25â‚¬ | Hors Europe |
+| **Cartes Bancaires (CB)** | 1.5% + 0.25â‚¬ | RÃ©seau franÃ§ais, nÃ©cessite SIREN |
+
+#### 11.8.2 Frais Connect SpÃ©cifiques
+
+| Service | Tarif | Description |
+|---------|-------|-------------|
+| **Compte Express actif** | 2â‚¬/mois/compte* | Comptes ayant reÃ§u â‰¥1 payout dans le mois |
+| **Virements (payouts)** | 0.25â‚¬/virement | Virement vers compte bancaire |
+| **Virements intra-zone euro** | 0â‚¬ cross-border | Pas de frais supplÃ©mentaires |
+| **Instant Payouts** | 1% (min 0.50â‚¬) | Virements instantanÃ©s (optionnel) |
+
+*Note : Le tarif exact des comptes Express peut varier. VÃ©rifier sur [stripe.com/connect/pricing](https://stripe.com/connect/pricing).
+
+#### 11.8.3 Frais de Litiges (Disputes)
+
+| Ã‰vÃ©nement | Frais | Remboursable ? |
+|-----------|-------|----------------|
+| **Litige ouvert (chargeback)** | 15â‚¬ | Non (sauf Mexique) |
+| **Litige contestÃ©** | +15â‚¬ additionnel | Non |
+| **CB (Cartes Bancaires)** | 0â‚¬ | Zone SEPA exemptÃ©e |
+
+#### 11.8.4 SynthÃ¨se des Frais pour un Don Type
+
+**Exemple : Don de 100â‚¬ (carte europÃ©enne)**
+
+```
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚  ðŸ’³ DÃ‰COMPOSITION FRAIS - DON 100â‚¬                                    â”‚
+â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
+â”‚                                                                       â”‚
+â”‚  Montant intentionnel du don :            100.00 â‚¬                    â”‚
+â”‚                                                                       â”‚
+â”‚  â”€â”€â”€ Si "Donor Pays Fee" = true â”€â”€â”€                                   â”‚
+â”‚                                                                       â”‚
+â”‚  + Frais Stripe (1.5% + 0.25â‚¬) :          +  1.75 â‚¬                   â”‚
+â”‚  + Commission DONACTION (4%) :            +  4.00 â‚¬                   â”‚
+â”‚  â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•â•                  â”‚
+â”‚  Total dÃ©bitÃ© au donateur :               105.75 â‚¬                    â”‚
+â”‚                                                                       â”‚
+â”‚  â†’ Association reÃ§oit :                   100.00 â‚¬ âœ…                 â”‚
+â”‚  â†’ DONACTION reÃ§oit :                       4.00 â‚¬ (application_fee)  â”‚
+â”‚  â†’ Stripe prÃ©lÃ¨ve :                         1.75 â‚¬ (sur plateforme)   â”‚
+â”‚                                                                       â”‚
+â”‚  â”€â”€â”€ Si "Donor Pays Fee" = false â”€â”€â”€                                  â”‚
+â”‚                                                                       â”‚
+â”‚  Total dÃ©bitÃ© au donateur :               100.00 â‚¬                    â”‚
+â”‚                                                                       â”‚
+â”‚  â†’ Association reÃ§oit :                    94.25 â‚¬ (100 - 5.75)       â”‚
+â”‚  â†’ DONACTION reÃ§oit :                       4.00 â‚¬                    â”‚
+â”‚  â†’ Stripe prÃ©lÃ¨ve :                         1.75 â‚¬                    â”‚
+â”‚                                                                       â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+```
+
+#### 11.8.5 Estimation Mensuelle des CoÃ»ts
+
+| Volume mensuel | Frais Stripe (~1.8%) | Comptes actifs | Total estimÃ© |
+|----------------|---------------------|----------------|--------------|
+| 10 000â‚¬ (50 dons) | ~180â‚¬ | ~5 Ã— 2â‚¬ = 10â‚¬ | ~190â‚¬ |
+| 50 000â‚¬ (250 dons) | ~900â‚¬ | ~25 Ã— 2â‚¬ = 50â‚¬ | ~950â‚¬ |
+| 100 000â‚¬ (500 dons) | ~1 800â‚¬ | ~50 Ã— 2â‚¬ = 100â‚¬ | ~1 900â‚¬ |
+
+> **Important :** Dans le modÃ¨le "Donor Pays Fee", ces frais Stripe sont inclus dans le montant payÃ© par le donateur. DONACTION ne supporte que les frais des comptes Express actifs.
+
+### 11.9 Gestion des Disputes (Chargebacks)
+
+#### 11.9.1 ResponsabilitÃ©s avec Destination Charges
+
+Avec les **destination charges** utilisÃ©es par DONACTION :
+
+```
+â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
+â”‚  âš–ï¸ RESPONSABILITÃ‰ DES LITIGES - DESTINATION CHARGES                  â”‚
+â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
+â”‚                                                                        â”‚
+â”‚  La charge est crÃ©Ã©e sur le compte PLATEFORME (DONACTION)              â”‚
+â”‚  puis transfÃ©rÃ©e vers le compte ASSOCIATION (connected account)        â”‚
+â”‚                                                                        â”‚
+â”‚  En cas de litige :                                                    â”‚
+â”‚                                                                        â”‚
+â”‚  1ï¸âƒ£ Stripe dÃ©bite le montant du compte PLATEFORME                     â”‚
+â”‚  2ï¸âƒ£ DONACTION doit reverser le transfer vers l'association            â”‚
+â”‚  3ï¸âƒ£ DONACTION est responsable des soldes nÃ©gatifs                     â”‚
+â”‚                                                                        â”‚
+â”‚  âš ï¸ DONACTION EST ULTIMEMENT RESPONSABLE                               â”‚
+â”‚     (mÃªme si l'association a un solde positif)                         â”‚
+â”‚                                                                        â”‚
+â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+```
+
+#### 11.9.2 Cycle de Vie d'un Litige
+
+```mermaid
+stateDiagram-v2
+    [*] --> EarlyFraudWarning: Signal fraude potentielle
+    EarlyFraudWarning --> Inquiry: Escalade optionnelle
+    EarlyFraudWarning --> [*]: Pas d'action requise
+    
+    [*] --> Inquiry: Demande d'info (AmEx/Discover)
+    Inquiry --> DisputeCreated: Escalade en chargeback
+    Inquiry --> [*]: RÃ©solu sans chargeback
+    
+    [*] --> DisputeCreated: Chargeback initiÃ©
+    
+    DisputeCreated --> NeedsResponse: En attente preuves
+    NeedsResponse --> UnderReview: Preuves soumises
+    NeedsResponse --> Lost: DÃ©lai expirÃ© (auto-perdu)
+    
+    UnderReview --> Won: Banque favorable
+    UnderReview --> Lost: Banque dÃ©favorable
+    
+    Won --> [*]: Fonds restituÃ©s
+    Lost --> [*]: Fonds perdus dÃ©finitivement
+```
+
+#### 11.9.3 DÃ©lais de RÃ©ponse
+
+| Phase | DÃ©lai | Action requise |
+|-------|-------|----------------|
+| **Early Fraud Warning** | N/A | Optionnel : rembourser prÃ©ventivement |
+| **Inquiry** | 7-14 jours | Fournir informations demandÃ©es |
+| **Dispute (chargeback)** | **7-21 jours** | Soumettre preuves via Dashboard/API |
+| **Arbitration** | 10-45 jours | Dernier recours (frais supplÃ©mentaires) |
+
+> **Critique :** Les litiges non contestÃ©s dans les dÃ©lais sont **automatiquement perdus**.
+
+#### 11.9.4 Flux de Gestion des Litiges
+
+```mermaid
+sequenceDiagram
+    participant Donateur
+    participant Banque as Banque Ã‰mettrice
+    participant Stripe
+    participant DONACTION
+    participant Association
+
+    Donateur->>Banque: Conteste le paiement
+    Banque->>Stripe: Initie chargeback
+    
+    Stripe->>DONACTION: Webhook: charge.dispute.created
+    Note right of Stripe: Fonds bloquÃ©s sur<br/>compte DONACTION
+    
+    Stripe->>DONACTION: Notification email
+    
+    DONACTION->>DONACTION: Ã‰value le litige
+    
+    alt Litige lÃ©gitime (erreur/fraude avÃ©rÃ©e)
+        DONACTION->>Stripe: Accepte le litige
+        Stripe->>Banque: Fonds restituÃ©s au donateur
+        DONACTION->>Association: Reverse le transfer
+        Note over DONACTION,Association: Association doit<br/>rembourser DONACTION
+    else Litige contestable
+        DONACTION->>Association: Demande preuves<br/>(reÃ§u, confirmation, etc.)
+        Association->>DONACTION: Fournit documents
+        DONACTION->>Stripe: Soumet preuves via API
+        Stripe->>Banque: Transmet dossier
+        
+        alt Litige gagnÃ©
+            Banque->>Stripe: DÃ©cision favorable
+            Stripe->>DONACTION: Webhook: charge.dispute.closed (won)
+            Note right of DONACTION: Fonds dÃ©bloquÃ©s
+        else Litige perdu
+            Banque->>Stripe: DÃ©cision dÃ©favorable
+            Stripe->>DONACTION: Webhook: charge.dispute.closed (lost)
+            DONACTION->>Association: Reverse le transfer
+            Note over DONACTION,Association: Perte financiÃ¨re<br/>pour l'association
+        end
+    end
+```
+
+#### 11.9.5 Preuves Ã  Collecter pour Contester
+
+Pour les **dons**, les preuves suivantes sont pertinentes :
+
+| Preuve | Description | Poids |
+|--------|-------------|-------|
+| **Confirmation email** | Email envoyÃ© au donateur aprÃ¨s le don | â­â­â­ |
+| **ReÃ§u fiscal PDF** | Preuve de la transaction et du destinataire | â­â­â­ |
+| **Attestation de don** | Document signÃ© si don en personne | â­â­ |
+| **IP address** | Adresse IP lors du paiement | â­â­ |
+| **AVS/CVC check** | RÃ©sultat des vÃ©rifications carte | â­â­ |
+| **3D Secure** | Authentification forte (SCA) | â­â­â­ |
+| **Logs d'activitÃ©** | Historique des actions du donateur | â­ |
+| **Correspondance** | Ã‰changes avec le donateur | â­â­ |
+
+> **Avantage dons :** Les transactions avec 3D Secure (obligatoire en France via SCA/PSD2) bÃ©nÃ©ficient d'un **liability shift** : la responsabilitÃ© fraude passe Ã  la banque Ã©mettrice.
+
+#### 11.9.6 ImplÃ©mentation Backend
+
+**Webhook Handler pour les Disputes :**
+
+```typescript
+// api/stripe-connect/controllers/webhook.ts
+
+async handleDisputeEvent(event: Stripe.Event) {
+    const dispute = event.data.object as Stripe.Dispute;
+    const paymentIntentId = dispute.payment_intent as string;
+    
+    // RÃ©cupÃ©rer le don associÃ©
+    const klubDonPayment = await strapi.db
+        .query('api::klub-don-payment.klub-don-payment')
+        .findOne({
+            where: { intent_id: paymentIntentId },
+            populate: { klub_don: { populate: ['klubr', 'klubDonateur'] } }
+        });
+    
+    if (!klubDonPayment) {
+        console.error(`âŒ Dispute: PaymentIntent ${paymentIntentId} non trouvÃ©`);
+        return;
+    }
+    
+    const klubDon = klubDonPayment.klub_don;
+    
+    switch (event.type) {
+        case 'charge.dispute.created':
+            console.log(`âš ï¸ LITIGE OUVERT - Don ${klubDon.uuid}`);
+            
+            // 1. Logger l'Ã©vÃ©nement
+            await logFinancialAction(
+                'dispute_created',
+                klubDon.klubr.id,
+                klubDon.id,
+                dispute.amount,
+                paymentIntentId,
+                {
+                    dispute_id: dispute.id,
+                    reason: dispute.reason,
+                    status: dispute.status
+                }
+            );
+            
+            // 2. Mettre Ã  jour le statut du don
+            await strapi.documents('api::klub-don.klub-don').update({
+                documentId: klubDon.documentId,
+                data: { 
+                    disputeStatus: 'open',
+                    disputeId: dispute.id,
+                    disputeReason: dispute.reason
+                }
+            });
+            
+            // 3. Notifier l'Ã©quipe DONACTION
+            await sendDisputeAlert({
+                type: 'dispute_opened',
+                don: klubDon,
+                dispute: dispute,
+                deadline: new Date(dispute.evidence_details.due_by * 1000)
+            });
+            
+            // 4. Notifier l'association
+            await sendDisputeNotificationToKlub({
+                klubr: klubDon.klubr,
+                don: klubDon,
+                dispute: dispute
+            });
+            break;
+            
+        case 'charge.dispute.updated':
+            console.log(`ðŸ“ LITIGE MIS Ã€ JOUR - ${dispute.status}`);
+            
+            await strapi.documents('api::klub-don.klub-don').update({
+                documentId: klubDon.documentId,
+                data: { disputeStatus: dispute.status }
+            });
+            break;
+            
+        case 'charge.dispute.closed':
+            const won = dispute.status === 'won';
+            console.log(`${won ? 'âœ…' : 'âŒ'} LITIGE FERMÃ‰ - ${dispute.status}`);
+            
+            await strapi.documents('api::klub-don.klub-don').update({
+                documentId: klubDon.documentId,
+                data: { 
+                    disputeStatus: dispute.status,
+                    disputeClosedAt: new Date()
+                }
+            });
+            
+            await logFinancialAction(
+                won ? 'dispute_won' : 'dispute_lost',
+                klubDon.klubr.id,
+                klubDon.id,
+                dispute.amount,
+                paymentIntentId,
+                { dispute_id: dispute.id }
+            );
+            
+            if (!won) {
+                // Reverser le transfer vers l'association
+                await reverseTransferForDispute(klubDon, dispute);
+            }
+            break;
+    }
+}
+```
+
+**Service de Reverse Transfer :**
+
+```typescript
+// helpers/stripe-connect-helper.ts
+
+export async function reverseTransferForDispute(
+    klubDon: KlubDonEntity,
+    dispute: Stripe.Dispute
+): Promise<void> {
+    // RÃ©cupÃ©rer le transfer original
+    const paymentIntent = await stripe.paymentIntents.retrieve(
+        dispute.payment_intent as string,
+        { expand: ['latest_charge.transfer'] }
+    );
+    
+    const transfer = (paymentIntent.latest_charge as Stripe.Charge)?.transfer;
+    
+    if (!transfer) {
+        console.error(`âŒ Pas de transfer trouvÃ© pour le dispute ${dispute.id}`);
+        return;
+    }
+    
+    try {
+        // Reverser le transfer
+        const reversal = await stripe.transfers.createReversal(
+            typeof transfer === 'string' ? transfer : transfer.id,
+            {
+                amount: dispute.amount,
+                description: `Reversal suite au litige ${dispute.id}`
+            }
+        );
+        
+        console.log(`âœ… Transfer reversÃ©: ${reversal.id}`);
+        
+        // Logger l'action
+        await logFinancialAction(
+            'transfer_reversed_dispute',
+            klubDon.klubr.id,
+            klubDon.id,
+            dispute.amount,
+            dispute.payment_intent as string,
+            { 
+                reversal_id: reversal.id,
+                dispute_id: dispute.id
+            }
+        );
+        
+    } catch (error) {
+        console.error(`âŒ Ã‰chec reversal transfer:`, error);
+        // Alerter l'Ã©quipe pour intervention manuelle
+        await sendDisputeAlert({
+            type: 'reversal_failed',
+            don: klubDon,
+            dispute: dispute,
+            error: error.message
+        });
+    }
+}
+```
+
+#### 11.9.7 Ã‰volutions SchÃ©ma pour les Disputes
+
+**Ajouts dans `klub-don/schema.json` :**
+
+```json
+{
+  "disputeStatus": {
+    "type": "enumeration",
+    "enum": ["none", "warning_received", "open", "under_review", "won", "lost"],
+    "default": "none"
+  },
+  "disputeId": {
+    "type": "string"
+  },
+  "disputeReason": {
+    "type": "string"
+  },
+  "disputeClosedAt": {
+    "type": "datetime"
+  }
+}
+```
+
+#### 11.9.8 PrÃ©vention des Litiges
+
+| Mesure | Description | EfficacitÃ© |
+|--------|-------------|------------|
+| **3D Secure (SCA)** | Authentification forte obligatoire en France | â­â­â­ |
+| **AVS/CVC checks** | VÃ©rification adresse + code de sÃ©curitÃ© | â­â­ |
+| **Email confirmation** | Envoi immÃ©diat aprÃ¨s le don | â­â­â­ |
+| **Statement descriptor clair** | `DONACTION - NomAssociation` | â­â­ |
+| **Radar for Fraud Teams** | RÃ¨gles ML anti-fraude Stripe | â­â­â­ |
+| **Blocklist** | Bloquer donateurs frauduleux rÃ©cidivistes | â­â­ |
+
+> **Statistique :** Les plateformes de dons ont gÃ©nÃ©ralement un taux de dispute < 0.1% grÃ¢ce Ã  la nature volontaire des transactions.
+
+#### 11.9.9 Tableau de Bord Disputes (Admin)
+
+PrÃ©voir une section dans le dashboard admin pour :
+
+| FonctionnalitÃ© | PrioritÃ© |
+|----------------|----------|
+| Liste des litiges en cours | âœ… P1 |
+| Statut et deadline de chaque litige | âœ… P1 |
+| Bouton "Voir dans Stripe Dashboard" | âœ… P1 |
+| Historique des litiges fermÃ©s | âš ï¸ P2 |
+| Statistiques (taux de dispute, wins/losses) | âš ï¸ P2 |
+| Upload de preuves directement (embedded component) | âŒ P3 |
+
+### 11.10 Test en Mode Sandbox
+
+#### 11.10.1 CrÃ©er un Compte Test
+
+```bash
+# Via Stripe CLI
+stripe accounts create \
+  --type=express \
+  --country=FR \
+  --capabilities[card_payments][requested]=true \
+  --capabilities[transfers][requested]=true \
+  --business_type=non_profit
+```
+
+#### 11.10.2 Simuler l'Onboarding
+
+```bash
+# GÃ©nÃ©rer lien d'onboarding
+stripe account_links create \
+  --account=acct_xxx \
+  --refresh_url="https://re7.donaction.fr/onboarding/refresh" \
+  --return_url="https://re7.donaction.fr/onboarding/complete" \
+  --type=account_onboarding
+```
+
+#### 11.10.3 Tester les Webhooks Localement
+
+```bash
+# Ã‰couter les webhooks en local
+stripe listen --forward-to localhost:1437/api/klub-don-payments/stripe-web-hooks
+
+# Pour les Ã©vÃ©nements Connect
+stripe listen --forward-connect-to localhost:1437/api/stripe-connect/webhook
+
+# DÃ©clencher un Ã©vÃ©nement test
+stripe trigger payment_intent.succeeded
+stripe trigger charge.dispute.created
+```
+
+#### 11.10.4 Cartes de Test
+
+| NumÃ©ro | RÃ©sultat |
+|--------|----------|
+| `4242 4242 4242 4242` | Paiement rÃ©ussi |
+| `4000 0000 0000 0002` | Carte refusÃ©e |
+| `4000 0025 0000 3155` | Requiert 3D Secure |
+| `4000 0000 0000 9995` | Fonds insuffisants |
+| `4000 0000 0000 0259` | **GÃ©nÃ¨re un dispute** |
+
+### 11.11 Checklist de Configuration
+
+```
+â–¡ Platform Profile complÃ©tÃ©
+â–¡ Account type = Express
+â–¡ Capabilities configurÃ©es (card_payments, transfers)
+â–¡ Branding configurÃ© (logo, couleurs, nom)
+â–¡ Webhook Account crÃ©Ã© + secret rÃ©cupÃ©rÃ©
+â–¡ Webhook Connect crÃ©Ã© + secret rÃ©cupÃ©rÃ© (incluant dispute events)
+â–¡ ClÃ©s API Live rÃ©cupÃ©rÃ©es
+â–¡ Variables d'environnement configurÃ©es
+â–¡ Test crÃ©ation compte Express en mode test
+â–¡ Test paiement avec destination charge en mode test
+â–¡ Test rÃ©ception webhooks en mode test
+â–¡ Test simulation dispute en mode test
+â–¡ Handler dispute implÃ©mentÃ©
+â–¡ Alertes dispute configurÃ©es
+```
+
+### 11.12 Ressources et Liens Utiles
+
+| Ressource | URL |
+|-----------|-----|
+| Dashboard Stripe | https://dashboard.stripe.com |
+| Connect Settings | https://dashboard.stripe.com/settings/connect |
+| Webhooks | https://dashboard.stripe.com/webhooks |
+| API Keys | https://dashboard.stripe.com/apikeys |
+| Documentation Connect | https://docs.stripe.com/connect |
+| Express Accounts | https://docs.stripe.com/connect/express-accounts |
+| Destination Charges | https://docs.stripe.com/connect/destination-charges |
+| Disputes Connect | https://docs.stripe.com/connect/disputes |
+| Tarification Connect | https://stripe.com/connect/pricing |
+| Stripe CLI | https://docs.stripe.com/stripe-cli |
+
+---
+
+> **Document gÃ©nÃ©rÃ© le :** 2025-01-10  
+> **Auteur :** Claude (Anthropic) - Architecte Solution  
+> **Statut :** PrÃªt pour revue et implÃ©mentation

--- a/donaction-api/src/api/klub-don/content-types/klub-don/schema.json
+++ b/donaction-api/src/api/klub-don/content-types/klub-don/schema.json
@@ -130,6 +130,11 @@
       "relation": "oneToOne",
       "target": "api::klub-don.klub-don",
       "mappedBy": "klub_don_contribution"
+    },
+    "donorPaysFee": {
+      "type": "boolean",
+      "default": false,
+      "required": false
     }
   }
 }

--- a/donaction-api/src/api/klubr-subscription/controllers/klubr-subscription.ts
+++ b/donaction-api/src/api/klubr-subscription/controllers/klubr-subscription.ts
@@ -232,7 +232,14 @@ export default factories.createCoreController(
                     logo: true,
                     klubr_house: true,
                     trade_policy: {
-                        fields: ['allowKlubrContribution'],
+                        fields: [
+                            'allowKlubrContribution',
+                            'stripe_connect',
+                            'allow_donor_fee_choice',
+                            'donor_pays_fee_project',
+                            'donor_pays_fee_club',
+                            'commissionPercentage',
+                        ],
                     },
                 },
             };

--- a/donaction-saas/README.md
+++ b/donaction-saas/README.md
@@ -11,6 +11,51 @@ This documentation provides an overview of the Sponsorship Form web-component, d
 4. [Validation](#validation)
 5. [API Integration](#api-integration)
 6. [Customization and Usage](#customization-and-usage)
+7. [Development Setup](#development-setup)
+
+---
+
+## Development Setup
+
+### Prerequisites
+- API running on `localhost:1437`
+- Node.js installed
+
+### Scripts
+| Command | Description |
+|---------|-------------|
+| `npm run dev:build` | One-time build to `public/` |
+| `npm run dev:watch` | Build + watch for changes |
+| `npm run dev:serve` | Vite server on port 3100 |
+
+### Workflow (2 terminals)
+```bash
+# Terminal 1 - Watch for changes
+npm run dev:watch
+
+# Terminal 2 - Serve application
+npm run dev:serve
+```
+
+### Daily Token Update
+The `apiToken` in `index.html` (line 7) expires daily. Generate a new one:
+
+**Endpoint:** `POST http://localhost:1437/api/klubr-subscriptions`
+
+**Payload:**
+```json
+{
+    "data": {
+        "web_component": "KlubrSponsorshipForm",
+        "host": "http://localhost:3100"
+    }
+}
+```
+
+Copy the token from response and update `index.html` line 7.
+
+### klubrUuid Configuration
+The `klubrUuid` attribute in `index.html` (line 11) must be a valid UUID from your local donaction database.
 
 ---
 https://drive.google.com/file/d/1pa-5abK5j3SZqg90r81atc5m3Am2WEZV/view?usp=drive_link

--- a/donaction-saas/index.html
+++ b/donaction-saas/index.html
@@ -4,11 +4,11 @@
     <meta charset="UTF-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <title>Klubr Web Components</title>
-    <script src="/KlubrSponsorshipForm.es.js?apiToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1dWlkIjoiZWE5NWY4YzgtZDk1OC00NGY4LWIzYmMtMWRkY2NiYjE5MmVkIiwiaG9zdCI6Imh0dHA6Ly9sb2NhbGhvc3Q6NTE3MyIsIndlYl9jb21wb25lbnQiOiJLbHViclNwb25zb3JzaGlwRm9ybSIsImlhdCI6MTczODg0MjAyNSwiZXhwIjoxNzM4OTI4NDI1fQ.FiQJOBd9QIKsGHTXIEuQ-JAFhkC_C0s20uD-BDKeIMw" type="module"></script>
+    <script src="/KlubrSponsorshipForm.es.js?apiToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1dWlkIjoiMzk3N2I0NzktOTRhNy00MjUzLWI5NTQtNGI5MTZlN2ExZjRiIiwiaG9zdCI6Imh0dHA6Ly9sb2NhbGhvc3Q6MzEwMCIsIndlYl9jb21wb25lbnQiOiJLbHViclNwb25zb3JzaGlwRm9ybSIsImlhdCI6MTc2ODM5OTg3NiwiZXhwIjoxNzY4NDg2Mjc2fQ.BsPGW1bfe1gqRtTUAQRUniUw_0qVcm8uozZRC9GsfWE" type="module"></script>
 </head>
 <body style="margin: unset;">
 <div style="margin: auto; width: 100%; height: 200vh;">
-    <klubr-sponsorship-form klubrUuid="c179dc75-5b1a-4a84-a541-a4e18fe245d2">
+    <klubr-sponsorship-form klubrUuid="5e4704b3-9ff8-4389-9716-09757f80910f">
 <!--        projectUuid="610140ce-fe08-47f1-88d0-42b72c4208c0"-->
         <div slot="stripe-payment-form"></div>
     </klubr-sponsorship-form>

--- a/donaction-saas/package.json
+++ b/donaction-saas/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
+    "dev:build": "vite build --config vite.config.development.ts",
+    "dev:watch": "vite build --config vite.config.development.ts --watch",
+    "dev:serve": "vite --port 3100",
     "test": "vitest",
     "build": "BUILD_MODE=INDIVIDUAL vite build"
   },

--- a/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/index.scss
+++ b/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/index.scss
@@ -29,6 +29,107 @@
     }
   }
 
+  .feeChoiceSection {
+    margin: 1.5rem 0;
+    padding: 1rem;
+    background: #f8f9fa;
+    border-radius: 8px;
+
+    @media screen and (max-width: 768px) {
+      padding: 0.75rem;
+    }
+  }
+
+  .feeChoiceTitle {
+    font-weight: 600;
+    margin-bottom: 1rem;
+    text-align: center;
+    font-size: 15px;
+  }
+
+  .feeOption {
+    display: flex;
+    align-items: flex-start;
+    padding: 1rem;
+    margin: 0.5rem 0;
+    border: 2px solid #e0e0e0;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: border-color 0.2s, background-color 0.2s;
+
+    &:hover {
+      border-color: #aaa;
+    }
+
+    &.selected {
+      border-color: var(--primary-color, #007bff);
+      background: rgba(0, 123, 255, 0.05);
+    }
+
+    input[type="radio"] {
+      margin-right: 0.75rem;
+      margin-top: 4px;
+      flex-shrink: 0;
+    }
+  }
+
+  .optionContent {
+    flex: 1;
+
+    strong {
+      display: block;
+      margin-bottom: 0.25rem;
+      font-size: 14px;
+    }
+  }
+
+  .optionDescription {
+    font-size: 13px;
+    color: #666;
+    margin: 0.25rem 0;
+  }
+
+  .feeDetail {
+    font-size: 12px;
+    color: #888;
+    margin: 0.25rem 0;
+  }
+
+  .optionSummary {
+    margin-top: 0.5rem;
+    padding: 0.5rem;
+    background: white;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+
+    .summaryDot {
+      margin: 0 0.5rem;
+      color: #ccc;
+    }
+
+    @media screen and (max-width: 768px) {
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+
+      .summaryDot {
+        display: none;
+      }
+    }
+  }
+
+  .feeInfoTrigger {
+    margin-top: 0.75rem;
+    cursor: pointer;
+
+    small {
+      font-size: 12px;
+      color: #666;
+      text-decoration: underline;
+    }
+  }
+
   .disclaimer {
     font-size: 14px;
 

--- a/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/step3.svelte
+++ b/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/step3.svelte
@@ -104,7 +104,7 @@
       </div>
       <div class="flex justify-between items-center gap-1">
         <p>Don à {SUBSCRIPTION.klubr?.denomination}</p>
-        <p class="font-bold">{DEFAULT_VALUES.montant} €</p>
+        <p class="font-bold">{formatCurrency(DEFAULT_VALUES.montant)}</p>
       </div>
       {#if SUBSCRIPTION.allowKlubrContribution}
         <div class="separator w-full" style="background: #C1BFBF;" />
@@ -119,7 +119,7 @@
               style="text-decoration: underline; cursor: pointer;">Modifier le soutien</a
             >
           </div>
-          <p class="font-bold">{DEFAULT_VALUES.contributionAKlubr} €</p>
+          <p class="font-bold">{formatCurrency(DEFAULT_VALUES.contributionAKlubr)}</p>
         </div>
       {/if}
       {#if isStripeConnect && DEFAULT_VALUES.donorPaysFee}

--- a/donaction-saas/src/components/sponsorshipForm/logic/submit.ts
+++ b/donaction-saas/src/components/sponsorshipForm/logic/submit.ts
@@ -59,6 +59,7 @@ async function createDonation(temp) {
         withTaxReduction: Boolean(temp.withTaxReduction),
         statusPaiment: 'notDone',
         contributionAKlubr: Number(temp.contributionAKlubr.toString()),
+        donorPaysFee: Boolean(temp.donorPaysFee),
         datePaiment: undefined,
         klubr: FORM_CONFIG.clubUuid,
         klubDonateur: undefined,

--- a/donaction-saas/src/components/sponsorshipForm/logic/useSponsorshipForm.svelte.ts
+++ b/donaction-saas/src/components/sponsorshipForm/logic/useSponsorshipForm.svelte.ts
@@ -51,6 +51,7 @@ const defVals = {
   withTaxReduction: true,
   montant: NaN,
   contributionAKlubr: NaN,
+  donorPaysFee: false,
   socialReason: '',
   siren: '',
   legalForm: '',

--- a/donaction-saas/src/components/sponsorshipForm/logic/utils.ts
+++ b/donaction-saas/src/components/sponsorshipForm/logic/utils.ts
@@ -1,4 +1,10 @@
-export function calculateTaxReduction(amount: number, isOrganization: boolean) {
+/**
+ * Calculate the cost after tax reduction for a donation
+ * @param amount - Donation amount in euros
+ * @param isOrganization - Whether the donor is an organization (60% reduction) or individual (66% reduction)
+ * @returns Formatted string of the cost after tax reduction
+ */
+export function calculateTaxReduction(amount: number, isOrganization: boolean): string {
   const TAUX_DEDUCTION_FISCALE_PART = 0.66;
   const TAUX_DEDUCTION_FISCALE_PRO = 0.6;
 
@@ -11,11 +17,22 @@ export function calculateTaxReduction(amount: number, isOrganization: boolean) {
     .replace(/\.00$/, '');
 }
 
+/**
+ * Calculate processing fees for a donation (platform commission only)
+ * @param montant - Donation amount in euros
+ * @param commissionPercentage - Platform commission percentage (e.g., 4 for 4%)
+ * @returns Fee amount in euros, rounded to 2 decimal places
+ */
 export function calculateFeeAmount(montant: number, commissionPercentage: number): number {
   if (isNaN(montant) || montant <= 0) return 0;
   return Math.round(montant * (commissionPercentage / 100) * 100) / 100;
 }
 
+/**
+ * Format a number as currency in euros
+ * @param amount - Amount to format
+ * @returns Formatted string with € symbol (e.g., "100 €" or "99.50 €")
+ */
 export function formatCurrency(amount: number): string {
   if (isNaN(amount)) return '0 €';
   return amount.toFixed(2).replace(/\.00$/, '') + ' €';

--- a/donaction-saas/src/components/sponsorshipForm/logic/utils.ts
+++ b/donaction-saas/src/components/sponsorshipForm/logic/utils.ts
@@ -10,3 +10,13 @@ export function calculateTaxReduction(amount: number, isOrganization: boolean) {
     .toFixed(2)
     .replace(/\.00$/, '');
 }
+
+export function calculateFeeAmount(montant: number, commissionPercentage: number): number {
+  if (isNaN(montant) || montant <= 0) return 0;
+  return Math.round(montant * (commissionPercentage / 100) * 100) / 100;
+}
+
+export function formatCurrency(amount: number): string {
+  if (isNaN(amount)) return '0 €';
+  return amount.toFixed(2).replace(/\.00$/, '') + ' €';
+}

--- a/donaction-saas/src/utils/tooltip/index.scss
+++ b/donaction-saas/src/utils/tooltip/index.scss
@@ -28,11 +28,21 @@
       right: unset;
     }
 
+    &.left {
+      left: 0;
+      right: unset;
+      transform: none;
+    }
+
     @media screen and (max-width: 768px) {
       max-width: 80dvw;
       &.md-left-14 {
         left: 50%;
         right: 50%;
+      }
+      &.left {
+        left: 0;
+        transform: none;
       }
     }
 


### PR DESCRIPTION
## Summary

- Add radio button component at step 3 allowing donors to choose whether they pay processing fees on top of their donation or have them deducted
- Feature gated by `stripe_connect` and `allow_donor_fee_choice` flags in trade_policy
- Default values based on donation type (project vs club)

## Changes

### Backend (Strapi API)
- Add `donorPaysFee` boolean field to `klub-don` schema
- Populate new trade_policy fields in `decrypt` endpoint

### SaaS Widget (Svelte)
- Add `donorPaysFee` to form state
- Add fee calculation utilities (`calculateFeeAmount`, `formatCurrency`)
- Add radio button section in step3 with fee breakdown
- Update payment intent calculation in step4
- Add left-aligned tooltip for fee info

## Test plan

- [ ] Verify radio buttons appear when `stripe_connect=true` and `allow_donor_fee_choice=true`
- [ ] Verify default selection based on donation type (project vs club)
- [ ] Verify fee line appears in recap when "Je paie les frais" is selected
- [ ] Verify total amount updates correctly
- [ ] Verify payment intent includes fee when `donorPaysFee=true`
- [ ] Verify legacy mode: no radio when `stripe_connect=false`

Closes #53