### PR TITLE
feat(saas): add detailed fee breakdown in step 3 recap

### DIFF
--- a/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/index.scss
+++ b/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/index.scss
@@ -27,6 +27,51 @@
       height: 1px;
       background: #000;
     }
+
+    .sub-line {
+      font-size: 13px;
+      color: #666;
+      padding-left: 0.5rem;
+
+      p {
+        font-size: 13px;
+      }
+    }
+  }
+
+  .association-message {
+    margin: 1rem 0;
+    padding: 0.75rem 1rem;
+    border-radius: 6px;
+    background: #f0f4f8;
+    font-size: 14px;
+    text-align: center;
+    width: 100%;
+
+    &.success {
+      background: #e8f5e9;
+      color: #2e7d32;
+    }
+
+    .icon {
+      margin-right: 0.5rem;
+    }
+
+    .tooltip-link {
+      text-decoration: underline;
+      cursor: pointer;
+      color: #1976d2;
+    }
+  }
+
+  .receipt-preview {
+    margin: 0.5rem 0;
+    padding: 0.75rem 1rem;
+    background: #fff3e0;
+    border-radius: 6px;
+    font-size: 14px;
+    text-align: center;
+    width: 100%;
   }
 
   .feeChoiceSection {

--- a/donaction-saas/src/components/sponsorshipForm/logic/fee-calculation-helper.ts
+++ b/donaction-saas/src/components/sponsorshipForm/logic/fee-calculation-helper.ts
@@ -1,0 +1,141 @@
+/**
+ * Fee Calculation Helper for Stripe Connect
+ * Implements US-PAY-002 specification for fee model calculations
+ */
+
+/** Stripe fees for European cards (France) */
+export const STRIPE_FEES = {
+  PERCENTAGE: 0.015, // 1.5% for European cards
+  FIXED: 0.25 // 0.25€ per transaction
+} as const;
+
+export interface FeeCalculationInput {
+  montantDon: number; // In euros
+  contribution: number; // In euros (voluntary DONACTION contribution)
+  donorPaysFee: boolean;
+  commissionPercentage: number; // As decimal (0.04 = 4%)
+}
+
+export interface FeeCalculationOutput {
+  totalDonateur: number; // What donor pays
+  netAssociation: number; // What association receives
+  applicationFee: number; // application_fee_amount for Stripe
+  commissionDonaction: number; // Platform commission (4%)
+  fraisStripeEstimes: number; // Estimated Stripe fees
+  montantRecuFiscal: number; // Tax receipt amount
+}
+
+/**
+ * Calculate fees for Stripe Connect donations
+ *
+ * Scenario A (donorPaysFee=true): Donor pays commission + Stripe fees on top
+ * Scenario B (donorPaysFee=false): Fees deducted from donation, association receives less
+ *
+ * @param input - Fee calculation input parameters
+ * @returns Full fee breakdown
+ */
+export function calculateFees(input: FeeCalculationInput): FeeCalculationOutput {
+  const { montantDon, contribution, donorPaysFee, commissionPercentage } = input;
+
+  // Handle invalid inputs
+  if (isNaN(montantDon) || montantDon <= 0) {
+    return {
+      totalDonateur: contribution || 0,
+      netAssociation: 0,
+      applicationFee: 0,
+      commissionDonaction: 0,
+      fraisStripeEstimes: 0,
+      montantRecuFiscal: 0
+    };
+  }
+
+  // Calculate DONACTION commission
+  const commissionDonaction = roundToCents(montantDon * commissionPercentage);
+
+  if (donorPaysFee) {
+    return calculateScenarioA(montantDon, contribution, commissionDonaction);
+  } else {
+    return calculateScenarioB(montantDon, contribution, commissionDonaction);
+  }
+}
+
+/**
+ * Scenario A: Donor pays fees on top of donation
+ * - Association receives 100% of donation amount
+ * - Donor pays: donation + commission + Stripe fees + contribution
+ */
+function calculateScenarioA(
+  montantDon: number,
+  contribution: number,
+  commissionDonaction: number
+): FeeCalculationOutput {
+  // Subtotal before Stripe fees
+  const subtotal = montantDon + commissionDonaction + contribution;
+
+  // Stripe fees on total charged amount
+  const fraisStripeEstimes = calculateStripeFees(montantDon);
+
+  // Total donor pays
+  const totalDonateur = roundToCents(subtotal + fraisStripeEstimes);
+
+  // Application fee includes commission + Stripe fees
+  const applicationFee = roundToCents(commissionDonaction + fraisStripeEstimes);
+
+  return {
+    totalDonateur,
+    netAssociation: montantDon, // Association receives 100%
+    applicationFee, 
+    commissionDonaction,
+    fraisStripeEstimes,
+    montantRecuFiscal: montantDon // Tax receipt = full donation amount
+  };
+}
+
+/**
+ * Scenario B: Fees deducted from donation
+ * - Donor pays only: donation + contribution
+ * - Association receives: donation - (commission + Stripe fees)
+ *
+ * CRITICAL: application_fee includes Stripe fees to maintain 4% net commission for DONACTION
+ */
+function calculateScenarioB(
+  montantDon: number,
+  contribution: number,
+  commissionDonaction: number
+): FeeCalculationOutput {
+  // Total charged to donor (no visible fees)
+  const totalDonateur = roundToCents(montantDon + contribution);
+
+  // Stripe fees calculated on total charged
+  const fraisStripeEstimes = calculateStripeFees(montantDon);
+
+  // Application fee INCLUDES Stripe fees to ensure DONACTION maintains 4% net
+  const applicationFee = roundToCents(commissionDonaction + fraisStripeEstimes);
+
+  // Association receives donation minus application fee
+  const netAssociation = roundToCents(montantDon - applicationFee);
+
+  return {
+    totalDonateur,
+    netAssociation,
+    applicationFee,
+    commissionDonaction,
+    fraisStripeEstimes,
+    montantRecuFiscal: netAssociation // Tax receipt = actual amount received
+  };
+}
+
+/**
+ * Calculate Stripe fees for a given amount
+ * Formula: (amount × 1.5%) + 0.25€
+ */
+function calculateStripeFees(amount: number): number {
+  return roundToCents(amount * STRIPE_FEES.PERCENTAGE + STRIPE_FEES.FIXED);
+}
+
+/**
+ * Round to 2 decimal places (cents)
+ */
+function roundToCents(value: number): number {
+  return Math.round(value * 100) / 100;
+}


### PR DESCRIPTION
## Summary
- Implement detailed fee breakdown display in donation form step 3 (récapitulatif)
- Create `calculateFees()` helper with Stripe fee estimation
- Add association message showing net amount received
- Add tax receipt amount display

## Changes
- **NEW**: `fee-calculation-helper.ts` - Full fee calculation with Scenario A/B support
- **UPDATE**: `step3.svelte` - Enhanced recap with fee breakdown and association message
- **UPDATE**: `index.scss` - New styles for association message and receipt preview

## Test Scenarios
### Scenario A (donorPaysFee=true): Don 100€, Contribution 10€
- Commission: 4.00€
- Stripe fees: 1.75€
- **Total: 115.75€**
- Net association: 100.00€
- Tax receipt: 100.00€

### Scenario B (donorPaysFee=false): Don 100€, Contribution 10€
- **Total: 110.00€**
- Application fee: 5.75€
- Net association: 94.25€
- Tax receipt: 94.25€

## Test plan
- [ ] Verify Scenario A displays commission + Stripe fees separately
- [ ] Verify Scenario B shows total without fees breakdown
- [ ] Verify association message updates dynamically on toggle
- [ ] Verify tooltip shows fee decomposition on hover
- [ ] Verify tax receipt amount matches expected values
- [ ] Test on mobile viewport

Closes #54