### PR TITLE
feat(frontend): NewHpHero section with CTAs

### DIFF
--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.scss
@@ -1,13 +1,27 @@
+// Layout variables
+$hero-min-height: 80vh;
+$hero-text-width: 60%;
+$hero-illustration-width: 40%;
+
+// Scroll indicator variables
+$scroll-indicator-size: 24px;
+$scroll-indicator-border: 3px;
+
 .new-hp-hero {
+	--hero-min-height: #{$hero-min-height};
+	--hero-text-width: #{$hero-text-width};
+	--hero-illustration-width: #{$hero-illustration-width};
+
 	&__scroll-indicator {
 		transform: translateX(-50%);
 		animation: bounce 2s infinite;
+		will-change: transform;
 
 		.scroll-indicator-arrow {
-			width: 24px;
-			height: 24px;
-			border-right: 3px solid #000;
-			border-bottom: 3px solid #000;
+			width: $scroll-indicator-size;
+			height: $scroll-indicator-size;
+			border-right: $scroll-indicator-border solid theme('colors.black');
+			border-bottom: $scroll-indicator-border solid theme('colors.black');
 			transform: rotate(45deg);
 		}
 	}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.scss
@@ -1,0 +1,31 @@
+.new-hp-hero {
+	position: relative;
+
+	&__scroll-indicator {
+		animation: bounce 2s infinite;
+
+		.scroll-indicator-arrow {
+			width: 24px;
+			height: 24px;
+			border-right: 3px solid #000;
+			border-bottom: 3px solid #000;
+			transform: rotate(45deg);
+		}
+	}
+}
+
+@keyframes bounce {
+	0%,
+	20%,
+	50%,
+	80%,
+	100% {
+		transform: translateX(-50%) translateY(0);
+	}
+	40% {
+		transform: translateX(-50%) translateY(-10px);
+	}
+	60% {
+		transform: translateX(-50%) translateY(-5px);
+	}
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.scss
@@ -1,7 +1,6 @@
 .new-hp-hero {
-	position: relative;
-
 	&__scroll-indicator {
+		transform: translateX(-50%);
 		animation: bounce 2s infinite;
 
 		.scroll-indicator-arrow {

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.tsx
@@ -3,7 +3,7 @@ import './index.scss';
 
 export default function NewHpHero() {
 	return (
-		<section className="new-hp-hero w-full min-h-[80vh] flex items-center py-16 px-6 md:px-0">
+		<section className="new-hp-hero w-full min-h-[80vh] relative flex items-center py-16 px-6 md:px-0">
 			<div className="flex flex-col lg:flex-row items-center justify-between gap-12 w-full max-w-screen-xl mx-auto">
 				{/* Text content - 60% */}
 				<div className="lg:w-[60%] w-full flex flex-col gap-6">
@@ -36,7 +36,11 @@ export default function NewHpHero() {
 			</div>
 
 			{/* Scroll indicator */}
-			<div className="new-hp-hero__scroll-indicator absolute bottom-8 left-1/2 -translate-x-1/2">
+			<div
+				className="new-hp-hero__scroll-indicator absolute bottom-8 left-1/2"
+				role="img"
+				aria-label="Défiler vers le bas"
+			>
 				<div className="scroll-indicator-arrow"></div>
 			</div>
 		</section>

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+import './index.scss';
+
+export default function NewHpHero() {
+	return (
+		<section className="new-hp-hero w-full min-h-[80vh] flex items-center py-16 px-6 md:px-0">
+			<div className="flex flex-col lg:flex-row items-center justify-between gap-12 w-full max-w-screen-xl mx-auto">
+				{/* Text content - 60% */}
+				<div className="lg:w-[60%] w-full flex flex-col gap-6">
+					<h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-black leading-tight">
+						Mobilisez votre communauté pour vos projets
+					</h1>
+					<p className="text-lg md:text-xl text-gray-700 max-w-xl">
+						Créez des collectes de dons, fidélisez vos donateurs et développez votre association
+						avec Donaction.
+					</p>
+
+					{/* CTA Buttons */}
+					<div className="flex flex-col sm:flex-row gap-4 mt-4">
+						<Link href="/new-club" className="btn btn-primary text-center">
+							Créer mon club
+						</Link>
+						<Link href="/projets" className="btn btn-outline-primary text-center">
+							Voir les projets
+						</Link>
+					</div>
+				</div>
+
+				{/* Illustration - 40% */}
+				<div className="lg:w-[40%] w-full flex items-center justify-center">
+					<div className="w-full max-w-md aspect-square bg-secondary/20 rounded-3xl flex items-center justify-center">
+						{/* Placeholder for illustration */}
+						<span className="text-6xl">🎯</span>
+					</div>
+				</div>
+			</div>
+
+			{/* Scroll indicator */}
+			<div className="new-hp-hero__scroll-indicator absolute bottom-8 left-1/2 -translate-x-1/2">
+				<div className="scroll-indicator-arrow"></div>
+			</div>
+		</section>
+	);
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.tsx
@@ -29,8 +29,15 @@ export default function NewHpHero() {
 				{/* Illustration - 40% */}
 				<div className="lg:w-[40%] w-full flex items-center justify-center">
 					<div className="w-full max-w-md aspect-square bg-secondary/20 rounded-3xl flex items-center justify-center">
-						{/* Placeholder for illustration */}
-						<span className="text-6xl">🎯</span>
+						{/* TODO: Replace with actual illustration - Issue #125 */}
+						<svg
+							className="w-32 h-32 text-secondary"
+							fill="currentColor"
+							viewBox="0 0 24 24"
+							aria-hidden="true"
+						>
+							<path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z" />
+						</svg>
 					</div>
 				</div>
 			</div>

--- a/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
@@ -1,8 +1,10 @@
+import NewHpHero from './NewHpHero';
+
 export default function NewHomepageContent() {
-  return (
-    <main className="flex flex-col items-center justify-center gap-16 text-black w-full min-h-[25rem]">
-      <h1 className="text-3xl font-semibold">New Homepage</h1>
-      <p>Content coming soon...</p>
-    </main>
-  );
+	return (
+		<main className="flex flex-col items-center w-full">
+			<NewHpHero />
+			{/* Future sections will be added here */}
+		</main>
+	);
 }

--- a/plans/issue-104-plan.md
+++ b/plans/issue-104-plan.md
@@ -1,0 +1,136 @@
+# Plan: Issue #104 - NewHpHero Section
+
+## Summary
+Create Hero section for `/new-hp` with 60/40 text/illustration layout, dual CTAs, and animated scroll indicator.
+
+## Technical Analysis
+
+### Affected Files
+1. `src/layouts/partials/newHomepage/NewHpHero/index.tsx` (NEW)
+2. `src/layouts/partials/newHomepage/NewHpHero/index.scss` (NEW)
+3. `src/layouts/partials/newHomepage/index.tsx` (MODIFY)
+
+### Design Tokens (from theme.json)
+- Primary: `#000` (black)
+- Secondary: `#73cfa8` (green)
+- Tertiary: `#fb9289` (coral/pink)
+
+### Layout Pattern
+Based on existing `textImageSection` and project conventions:
+- 60% text / 40% illustration (lg breakpoint)
+- Mobile: stack vertically
+- Use Tailwind responsive classes
+
+## Implementation Steps
+
+### Step 1: Create NewHpHero component
+
+**File:** `src/layouts/partials/newHomepage/NewHpHero/index.tsx`
+
+```typescript
+import Link from 'next/link';
+import './index.scss';
+
+export default function NewHpHero() {
+  return (
+    <section className="new-hp-hero w-full min-h-[80vh] flex items-center py-16 px-6 md:px-0">
+      <div className="flex flex-col lg:flex-row items-center justify-between gap-12 w-full max-w-screen-xl mx-auto">
+        {/* Text content - 60% */}
+        <div className="lg:w-[60%] w-full flex flex-col gap-6">
+          <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-black leading-tight">
+            Mobilisez votre communauté pour vos projets
+          </h1>
+          <p className="text-lg md:text-xl text-gray-700 max-w-xl">
+            Créez des collectes de dons, fidélisez vos donateurs et développez votre association avec Donaction.
+          </p>
+
+          {/* CTA Buttons */}
+          <div className="flex flex-col sm:flex-row gap-4 mt-4">
+            <Link href="/new-club" className="btn btn-primary text-center">
+              Créer mon club
+            </Link>
+            <Link href="/projets" className="btn btn-outline-primary text-center">
+              Voir les projets
+            </Link>
+          </div>
+        </div>
+
+        {/* Illustration - 40% */}
+        <div className="lg:w-[40%] w-full flex items-center justify-center">
+          <div className="w-full max-w-md aspect-square bg-secondary/20 rounded-3xl flex items-center justify-center">
+            {/* Placeholder for illustration */}
+            <span className="text-6xl">🎯</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Scroll indicator */}
+      <div className="new-hp-hero__scroll-indicator absolute bottom-8 left-1/2 -translate-x-1/2">
+        <div className="scroll-indicator-arrow"></div>
+      </div>
+    </section>
+  );
+}
+```
+
+### Step 2: Create SCSS for scroll animation
+
+**File:** `src/layouts/partials/newHomepage/NewHpHero/index.scss`
+
+```scss
+.new-hp-hero {
+  position: relative;
+
+  &__scroll-indicator {
+    animation: bounce 2s infinite;
+
+    .scroll-indicator-arrow {
+      width: 24px;
+      height: 24px;
+      border-right: 3px solid #000;
+      border-bottom: 3px solid #000;
+      transform: rotate(45deg);
+    }
+  }
+}
+
+@keyframes bounce {
+  0%, 20%, 50%, 80%, 100% {
+    transform: translateX(-50%) translateY(0);
+  }
+  40% {
+    transform: translateX(-50%) translateY(-10px);
+  }
+  60% {
+    transform: translateX(-50%) translateY(-5px);
+  }
+}
+```
+
+### Step 3: Update NewHomepageContent
+
+**File:** `src/layouts/partials/newHomepage/index.tsx`
+
+```typescript
+import NewHpHero from './NewHpHero';
+
+export default function NewHomepageContent() {
+  return (
+    <main className="flex flex-col items-center w-full">
+      <NewHpHero />
+      {/* Future sections will be added here */}
+    </main>
+  );
+}
+```
+
+## Acceptance Criteria Verification
+- ✅ `/new-hp` shows Hero with title and illustration
+- ✅ Two CTA buttons visible (primary → /new-club, secondary → /projets)
+- ✅ 60/40 layout on desktop
+- ✅ Animated scroll indicator
+
+## Notes
+- Using Server Component (no `'use client'`) - Links work without client-side JS
+- Following existing patterns from `textImageSection` and `buttons.scss`
+- Placeholder illustration (emoji) - can be replaced with actual image later


### PR DESCRIPTION
## Summary
- Create NewHpHero component with 60/40 text/illustration layout
- Add primary CTA → `/new-club`, secondary CTA → `/projets`
- Add animated scroll indicator with bounce animation

## Test plan
- [ ] Visit `/new-hp` and verify Hero section displays
- [ ] Check 60/40 layout on desktop (responsive on mobile)
- [ ] Click "Créer mon club" → navigates to `/new-club`
- [ ] Click "Voir les projets" → navigates to `/projets`
- [ ] Scroll indicator animates with bounce effect

Closes #104