### PR TITLE
feat(frontend): add NewHpWhyDonaction section (#106)

### DIFF
--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/NewHpWhyDonaction.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/NewHpWhyDonaction.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import NewHpWhyDonaction from './index';
+
+describe('NewHpWhyDonaction', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders section with correct class', () => {
+		const { container } = render(<NewHpWhyDonaction />);
+
+		const section = container.querySelector('.new-hp-why-donaction');
+		expect(section).toBeInTheDocument();
+		expect(section?.tagName).toBe('SECTION');
+	});
+
+	it('renders 6 advantage cards', () => {
+		render(<NewHpWhyDonaction />);
+
+		const cards = screen.getAllByRole('listitem');
+		expect(cards).toHaveLength(6);
+	});
+
+	it('renders section title', () => {
+		render(<NewHpWhyDonaction />);
+
+		const heading = screen.getByRole('heading', { level: 2 });
+		expect(heading).toBeInTheDocument();
+		expect(heading).toHaveTextContent('Pourquoi choisir DONACTION ?');
+	});
+
+	it('renders all advantage titles', () => {
+		render(<NewHpWhyDonaction />);
+
+		expect(screen.getByText('100% Transparent')).toBeInTheDocument();
+		expect(screen.getByText('Zéro abonnement')).toBeInTheDocument();
+		expect(screen.getByText('Prêt en 5 min')).toBeInTheDocument();
+		expect(screen.getByText('Reçus fiscaux auto')).toBeInTheDocument();
+		expect(screen.getByText('Pensé pour le sport')).toBeInTheDocument();
+		expect(screen.getByText('Tableau de bord')).toBeInTheDocument();
+	});
+
+	it('renders all advantage descriptions', () => {
+		render(<NewHpWhyDonaction />);
+
+		expect(screen.getByText(/Aucun frais caché/)).toBeInTheDocument();
+		expect(screen.getByText(/Payez uniquement sur les dons/)).toBeInTheDocument();
+		expect(screen.getByText(/Créez votre page de collecte/)).toBeInTheDocument();
+		expect(screen.getByText(/Génération automatique des Cerfa/)).toBeInTheDocument();
+		expect(screen.getByText(/Des outils adaptés aux associations/)).toBeInTheDocument();
+		expect(screen.getByText(/Suivez vos collectes et donateurs/)).toBeInTheDocument();
+	});
+
+	it('renders icons with aria-hidden for accessibility', () => {
+		const { container } = render(<NewHpWhyDonaction />);
+
+		const icons = container.querySelectorAll('[aria-hidden="true"]');
+		expect(icons).toHaveLength(6);
+	});
+
+	it('uses semantic list structure', () => {
+		render(<NewHpWhyDonaction />);
+
+		const list = screen.getByRole('list');
+		expect(list).toBeInTheDocument();
+		expect(list).toHaveClass('new-hp-why-donaction__grid');
+	});
+
+	it('renders card elements with correct structure', () => {
+		const { container } = render(<NewHpWhyDonaction />);
+
+		const cards = container.querySelectorAll('.new-hp-why-donaction__card');
+		expect(cards).toHaveLength(6);
+
+		const firstCard = cards[0];
+		expect(firstCard.querySelector('.new-hp-why-donaction__icon')).toBeInTheDocument();
+		expect(firstCard.querySelector('.new-hp-why-donaction__title')).toBeInTheDocument();
+		expect(firstCard.querySelector('.new-hp-why-donaction__description')).toBeInTheDocument();
+	});
+
+	it('card elements support hover interactions', () => {
+		const { container } = render(<NewHpWhyDonaction />);
+
+		const card = container.querySelector('.new-hp-why-donaction__card');
+		expect(card).toBeInTheDocument();
+
+		fireEvent.mouseEnter(card!);
+		fireEvent.mouseLeave(card!);
+
+		expect(card).toBeInTheDocument();
+	});
+
+	it('renders subtitle paragraph', () => {
+		render(<NewHpWhyDonaction />);
+
+		expect(
+			screen.getByText(/Tout ce dont votre association a besoin/)
+		).toBeInTheDocument();
+	});
+});

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/index.scss
@@ -1,0 +1,68 @@
+// Layout variables
+$card-gap: 1.5rem;
+$icon-size: 3rem;
+$title-font-size: 1.125rem;
+$description-font-size: 0.9375rem;
+
+// Color variables
+$color-black: #000;
+$color-gray-600: #4b5563;
+$color-white: #fff;
+
+.new-hp-why-donaction {
+	&__grid {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: $card-gap;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+
+		// Tablet: 2 columns
+		@media (max-width: 768px) {
+			grid-template-columns: repeat(2, 1fr);
+		}
+
+		// Mobile: 1 column
+		@media (max-width: 480px) {
+			grid-template-columns: 1fr;
+		}
+	}
+
+	&__card {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		text-align: center;
+		padding: 2rem 1.5rem;
+		background: $color-white;
+		border-radius: 1rem;
+		box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+		transition: transform 0.2s ease, box-shadow 0.2s ease;
+
+		&:hover {
+			transform: translateY(-4px);
+			box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
+		}
+	}
+
+	&__icon {
+		font-size: $icon-size;
+		line-height: 1;
+		margin-bottom: 1rem;
+	}
+
+	&__title {
+		font-weight: 600;
+		font-size: $title-font-size;
+		color: $color-black;
+		margin-bottom: 0.5rem;
+	}
+
+	&__description {
+		font-size: $description-font-size;
+		color: $color-gray-600;
+		line-height: 1.5;
+		margin: 0;
+	}
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/index.tsx
@@ -1,0 +1,67 @@
+import './index.scss';
+
+const ADVANTAGES = [
+	{
+		id: 'transparent',
+		icon: '💯',
+		title: '100% Transparent',
+		description: 'Aucun frais caché, vous savez exactement où va chaque euro.',
+	},
+	{
+		id: 'no-subscription',
+		icon: '🎯',
+		title: 'Zéro abonnement',
+		description: "Payez uniquement sur les dons reçus, pas d'engagement.",
+	},
+	{
+		id: 'quick-setup',
+		icon: '📱',
+		title: 'Prêt en 5 min',
+		description: 'Créez votre page de collecte en quelques clics.',
+	},
+	{
+		id: 'tax-receipts',
+		icon: '🧾',
+		title: 'Reçus fiscaux auto',
+		description: 'Génération automatique des Cerfa pour vos donateurs.',
+	},
+	{
+		id: 'sport-focused',
+		icon: '🏆',
+		title: 'Pensé pour le sport',
+		description: 'Des outils adaptés aux associations sportives.',
+	},
+	{
+		id: 'dashboard',
+		icon: '📊',
+		title: 'Tableau de bord',
+		description: 'Suivez vos collectes et donateurs en temps réel.',
+	},
+];
+
+export default function NewHpWhyDonaction() {
+	return (
+		<section className="new-hp-why-donaction w-full py-16 md:py-24">
+			<div className="w-full max-w-screen-xl mx-auto px-6">
+				<h2 className="text-3xl md:text-4xl font-bold text-center mb-4">
+					Pourquoi choisir DONACTION ?
+				</h2>
+				<p className="text-gray-600 text-center max-w-2xl mx-auto mb-12">
+					Tout ce dont votre association a besoin pour réussir ses collectes.
+				</p>
+
+				<ul className="new-hp-why-donaction__grid" role="list">
+					{ADVANTAGES.map((advantage) => (
+						<li key={advantage.id} className="new-hp-why-donaction__card">
+							<span className="new-hp-why-donaction__icon" aria-hidden="true">
+								{advantage.icon}
+							</span>
+							<h3 className="new-hp-why-donaction__title">{advantage.title}</h3>
+							<p className="new-hp-why-donaction__description">{advantage.description}</p>
+						</li>
+					))}
+				</ul>
+			</div>
+		</section>
+	);
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
@@ -1,11 +1,13 @@
 import NewHpHero from './NewHpHero';
 import NewHpReassurance from './NewHpReassurance';
+import NewHpWhyDonaction from './NewHpWhyDonaction';
 
 export default function NewHomepageContent() {
 	return (
 		<main className="flex flex-col items-center w-full">
 			<NewHpHero />
 			<NewHpReassurance />
+			<NewHpWhyDonaction />
 		</main>
 	);
 }


### PR DESCRIPTION
## Summary
- Add "Why Donaction" section with 6 advantage cards
- 3x2 responsive grid (2 cols on tablet, 1 on mobile)
- Icons: 💯 🎯 📱 🧾 🏆 📊
- Hover animations on cards
- Full test coverage (10 tests)
- Accessible semantic structure (list, aria-hidden icons)

## Test plan
- [x] Component renders all 6 cards
- [x] Tests pass: `npm test -- NewHpWhyDonaction`
- [x] TypeScript compiles
- [ ] Visual review on /new-hp page

Closes #106