### PR TITLE
feat(saas): extract TaxReductionSummary component (#56)

### DIFF
--- a/donaction-saas/e2e/pages/Step3Page.ts
+++ b/donaction-saas/e2e/pages/Step3Page.ts
@@ -32,6 +32,13 @@ export class Step3Page extends BasePage {
   // Recap fees line
   readonly recapFeesLine: Locator;
 
+  // Tax reduction summary component (TaxReductionSummary.svelte)
+  readonly taxReductionSummary: Locator;
+  readonly taxReceiptValue: Locator;
+  readonly taxSavingsValue: Locator;
+  readonly taxRealCostValue: Locator;
+  readonly taxContributionNote: Locator;
+
   constructor(page: Page) {
     super(page);
     this.recapAmount = this.shadow('[data-testid="recap-amount"]');
@@ -63,6 +70,13 @@ export class Step3Page extends BasePage {
 
     // Recap fees line
     this.recapFeesLine = this.shadow('[data-testid="recap-fees-line"]');
+
+    // Tax reduction summary component (TaxReductionSummary.svelte)
+    this.taxReductionSummary = this.shadow('[data-testid="tax-reduction-summary"]');
+    this.taxReceiptValue = this.shadow('[data-testid="tax-receipt-value"]');
+    this.taxSavingsValue = this.shadow('[data-testid="tax-savings-value"]');
+    this.taxRealCostValue = this.shadow('[data-testid="real-cost-value"]');
+    this.taxContributionNote = this.shadow('[data-testid="contribution-note"]');
   }
 
   /** Accept CGU + conditions to proceed */

--- a/donaction-saas/e2e/tests/step3/summary.spec.ts
+++ b/donaction-saas/e2e/tests/step3/summary.spec.ts
@@ -44,37 +44,55 @@ test.describe('Step 3 — Summary', () => {
 
     const step3 = new Step3Page(page);
     await expect(step3.recapAmount).toContainText('100');
-    // Tax section should not be visible
-    await expect(step3.shadow('.don-tax-section')).not.toBeVisible();
+    // Tax reduction summary should not be visible
+    await expect(step3.taxReductionSummary).not.toBeVisible();
   });
 
   test('7.2 — Should display 66% reduction for particulier', async ({ page }) => {
-    const step3 = await goToStep3(page, { amount: 100 });
+    const step1 = new Step1Page(page);
+    // Use Stripe Connect config to enable tax reduction summary
+    await step1.navigate({ klubrConfig: 'stripe-connect-choice-enabled' });
+    await step1.waitForStep(0);
+    await step1.selectAmount(100);
+    await step1.clickNext();
+    await step1.waitForStep(1);
+
+    const step2 = new Step2Page(page);
+    await step2.fillParticulier();
+    await step2.clickNext();
+    await step2.waitForStep(2);
+
+    const step3 = new Step3Page(page);
     await expect(step3.recapAmount).toContainText('100');
-    await expect(step3.shadow('.don-tax-section')).toBeVisible();
-    const taxLabels = step3.shadow('.don-tax-item__label');
-    const count = await taxLabels.count();
-    let found66 = false;
-    for (let i = 0; i < count; i++) {
-      const text = await taxLabels.nth(i).textContent();
-      if (text?.includes('66')) found66 = true;
-    }
-    expect(found66).toBeTruthy();
+    // Tax reduction summary component uses new data-testid
+    await expect(step3.taxReductionSummary).toBeVisible();
+    // Check for 66% rate in the tax reduction label
+    const reductionItem = step3.shadow('[data-testid="tax-reduction-item"]');
+    await expect(reductionItem).toContainText('66%');
   });
 
   test('7.3 — Should display 60% reduction for entreprise', async ({ page }) => {
-    const step3 = await goToStep3(page, { amount: 200, entreprise: true });
+    const step1 = new Step1Page(page);
+    // Use Stripe Connect config to enable tax reduction summary
+    await step1.navigate({ klubrConfig: 'stripe-connect-choice-enabled' });
+    await step1.waitForStep(0);
+    await step1.selectAmount(200);
+    await step1.selectEntreprise();
+    await step1.clickNext();
+    await step1.waitForStep(1);
+
+    const step2 = new Step2Page(page);
+    await step2.fillEntreprise();
+    await step2.clickNext();
+    await step2.waitForStep(2);
+
+    const step3 = new Step3Page(page);
     await expect(step3.recapAmount).toContainText('200');
-    await expect(step3.shadow('.don-tax-section')).toBeVisible();
+    // Tax reduction summary should be visible
+    await expect(step3.taxReductionSummary).toBeVisible();
     // The reduction label should mention 60%
-    const taxLabels = step3.shadow('.don-tax-item__label');
-    const count = await taxLabels.count();
-    let found60 = false;
-    for (let i = 0; i < count; i++) {
-      const text = await taxLabels.nth(i).textContent();
-      if (text?.includes('60')) found60 = true;
-    }
-    expect(found60).toBeTruthy();
+    const reductionItem = step3.shadow('[data-testid="tax-reduction-item"]');
+    await expect(reductionItem).toContainText('60%');
   });
 
   test('7.4 — Should toggle fee options (donor pays vs included)', async ({ page }) => {

--- a/donaction-saas/src/components/sponsorshipForm/__tests__/TaxReductionSummary.test.ts
+++ b/donaction-saas/src/components/sponsorshipForm/__tests__/TaxReductionSummary.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { calculateTaxReduction, calculateTaxSavings, formatCurrency } from '../logic/utils';
+
+/**
+ * Tests for TaxReductionSummary component logic
+ *
+ * The component uses:
+ * - taxRate = isOrganization ? 0.6 : 0.66
+ * - taxSavingsAmount = taxReceiptAmount * taxRate
+ * - realCost = calculateTaxReduction(taxReceiptAmount, isOrganization)
+ *
+ * These tests validate the calculated values that the component displays.
+ */
+describe('TaxReductionSummary - Component Logic', () => {
+  // Tax rates per French tax law
+  const TAUX_PARTICULIER = 0.66; // Article 200 CGI
+  const TAUX_ORGANISME = 0.6; // Article 238 bis CGI
+
+  describe('Individual donor (66% rate)', () => {
+    const isOrganization = false;
+    const taxRate = TAUX_PARTICULIER;
+
+    it('calculates tax savings correctly (66€ for 100€)', () => {
+      const taxReceiptAmount = 100;
+      const taxSavingsAmount = taxReceiptAmount * taxRate;
+      expect(formatCurrency(taxSavingsAmount)).toBe('66 €');
+    });
+
+    it('calculates real cost correctly (34€ for 100€)', () => {
+      const realCost = calculateTaxReduction(100, isOrganization);
+      expect(realCost).toBe('34');
+    });
+
+    it('formats tax receipt amount correctly', () => {
+      expect(formatCurrency(100)).toBe('100 €');
+    });
+  });
+
+  describe('Organization donor (60% rate)', () => {
+    const isOrganization = true;
+    const taxRate = TAUX_ORGANISME;
+
+    it('calculates tax savings correctly (60€ for 100€)', () => {
+      const taxReceiptAmount = 100;
+      const taxSavingsAmount = taxReceiptAmount * taxRate;
+      expect(formatCurrency(taxSavingsAmount)).toBe('60 €');
+    });
+
+    it('calculates real cost correctly (40€ for 100€)', () => {
+      const realCost = calculateTaxReduction(100, isOrganization);
+      expect(realCost).toBe('40');
+    });
+  });
+
+  describe('Issue #56 Acceptance Criteria - Scenario validation', () => {
+    it('Scenario 1: donorPaysFee=true, 100€ donation → receipt shows 100€', () => {
+      // When donorPaysFee=true, montantRecuFiscal = montantDon (100€)
+      const taxReceiptAmount = 100;
+      const isOrganization = false;
+
+      expect(formatCurrency(taxReceiptAmount)).toBe('100 €');
+      expect(formatCurrency(taxReceiptAmount * TAUX_PARTICULIER)).toBe('66 €');
+      expect(calculateTaxReduction(taxReceiptAmount, isOrganization)).toBe('34');
+    });
+
+    it('Scenario 2: donorPaysFee=false, 100€ donation (4% commission) → receipt shows 96€', () => {
+      // When donorPaysFee=false, fees are deducted from donation
+      // Per issue example: montantRecuFiscal = 96€
+      const taxReceiptAmount = 96;
+      const isOrganization = false;
+
+      expect(formatCurrency(taxReceiptAmount)).toBe('96 €');
+      expect(formatCurrency(taxReceiptAmount * TAUX_PARTICULIER)).toBe('63.36 €');
+      expect(calculateTaxReduction(taxReceiptAmount, isOrganization)).toBe('32.64');
+    });
+
+    it('Scenario 3: Organization donor uses 60% rate (article 238 bis CGI)', () => {
+      const taxReceiptAmount = 100;
+      const isOrganization = true;
+
+      expect(formatCurrency(taxReceiptAmount * TAUX_ORGANISME)).toBe('60 €');
+      expect(calculateTaxReduction(taxReceiptAmount, isOrganization)).toBe('40');
+    });
+  });
+
+  describe('Component derived values', () => {
+    it('taxRateLabel is 66 for individual', () => {
+      const isOrganization = false;
+      const taxRateLabel = isOrganization ? '60' : '66';
+      expect(taxRateLabel).toBe('66');
+    });
+
+    it('taxRateLabel is 60 for organization', () => {
+      const isOrganization = true;
+      const taxRateLabel = isOrganization ? '60' : '66';
+      expect(taxRateLabel).toBe('60');
+    });
+
+    it('showNote is true when contribution > 0 and showContributionNote=true', () => {
+      const platformContribution = 5;
+      const showContributionNote = true;
+      const showNote = showContributionNote && platformContribution > 0;
+      expect(showNote).toBe(true);
+    });
+
+    it('showNote is false when contribution = 0', () => {
+      const platformContribution = 0;
+      const showContributionNote = true;
+      const showNote = showContributionNote && platformContribution > 0;
+      expect(showNote).toBe(false);
+    });
+
+    it('showNote is false when showContributionNote = false', () => {
+      const platformContribution = 5;
+      const showContributionNote = false;
+      const showNote = showContributionNote && platformContribution > 0;
+      expect(showNote).toBe(false);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('handles zero amount gracefully', () => {
+      expect(formatCurrency(0)).toBe('0 €');
+      expect(calculateTaxReduction(0, false)).toBe('0');
+      expect(calculateTaxSavings(0, false)).toBe('0');
+    });
+
+    it('handles decimal amounts correctly', () => {
+      const taxReceiptAmount = 94.25;
+      const isOrganization = false;
+
+      expect(formatCurrency(taxReceiptAmount)).toBe('94.25 €');
+      // 94.25 * 0.66 = 62.205
+      expect(formatCurrency(taxReceiptAmount * TAUX_PARTICULIER)).toBe('62.21 €');
+    });
+
+    it('handles large amounts', () => {
+      const taxReceiptAmount = 10000;
+      const isOrganization = false;
+
+      expect(formatCurrency(taxReceiptAmount)).toBe('10000 €');
+      expect(formatCurrency(taxReceiptAmount * TAUX_PARTICULIER)).toBe('6600 €');
+      expect(calculateTaxReduction(taxReceiptAmount, isOrganization)).toBe('3400');
+    });
+  });
+
+  describe('Integration with calculateTaxSavings utility', () => {
+    it('calculateTaxSavings matches manual calculation for individual', () => {
+      const amount = 100;
+      const manual = formatCurrency(amount * TAUX_PARTICULIER);
+      const utility = calculateTaxSavings(amount, false) + ' €';
+      expect(manual).toBe('66 €');
+      expect(utility).toBe('66 €');
+    });
+
+    it('calculateTaxSavings matches manual calculation for organization', () => {
+      const amount = 100;
+      const manual = formatCurrency(amount * TAUX_ORGANISME);
+      const utility = calculateTaxSavings(amount, true) + ' €';
+      expect(manual).toBe('60 €');
+      expect(utility).toBe('60 €');
+    });
+  });
+});

--- a/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/index.scss
+++ b/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/index.scss
@@ -449,79 +449,9 @@
   font-weight: var(--don-font-weight-medium);
 }
 
-// Tax section
+// Tax section wrapper - styles moved to TaxReductionSummary component
 .don-tax-section {
   margin-top: var(--don-spacing-2xl);
-  padding: var(--don-spacing-xl);
-  background-color: var(--don-color-success-light);
-  border-radius: var(--don-radius-xl);
-}
-
-.don-tax-flow {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: var(--don-spacing-lg);
-
-  @media screen and (max-width: 768px) {
-    flex-direction: column;
-  }
-}
-
-.don-tax-item {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
-}
-
-.don-tax-item__icon {
-  font-size: var(--don-font-size-xl);
-  margin-bottom: 2px;
-}
-
-.don-tax-item__label {
-  font-size: var(--don-font-size-xs);
-  color: var(--don-color-success-dark);
-  text-transform: uppercase;
-  letter-spacing: 0.3px;
-}
-
-.don-tax-item__value {
-  font-size: var(--don-font-size-lg);
-  font-weight: var(--don-font-weight-semibold);
-  color: var(--don-color-success-dark);
-}
-
-.don-tax-arrow {
-  color: #86efac;
-  font-size: var(--don-font-size-xl);
-  font-weight: 300;
-
-  @media screen and (max-width: 768px) {
-    transform: rotate(90deg);
-  }
-}
-
-.don-tax-item--final {
-  background-color: #dcfce7;
-  padding: var(--don-spacing-md) var(--don-spacing-xl);
-  border-radius: var(--don-radius-lg);
-}
-
-.don-tax-item__value--final {
-  font-size: var(--don-font-size-2xl);
-  font-weight: var(--don-font-weight-bold);
-  color: var(--don-color-success);
-}
-
-.don-tax-note {
-  margin: var(--don-spacing-lg) 0 0 0;
-  font-size: 11px;
-  color: var(--don-color-text-muted);
-  text-align: center;
-  font-style: italic;
 }
 
 // Documents

--- a/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/step3.svelte
+++ b/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/step3.svelte
@@ -18,13 +18,14 @@
   import userAvatar from '../../../../../../assets/icons/userAvatar.svg';
   import resendFiles from '../../../../../../assets/icons/resendFiles.svg';
   import Tooltip from '../../../../../../utils/tooltip/Tooltip.svelte';
-  import { calculateTaxReduction, formatCurrency } from '../../../../logic/utils';
+  import { formatCurrency } from '../../../../logic/utils';
   import {
     calculateFees,
     type FeeCalculationOutput,
   } from '../../../../logic/fee-calculation-helper';
   import ProjectHighlight from '../../../projectHighlight/ProjectHighlight.svelte';
   import FormError from '../../../formError/FormError.svelte';
+  import TaxReductionSummary from '../../../taxReductionSummary/TaxReductionSummary.svelte';
 
   const cgu = $state({
     title: '',
@@ -341,41 +342,15 @@
         </div>
       </div>
 
-      <!-- Tax section -->
-      {#if DEFAULT_VALUES.withTaxReduction}
+      <!-- Tax section - guard: stripe_connect + withTaxReduction -->
+      {#if DEFAULT_VALUES.withTaxReduction && isStripeConnect}
         <div class="don-tax-section">
-          <div class="don-tax-flow">
-            <div class="don-tax-item">
-              <span class="don-tax-item__icon">📄</span>
-              <span class="don-tax-item__label">Reçu fiscal</span>
-              <span class="don-tax-item__value">{formatCurrency(fees.montantRecuFiscal)}</span>
-            </div>
-            <span class="don-tax-arrow">→</span>
-            <div class="don-tax-item">
-              <span class="don-tax-item__icon">💰</span>
-              <span class="don-tax-item__label"
-                >Réduction ({DEFAULT_VALUES.estOrganisme ? '60' : '66'}%)</span
-              >
-              <span class="don-tax-item__value"
-                >{formatCurrency(
-                  fees.montantRecuFiscal * (DEFAULT_VALUES.estOrganisme ? 0.6 : 0.66),
-                )}</span
-              >
-            </div>
-            <span class="don-tax-arrow">→</span>
-            <div class="don-tax-item don-tax-item--final">
-              <span class="don-tax-item__label">Coût réel</span>
-              <span class="don-tax-item__value--final">
-                {calculateTaxReduction(fees.montantRecuFiscal, DEFAULT_VALUES.estOrganisme)} €
-              </span>
-            </div>
-          </div>
-          {#if SUBSCRIPTION.allowKlubrContribution && DEFAULT_VALUES.contributionAKlubr > 0}
-            <p class="don-tax-note">
-              * Le soutien à la plateforme ({formatCurrency(DEFAULT_VALUES.contributionAKlubr)})
-              n'est pas déductible
-            </p>
-          {/if}
+          <TaxReductionSummary
+            taxReceiptAmount={fees.montantRecuFiscal}
+            isOrganization={DEFAULT_VALUES.estOrganisme}
+            platformContribution={DEFAULT_VALUES.contributionAKlubr}
+            showContributionNote={SUBSCRIPTION.allowKlubrContribution}
+          />
         </div>
       {/if}
     </section>

--- a/donaction-saas/src/components/sponsorshipForm/components/taxReductionSummary/TaxReductionSummary.svelte
+++ b/donaction-saas/src/components/sponsorshipForm/components/taxReductionSummary/TaxReductionSummary.svelte
@@ -1,0 +1,70 @@
+<script lang="ts">
+  import { formatCurrency, calculateTaxReduction } from '../../logic/utils';
+
+  let {
+    taxReceiptAmount,
+    isOrganization,
+    platformContribution = 0,
+    showContributionNote = false,
+  }: {
+    taxReceiptAmount: number;
+    isOrganization: boolean;
+    platformContribution?: number;
+    showContributionNote?: boolean;
+  } = $props();
+
+  // Tax rates per French tax law
+  // Individual: 66% (article 200 CGI)
+  // Organization: 60% (article 238 bis CGI)
+  const taxRate = $derived(isOrganization ? 0.6 : 0.66);
+  const taxRateLabel = $derived(isOrganization ? '60' : '66');
+  const taxSavingsAmount = $derived(taxReceiptAmount * taxRate);
+  const realCost = $derived(calculateTaxReduction(taxReceiptAmount, isOrganization));
+
+  // Show footnote only if contribution > 0 and allowed
+  const showNote = $derived(showContributionNote && platformContribution > 0);
+</script>
+
+<div class="tax-reduction" data-testid="tax-reduction-summary">
+  <div class="tax-reduction__flow">
+    <!-- Tax Receipt -->
+    <div class="tax-reduction__item" data-testid="tax-receipt-item">
+      <span class="tax-reduction__item-icon">📄</span>
+      <span class="tax-reduction__item-label">Reçu fiscal</span>
+      <span class="tax-reduction__item-value" data-testid="tax-receipt-value">
+        {formatCurrency(taxReceiptAmount)}
+      </span>
+    </div>
+
+    <span class="tax-reduction__arrow">→</span>
+
+    <!-- Tax Reduction -->
+    <div class="tax-reduction__item" data-testid="tax-reduction-item">
+      <span class="tax-reduction__item-icon">💰</span>
+      <span class="tax-reduction__item-label">Réduction ({taxRateLabel}%)</span>
+      <span class="tax-reduction__item-value" data-testid="tax-savings-value">
+        {formatCurrency(taxSavingsAmount)}
+      </span>
+    </div>
+
+    <span class="tax-reduction__arrow">→</span>
+
+    <!-- Real Cost -->
+    <div class="tax-reduction__item tax-reduction__item--final" data-testid="real-cost-item">
+      <span class="tax-reduction__item-label">Coût réel</span>
+      <span class="tax-reduction__item-value--final" data-testid="real-cost-value">
+        {realCost} €
+      </span>
+    </div>
+  </div>
+
+  {#if showNote}
+    <p class="tax-reduction__note" data-testid="contribution-note">
+      * Le soutien à la plateforme ({formatCurrency(platformContribution)}) n'est pas déductible
+    </p>
+  {/if}
+</div>
+
+<style lang="scss">
+  @use 'index';
+</style>

--- a/donaction-saas/src/components/sponsorshipForm/components/taxReductionSummary/index.scss
+++ b/donaction-saas/src/components/sponsorshipForm/components/taxReductionSummary/index.scss
@@ -1,0 +1,88 @@
+// TaxReductionSummary Component Styles
+// Displays tax receipt amount, reduction percentage, and real cost
+// Extracted from step3/index.scss for reusability
+
+@use '../../../../styles/main';
+
+.tax-reduction {
+  padding: var(--don-spacing-xl);
+  background-color: var(--don-color-success-light);
+  border-radius: var(--don-radius-xl);
+}
+
+.tax-reduction__flow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--don-spacing-lg);
+
+  @media screen and (max-width: 768px) {
+    flex-direction: column;
+  }
+}
+
+.tax-reduction__item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+.tax-reduction__item-icon {
+  font-size: var(--don-font-size-xl);
+  margin-bottom: 2px;
+}
+
+.tax-reduction__item-label {
+  font-size: var(--don-font-size-xs);
+  color: var(--don-color-success-dark);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.tax-reduction__item-value {
+  font-size: var(--don-font-size-lg);
+  font-weight: var(--don-font-weight-semibold);
+  color: var(--don-color-success-dark);
+}
+
+.tax-reduction__arrow {
+  color: #86efac;
+  font-size: var(--don-font-size-xl);
+  font-weight: 300;
+
+  @media screen and (max-width: 768px) {
+    transform: rotate(90deg);
+  }
+}
+
+.tax-reduction__item--final {
+  background-color: #dcfce7;
+  padding: var(--don-spacing-md) var(--don-spacing-xl);
+  border-radius: var(--don-radius-lg);
+}
+
+.tax-reduction__item-value--final {
+  font-size: var(--don-font-size-2xl);
+  font-weight: var(--don-font-weight-bold);
+  color: var(--don-color-success);
+}
+
+.tax-reduction__note {
+  margin: var(--don-spacing-lg) 0 0 0;
+  font-size: 11px;
+  color: var(--don-color-text-muted);
+  text-align: center;
+  font-style: italic;
+}
+
+// Respect reduced motion preference (WCAG 2.1 AA)
+@media (prefers-reduced-motion: reduce) {
+  .tax-reduction,
+  .tax-reduction__item,
+  .tax-reduction__arrow {
+    animation: none !important;
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- Create reusable `TaxReductionSummary.svelte` component displaying tax receipt, reduction percentage (66%/60%), and real cost
- Guard condition: only visible when `stripe_connect=true` AND `withTaxReduction=true`
- Extract styles to dedicated component stylesheet
- Update E2E tests with new `data-testid` selectors

## Test plan
- [x] Unit tests pass (18 tests)
- [x] Build passes
- [x] E2E page objects updated with new locators
- [x] E2E summary tests updated for Stripe Connect config

Closes #56