### PR TITLE
feat(frontend): add NewHpWidgetDemo interactive donation widget section

### DIFF
--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/NewHpWidgetDemo.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/NewHpWidgetDemo.test.tsx
@@ -1,0 +1,201 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import NewHpWidgetDemo from './index';
+
+describe('NewHpWidgetDemo', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders section with correct class', () => {
+		const { container } = render(<NewHpWidgetDemo />);
+
+		const section = container.querySelector('.new-hp-widget-demo');
+		expect(section).toBeInTheDocument();
+		expect(section?.tagName).toBe('SECTION');
+	});
+
+	it('renders main heading', () => {
+		render(<NewHpWidgetDemo />);
+
+		const heading = screen.getByRole('heading', { level: 2 });
+		expect(heading).toBeInTheDocument();
+		expect(heading).toHaveTextContent('Testez notre formulaire de don');
+	});
+
+	it('renders widget heading', () => {
+		render(<NewHpWidgetDemo />);
+
+		const heading = screen.getByRole('heading', { level: 3 });
+		expect(heading).toBeInTheDocument();
+		expect(heading).toHaveTextContent('Faites un don');
+	});
+
+	it('renders 4 preset amount buttons', () => {
+		const { container } = render(<NewHpWidgetDemo />);
+
+		const amountButtons = container.querySelectorAll('.new-hp-widget-demo__amount-btn');
+		expect(amountButtons).toHaveLength(4);
+		expect(amountButtons[0]).toHaveTextContent('10');
+		expect(amountButtons[1]).toHaveTextContent('25');
+		expect(amountButtons[2]).toHaveTextContent('50');
+		expect(amountButtons[3]).toHaveTextContent('100');
+	});
+
+	it('renders custom amount input', () => {
+		render(<NewHpWidgetDemo />);
+
+		const input = screen.getByRole('textbox', { name: /montant personnalisé/i });
+		expect(input).toBeInTheDocument();
+		expect(input).toHaveAttribute('placeholder', 'Autre');
+	});
+
+	it('defaults to 50€ selected', () => {
+		const { container } = render(<NewHpWidgetDemo />);
+
+		const amountButtons = container.querySelectorAll('.new-hp-widget-demo__amount-btn');
+		const button50 = amountButtons[2]; // 50€ is the third button
+		expect(button50).toHaveAttribute('aria-pressed', 'true');
+		expect(button50).toHaveClass('active');
+
+		expect(screen.getByTestId('amount-display')).toHaveTextContent('50');
+	});
+
+	it('calculates tax reduction correctly for 50€', () => {
+		render(<NewHpWidgetDemo />);
+
+		// 50€ * 66% = 33€ tax savings
+		expect(screen.getByTestId('tax-savings')).toHaveTextContent('33');
+		// 50€ - 33€ = 17€ cost after tax
+		expect(screen.getByTestId('cost-after-tax')).toHaveTextContent('17');
+	});
+
+	it('updates calculation when preset amount is clicked', () => {
+		render(<NewHpWidgetDemo />);
+
+		const button100 = screen.getByRole('button', { name: /100 €/i });
+		fireEvent.click(button100);
+
+		expect(button100).toHaveAttribute('aria-pressed', 'true');
+		expect(screen.getByTestId('amount-display')).toHaveTextContent('100');
+		// 100€ * 66% = 66€ tax savings
+		expect(screen.getByTestId('tax-savings')).toHaveTextContent('66');
+		// 100€ - 66€ = 34€ cost after tax
+		expect(screen.getByTestId('cost-after-tax')).toHaveTextContent('34');
+	});
+
+	it('updates calculation when custom amount is entered', () => {
+		render(<NewHpWidgetDemo />);
+
+		const input = screen.getByRole('textbox', { name: /montant personnalisé/i });
+		fireEvent.focus(input);
+		fireEvent.change(input, { target: { value: '200' } });
+
+		expect(screen.getByTestId('amount-display')).toHaveTextContent('200');
+		// 200€ * 66% = 132€ tax savings
+		expect(screen.getByTestId('tax-savings')).toHaveTextContent('132');
+		// 200€ - 132€ = 68€ cost after tax
+		expect(screen.getByTestId('cost-after-tax')).toHaveTextContent('68');
+	});
+
+	it('only accepts numeric input in custom field', () => {
+		render(<NewHpWidgetDemo />);
+
+		const input = screen.getByRole('textbox', { name: /montant personnalisé/i });
+		fireEvent.focus(input);
+		fireEvent.change(input, { target: { value: 'abc' } });
+
+		expect(input).toHaveValue('');
+	});
+
+	it('deselects preset when custom input is focused', () => {
+		const { container } = render(<NewHpWidgetDemo />);
+
+		const amountButtons = container.querySelectorAll('.new-hp-widget-demo__amount-btn');
+		const button50 = amountButtons[2]; // 50€ is the third button
+		expect(button50).toHaveAttribute('aria-pressed', 'true');
+
+		const input = screen.getByRole('textbox', { name: /montant personnalisé/i });
+		fireEvent.focus(input);
+
+		expect(button50).toHaveAttribute('aria-pressed', 'false');
+	});
+
+	it('clears custom input when preset is clicked', () => {
+		render(<NewHpWidgetDemo />);
+
+		const input = screen.getByRole('textbox', { name: /montant personnalisé/i });
+		fireEvent.focus(input);
+		fireEvent.change(input, { target: { value: '75' } });
+
+		const button25 = screen.getByRole('button', { name: /25 €/i });
+		fireEvent.click(button25);
+
+		expect(input).toHaveValue('');
+		expect(button25).toHaveAttribute('aria-pressed', 'true');
+	});
+
+	it('renders disabled CTA button with demo badge', () => {
+		render(<NewHpWidgetDemo />);
+
+		const ctaButton = screen.getByRole('button', { name: /donner.*mode démo/i });
+		expect(ctaButton).toBeInTheDocument();
+		expect(ctaButton).toBeDisabled();
+		expect(ctaButton).toHaveAttribute('aria-disabled', 'true');
+	});
+
+	it('renders disclaimer text', () => {
+		render(<NewHpWidgetDemo />);
+
+		expect(
+			screen.getByText(/Ceci est une démonstration.*aucun paiement/i)
+		).toBeInTheDocument();
+	});
+
+	it('renders benefits list with 3 items', () => {
+		const { container } = render(<NewHpWidgetDemo />);
+
+		const benefits = container.querySelectorAll('.new-hp-widget-demo__benefit');
+		expect(benefits).toHaveLength(3);
+	});
+
+	it('renders benefits with icons having aria-hidden', () => {
+		const { container } = render(<NewHpWidgetDemo />);
+
+		const icons = container.querySelectorAll('.new-hp-widget-demo__benefit-icon[aria-hidden="true"]');
+		expect(icons).toHaveLength(3);
+	});
+
+	it('has accessible widget region', () => {
+		render(<NewHpWidgetDemo />);
+
+		const region = screen.getByRole('region', { name: /simulateur de don/i });
+		expect(region).toBeInTheDocument();
+	});
+
+	it('has accessible amount group', () => {
+		render(<NewHpWidgetDemo />);
+
+		const group = screen.getByRole('group', { name: /montant du don/i });
+		expect(group).toBeInTheDocument();
+	});
+
+	it('fiscal section has aria-live for screen readers', () => {
+		const { container } = render(<NewHpWidgetDemo />);
+
+		const fiscal = container.querySelector('.new-hp-widget-demo__fiscal');
+		expect(fiscal).toHaveAttribute('aria-live', 'polite');
+	});
+
+	it('handles zero amount correctly', () => {
+		render(<NewHpWidgetDemo />);
+
+		const input = screen.getByRole('textbox', { name: /montant personnalisé/i });
+		fireEvent.focus(input);
+		fireEvent.change(input, { target: { value: '' } });
+
+		expect(screen.getByTestId('amount-display')).toHaveTextContent('0');
+		expect(screen.getByTestId('tax-savings')).toHaveTextContent('0');
+		expect(screen.getByTestId('cost-after-tax')).toHaveTextContent('0');
+	});
+});

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/index.scss
@@ -1,0 +1,191 @@
+// Color variables
+$color-black: #000;
+$color-white: #fff;
+$color-gray-50: #f9fafb;
+$color-gray-100: #f3f4f6;
+$color-gray-200: #e5e7eb;
+$color-gray-400: #9ca3af;
+$color-gray-600: #4b5563;
+$color-secondary: #73cfa8;
+$color-secondary-light: rgba(115, 207, 168, 0.1);
+
+.new-hp-widget-demo {
+	background: $color-gray-50;
+
+	&__benefits {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+	}
+
+	&__benefit {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		font-size: 1rem;
+		color: $color-gray-600;
+	}
+
+	&__benefit-icon {
+		font-size: 1.25rem;
+		flex-shrink: 0;
+	}
+
+	&__widget {
+		background: $color-white;
+		border-radius: 1.5rem;
+		padding: 2rem;
+		box-shadow: 0 4px 24px rgba(0, 0, 0, 0.08);
+		max-width: 400px;
+		margin: 0 auto;
+
+		@media (min-width: 1024px) {
+			margin: 0 0 0 auto;
+		}
+	}
+
+	&__widget-title {
+		font-size: 1.5rem;
+		font-weight: 700;
+		text-align: center;
+		margin-bottom: 1.5rem;
+		color: $color-black;
+	}
+
+	&__amounts {
+		display: grid;
+		grid-template-columns: repeat(3, 1fr);
+		gap: 0.75rem;
+		margin-bottom: 1.5rem;
+	}
+
+	&__amount-btn {
+		padding: 0.75rem 1rem;
+		border: 2px solid $color-gray-200;
+		border-radius: 0.75rem;
+		background: $color-white;
+		font-size: 1rem;
+		font-weight: 600;
+		color: $color-black;
+		cursor: pointer;
+		transition: all 0.2s ease;
+
+		&:hover {
+			border-color: $color-secondary;
+		}
+
+		&.active,
+		&[aria-pressed='true'] {
+			border-color: $color-secondary;
+			background: $color-secondary-light;
+			color: $color-black;
+		}
+	}
+
+	&__custom-wrapper {
+		grid-column: span 3;
+		position: relative;
+		display: flex;
+		align-items: center;
+	}
+
+	&__custom-input {
+		width: 100%;
+		padding: 0.75rem 2.5rem 0.75rem 1rem;
+		border: 2px solid $color-gray-200;
+		border-radius: 0.75rem;
+		font-size: 1rem;
+		font-weight: 600;
+		color: $color-black;
+		outline: none;
+		transition: all 0.2s ease;
+
+		&::placeholder {
+			color: $color-gray-400;
+			font-weight: 400;
+		}
+
+		&:focus,
+		&.active {
+			border-color: $color-secondary;
+		}
+
+		&.active:not(:placeholder-shown) {
+			background: $color-secondary-light;
+		}
+	}
+
+	&__custom-suffix {
+		position: absolute;
+		right: 1rem;
+		font-size: 1rem;
+		font-weight: 600;
+		color: $color-gray-400;
+		pointer-events: none;
+	}
+
+	&__fiscal {
+		background: $color-gray-50;
+		border-radius: 1rem;
+		padding: 1.25rem;
+		margin-bottom: 1.5rem;
+	}
+
+	&__fiscal-row {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 0.5rem 0;
+		font-size: 0.9375rem;
+
+		&--highlight {
+			color: $color-secondary;
+		}
+
+		&--total {
+			padding-top: 0.75rem;
+		}
+	}
+
+	&__fiscal-divider {
+		height: 1px;
+		background: $color-gray-200;
+		margin: 0.5rem 0;
+	}
+
+	&__cta {
+		width: 100%;
+		padding: 1rem 1.5rem;
+		border: none;
+		border-radius: 0.75rem;
+		background: $color-black;
+		color: $color-white;
+		font-size: 1.125rem;
+		font-weight: 600;
+		cursor: not-allowed;
+		opacity: 0.7;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		gap: 0.75rem;
+		transition: all 0.2s ease;
+	}
+
+	&__cta-badge {
+		background: rgba(255, 255, 255, 0.2);
+		padding: 0.25rem 0.5rem;
+		border-radius: 0.25rem;
+		font-size: 0.75rem;
+		font-weight: 500;
+	}
+
+	&__disclaimer {
+		text-align: center;
+		font-size: 0.8125rem;
+		color: $color-gray-400;
+		margin-top: 1rem;
+	}
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/index.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import { useState } from 'react';
+import './index.scss';
+
+const PRESET_AMOUNTS = [10, 25, 50, 100];
+const TAX_REDUCTION_RATE = 0.66;
+
+function calculateCostAfterTax(amount: number): string {
+	if (isNaN(amount) || amount <= 0) return '0';
+	const costAfterTax = amount - amount * TAX_REDUCTION_RATE;
+	return costAfterTax.toFixed(2).replace(/\.00$/, '');
+}
+
+function calculateTaxSavings(amount: number): string {
+	if (isNaN(amount) || amount <= 0) return '0';
+	const savings = amount * TAX_REDUCTION_RATE;
+	return savings.toFixed(2).replace(/\.00$/, '');
+}
+
+export default function NewHpWidgetDemo() {
+	const [selectedAmount, setSelectedAmount] = useState<number>(50);
+	const [customAmount, setCustomAmount] = useState<string>('');
+	const [isCustom, setIsCustom] = useState(false);
+
+	const activeAmount = isCustom ? parseFloat(customAmount) || 0 : selectedAmount;
+	const costAfterTax = calculateCostAfterTax(activeAmount);
+	const taxSavings = calculateTaxSavings(activeAmount);
+
+	const handlePresetClick = (amount: number) => {
+		setSelectedAmount(amount);
+		setIsCustom(false);
+		setCustomAmount('');
+	};
+
+	const handleCustomChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const value = e.target.value;
+		if (value === '' || /^\d+$/.test(value)) {
+			setCustomAmount(value);
+			setIsCustom(true);
+		}
+	};
+
+	const handleCustomFocus = () => {
+		setIsCustom(true);
+	};
+
+	return (
+		<section className="new-hp-widget-demo w-full py-16 md:py-24 bg-gray-50">
+			<div className="w-full max-w-screen-xl mx-auto px-6">
+				<div className="flex flex-col lg:flex-row items-center gap-12 lg:gap-16">
+					{/* Text Content - Left */}
+					<div className="lg:w-1/2 w-full">
+						<h2 className="text-3xl md:text-4xl font-bold mb-4">
+							Testez notre formulaire de don
+						</h2>
+						<p className="text-gray-600 text-lg mb-6">
+							Découvrez la simplicité de notre widget de don. Saisissez un montant et voyez
+							instantanément le calcul de votre réduction fiscale.
+						</p>
+
+						<ul className="new-hp-widget-demo__benefits" role="list">
+							<li className="new-hp-widget-demo__benefit">
+								<span className="new-hp-widget-demo__benefit-icon" aria-hidden="true">
+									✨
+								</span>
+								<span>Réduction d&apos;impôt de 66% pour les particuliers</span>
+							</li>
+							<li className="new-hp-widget-demo__benefit">
+								<span className="new-hp-widget-demo__benefit-icon" aria-hidden="true">
+									🧾
+								</span>
+								<span>Reçu fiscal généré automatiquement</span>
+							</li>
+							<li className="new-hp-widget-demo__benefit">
+								<span className="new-hp-widget-demo__benefit-icon" aria-hidden="true">
+									🔒
+								</span>
+								<span>Paiement 100% sécurisé via Stripe</span>
+							</li>
+						</ul>
+					</div>
+
+					{/* Widget Demo - Right */}
+					<div className="lg:w-1/2 w-full">
+						<div
+							className="new-hp-widget-demo__widget"
+							role="region"
+							aria-label="Simulateur de don"
+						>
+							<h3 className="new-hp-widget-demo__widget-title">Faites un don</h3>
+
+							{/* Amount Selection */}
+							<div className="new-hp-widget-demo__amounts" role="group" aria-label="Montant du don">
+								{PRESET_AMOUNTS.map((amount) => (
+									<button
+										key={amount}
+										type="button"
+										className={`new-hp-widget-demo__amount-btn ${
+											!isCustom && selectedAmount === amount ? 'active' : ''
+										}`}
+										onClick={() => handlePresetClick(amount)}
+										aria-pressed={!isCustom && selectedAmount === amount}
+									>
+										{amount} &euro;
+									</button>
+								))}
+								<div className="new-hp-widget-demo__custom-wrapper">
+									<input
+										type="text"
+										inputMode="numeric"
+										pattern="[0-9]*"
+										placeholder="Autre"
+										value={customAmount}
+										onChange={handleCustomChange}
+										onFocus={handleCustomFocus}
+										className={`new-hp-widget-demo__custom-input ${isCustom ? 'active' : ''}`}
+										aria-label="Montant personnalisé en euros"
+									/>
+									<span className="new-hp-widget-demo__custom-suffix">&euro;</span>
+								</div>
+							</div>
+
+							{/* Fiscal Calculation */}
+							<div className="new-hp-widget-demo__fiscal" aria-live="polite">
+								<div className="new-hp-widget-demo__fiscal-row">
+									<span className="text-gray-600">Montant du don</span>
+									<span className="font-semibold" data-testid="amount-display">
+										{activeAmount} &euro;
+									</span>
+								</div>
+								<div className="new-hp-widget-demo__fiscal-row new-hp-widget-demo__fiscal-row--highlight">
+									<span className="text-gray-600">Réduction d&apos;impôt (66%)</span>
+									<span className="font-semibold text-secondary" data-testid="tax-savings">
+										- {taxSavings} &euro;
+									</span>
+								</div>
+								<div className="new-hp-widget-demo__fiscal-divider" />
+								<div className="new-hp-widget-demo__fiscal-row new-hp-widget-demo__fiscal-row--total">
+									<span className="font-semibold">Coût réel après impôt</span>
+									<span className="font-bold text-xl" data-testid="cost-after-tax">
+										{costAfterTax} &euro;
+									</span>
+								</div>
+							</div>
+
+							{/* Demo CTA */}
+							<button
+								type="button"
+								className="new-hp-widget-demo__cta"
+								disabled
+								aria-disabled="true"
+							>
+								<span>Donner {activeAmount > 0 ? `${activeAmount} €` : ''}</span>
+								<span className="new-hp-widget-demo__cta-badge">Mode démo</span>
+							</button>
+
+							<p className="new-hp-widget-demo__disclaimer">
+								Ceci est une démonstration. Aucun paiement ne sera effectué.
+							</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+	);
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
@@ -1,6 +1,7 @@
 import NewHpHero from './NewHpHero';
 import NewHpReassurance from './NewHpReassurance';
 import NewHpWhyDonaction from './NewHpWhyDonaction';
+import NewHpWidgetDemo from './NewHpWidgetDemo';
 
 export default function NewHomepageContent() {
 	return (
@@ -8,6 +9,7 @@ export default function NewHomepageContent() {
 			<NewHpHero />
 			<NewHpReassurance />
 			<NewHpWhyDonaction />
+			<NewHpWidgetDemo />
 		</main>
 	);
 }


### PR DESCRIPTION
## Summary
- Add NewHpWidgetDemo component for /new-hp page
- Interactive donation widget demo with real-time fiscal calculation
- 66% tax deduction display for individuals
- Demo mode (payment blocked)

## Changes
- New `NewHpWidgetDemo/` component folder:
  - `index.tsx` - Client component with amount selection + fiscal calculation
  - `index.scss` - Responsive styles with hover effects
  - `NewHpWidgetDemo.test.tsx` - Comprehensive test suite (20 tests)
- Updated `newHomepage/index.tsx` to include the new section

## Features
- Preset amounts: 10€, 25€, 50€, 100€
- Custom amount input (numeric only)
- Real-time fiscal calculation:
  - Tax savings (66%)
  - Cost after deduction
- Disabled CTA with "Demo mode" badge
- Accessible: ARIA labels, live regions, keyboard support

## Test plan
- [x] Unit tests pass (20 tests)
- [x] TypeScript compiles without errors
- [x] Production build succeeds
- [ ] Visual verification on /new-hp

Closes #107