### PR TITLE
feat(saas): transmit donorPaysFee flag (#55)

### DIFF
--- a/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step4/step4.svelte
+++ b/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step4/step4.svelte
@@ -56,7 +56,9 @@
           : 0;
 
       const totalAmount = DEFAULT_VALUES.montant + (DEFAULT_VALUES.contributionAKlubr || 0) + feeAmount;
-      const response = await createPaymentIntent(totalAmount, idempotencyKey, false);
+      // Only send donorPaysFee for Stripe Connect mode (guard condition per US-FORM-003)
+      const donorPaysFeeParam = isStripeConnect ? DEFAULT_VALUES.donorPaysFee : undefined;
+      const response = await createPaymentIntent(totalAmount, idempotencyKey, donorPaysFeeParam);
 
       clientSecret = response.intent;
 


### PR DESCRIPTION
## Summary
- Pass `donorPaysFee` param to `create-payment-intent` API conditionally
- Stripe Connect mode: sends `DEFAULT_VALUES.donorPaysFee` (true/false)
- Legacy mode: omits parameter (sends `undefined`)

## Test plan
- [ ] Stripe Connect klubr: verify API receives `donorPaysFee: true` when donor selects fee option
- [ ] Stripe Connect klubr: verify API receives `donorPaysFee: false` when donor declines
- [ ] Legacy klubr: verify API body does NOT contain `donorPaysFee` property

Closes #55