### PR TITLE
feat(frontend): implement NewHpHero component (#104)

### DIFF
--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/HeroIllustration.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/HeroIllustration.tsx
@@ -1,0 +1,108 @@
+/**
+ * Donation-themed illustration for NewHpHero section
+ * Shows hands holding heart with floating hearts and coins
+ */
+export default function HeroIllustration() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="w-full max-w-[420px] h-auto"
+      viewBox="0 0 420 360"
+    >
+      {/* Background Circle */}
+      <circle cx="210" cy="180" r="160" fill="#f8faf9" />
+      <circle cx="210" cy="180" r="140" fill="#f0f7f4" />
+
+      {/* Floating Hearts */}
+      <g className="new-hp-hero__float-slow">
+        <path
+          d="M120 100 C120 85 135 75 150 85 C165 75 180 85 180 100 C180 120 150 145 150 145 C150 145 120 120 120 100Z"
+          fill="#fb9289"
+          opacity="0.8"
+        />
+      </g>
+      <g className="new-hp-hero__float-medium">
+        <path
+          d="M300 80 C300 68 312 60 324 68 C336 60 348 68 348 80 C348 95 324 115 324 115 C324 115 300 95 300 80Z"
+          fill="#73cfa8"
+          opacity="0.6"
+        />
+      </g>
+      <g className="new-hp-hero__float-fast">
+        <path
+          d="M80 200 C80 190 90 183 100 190 C110 183 120 190 120 200 C120 212 100 228 100 228 C100 228 80 212 80 200Z"
+          fill="#fb9289"
+          opacity="0.5"
+        />
+      </g>
+
+      {/* Central Hands with Heart */}
+      <g transform="translate(130, 120)">
+        {/* Left Hand */}
+        <path
+          d="M40 100 C20 100 10 80 15 60 C20 40 35 35 50 40 L60 45 L60 120 C60 130 50 140 40 140 C30 140 20 130 20 120 L20 100 Z"
+          fill="#fcd9b6"
+          stroke="#e8c9a0"
+          strokeWidth="2"
+        />
+        {/* Right Hand */}
+        <path
+          d="M120 100 C140 100 150 80 145 60 C140 40 125 35 110 40 L100 45 L100 120 C100 130 110 140 120 140 C130 140 140 130 140 120 L140 100 Z"
+          fill="#fcd9b6"
+          stroke="#e8c9a0"
+          strokeWidth="2"
+        />
+        {/* Heart in Hands */}
+        <path
+          d="M80 50 C80 30 95 15 110 30 C125 15 140 30 140 50 C140 80 110 110 110 110 C110 110 80 80 80 50Z"
+          fill="#fb9289"
+          stroke="#e07a72"
+          strokeWidth="2"
+        />
+        {/* Heart Shine */}
+        <ellipse cx="95" cy="45" rx="8" ry="6" fill="white" opacity="0.4" />
+      </g>
+
+      {/* Floating Coins */}
+      <g className="new-hp-hero__float-medium">
+        <ellipse cx="320" cy="220" rx="25" ry="8" fill="#d4a853" />
+        <ellipse cx="320" cy="215" rx="25" ry="8" fill="#f4c663" />
+        <text
+          x="320"
+          y="219"
+          textAnchor="middle"
+          fontSize="12"
+          fill="#b8923d"
+          fontWeight="bold"
+        >
+          €
+        </text>
+      </g>
+      <g className="new-hp-hero__float-slow">
+        <ellipse cx="340" cy="250" rx="20" ry="6" fill="#d4a853" />
+        <ellipse cx="340" cy="246" rx="20" ry="6" fill="#f4c663" />
+        <text
+          x="340"
+          y="250"
+          textAnchor="middle"
+          fontSize="10"
+          fill="#b8923d"
+          fontWeight="bold"
+        >
+          €
+        </text>
+      </g>
+
+      {/* Decorative Elements */}
+      <circle cx="70" cy="280" r="6" fill="#73cfa8" opacity="0.4" />
+      <circle cx="350" cy="140" r="8" fill="#73cfa8" opacity="0.3" />
+      <circle cx="90" cy="140" r="4" fill="#fb9289" opacity="0.4" />
+
+      {/* Sparkles */}
+      <g fill="#73cfa8" opacity="0.6">
+        <path d="M280 160 L283 167 L290 167 L284 172 L286 180 L280 175 L274 180 L276 172 L270 167 L277 167 Z" />
+        <path d="M150 260 L152 265 L157 265 L153 268 L154 273 L150 270 L146 273 L147 268 L143 265 L148 265 Z" />
+      </g>
+    </svg>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/NewHpHero.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/NewHpHero.test.tsx
@@ -97,4 +97,12 @@ describe('NewHpHero', () => {
     const buttonContainer = container.querySelector('.flex-col.sm\\:flex-row');
     expect(buttonContainer).toBeInTheDocument();
   });
+
+  it('renders all three trust indicators', () => {
+    render(<NewHpHero />);
+
+    expect(screen.getByText(/100% Gratuit/i)).toBeInTheDocument();
+    expect(screen.getByText(/Reçu fiscal/i)).toBeInTheDocument();
+    expect(screen.getByText(/Sécurisé/i)).toBeInTheDocument();
+  });
 });

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.scss
@@ -1,0 +1,149 @@
+.new-hp-hero {
+  background: linear-gradient(180deg, #ffffff 0%, #f9fafb 50%, #f3f4f6 100%);
+
+  // Subtle dot pattern overlay
+  &__pattern {
+    background-image: radial-gradient(circle, #e5e7eb 1px, transparent 1px);
+    background-size: 24px 24px;
+    opacity: 0.5;
+  }
+
+  // Illustration container with subtle entrance
+  &__illustration {
+    animation: illustration-entrance 0.8s ease-out;
+  }
+
+  // Float animations for SVG elements
+  &__float-slow {
+    animation: float-slow 6s ease-in-out infinite;
+    transform-origin: center;
+  }
+
+  &__float-medium {
+    animation: float-medium 4s ease-in-out infinite;
+    transform-origin: center;
+  }
+
+  &__float-fast {
+    animation: float-fast 3s ease-in-out infinite;
+    transform-origin: center;
+  }
+
+  // Scroll indicator
+  &__scroll-indicator {
+    color: #9ca3af;
+    transition: color 0.3s ease;
+    cursor: pointer;
+    animation: fade-in 1s ease-out 0.5s both;
+
+    &:hover {
+      color: #374151;
+    }
+  }
+
+  &__scroll-dot {
+    animation: scroll-bounce 2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+  }
+}
+
+// Keyframe animations
+@keyframes illustration-entrance {
+  0% {
+    opacity: 0;
+    transform: translateY(20px) scale(0.95);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes float-slow {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-12px);
+  }
+}
+
+@keyframes float-medium {
+  0%,
+  100% {
+    transform: translateY(0) rotate(0deg);
+  }
+  50% {
+    transform: translateY(-8px) rotate(2deg);
+  }
+}
+
+@keyframes float-fast {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+@keyframes scroll-bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  50% {
+    transform: translateY(14px);
+    opacity: 0.3;
+  }
+}
+
+@keyframes fade-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+// Responsive adjustments
+@media (max-width: 1023px) {
+  .new-hp-hero {
+    &__illustration {
+      order: -1;
+      margin-bottom: 1rem;
+
+      svg {
+        max-width: 320px;
+      }
+    }
+  }
+}
+
+@media (max-width: 639px) {
+  .new-hp-hero {
+    &__pattern {
+      background-size: 20px 20px;
+    }
+
+    &__illustration svg {
+      max-width: 280px;
+    }
+  }
+}
+
+// Reduced motion preference
+@media (prefers-reduced-motion: reduce) {
+  .new-hp-hero {
+    &__illustration,
+    &__float-slow,
+    &__float-medium,
+    &__float-fast,
+    &__scroll-dot {
+      animation: none;
+    }
+  }
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.scss
@@ -29,16 +29,10 @@
     transform-origin: center;
   }
 
-  // Scroll indicator
+  // Scroll indicator (decorative, no interaction)
   &__scroll-indicator {
     color: #9ca3af;
-    transition: color 0.3s ease;
-    cursor: pointer;
     animation: fade-in 1s ease-out 0.5s both;
-
-    &:hover {
-      color: #374151;
-    }
   }
 
   &__scroll-dot {

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.tsx
@@ -1,0 +1,180 @@
+import Link from 'next/link';
+import './index.scss';
+
+export default function NewHpHero() {
+  return (
+    <section className="new-hp-hero min-h-[80vh] w-full relative flex items-center overflow-hidden">
+      {/* Background Pattern */}
+      <div className="new-hp-hero__pattern absolute inset-0 pointer-events-none" />
+
+      <div className="flex flex-col lg:flex-row items-center justify-between w-full max-w-[1320px] mx-auto px-6 gap-12 relative z-10">
+        {/* Text Content - 60% */}
+        <div className="lg:w-[60%] flex flex-col gap-6 text-center lg:text-left">
+          <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-black leading-[1.1] tracking-tight">
+            Transformez vos idées en{' '}
+            <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#73cfa8] to-[#5bb892]">
+              actions solidaires
+            </span>
+          </h1>
+
+          <p className="text-lg md:text-xl text-gray-600 leading-relaxed max-w-[540px] mx-auto lg:mx-0">
+            Créez des collectes de dons pour votre association et mobilisez votre
+            communauté autour de vos projets. Simple, transparent et efficace.
+          </p>
+
+          {/* CTA Buttons */}
+          <div className="flex flex-col sm:flex-row gap-4 mt-4 justify-center lg:justify-start">
+            <Link href="/new-club" className="btn btn-primary">
+              Créer mon club
+            </Link>
+            <Link href="/projets" className="btn btn-outline-primary">
+              Voir les projets
+            </Link>
+          </div>
+
+          {/* Trust Indicators */}
+          <div className="flex items-center gap-6 mt-4 text-sm text-gray-500 justify-center lg:justify-start">
+            <span className="flex items-center gap-2">
+              <svg className="w-4 h-4 text-[#73cfa8]" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+              </svg>
+              100% Gratuit
+            </span>
+            <span className="flex items-center gap-2">
+              <svg className="w-4 h-4 text-[#73cfa8]" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+              </svg>
+              Reçu fiscal
+            </span>
+            <span className="flex items-center gap-2">
+              <svg className="w-4 h-4 text-[#73cfa8]" fill="currentColor" viewBox="0 0 20 20">
+                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+              </svg>
+              Sécurisé
+            </span>
+          </div>
+        </div>
+
+        {/* Illustration - 40% */}
+        <div className="lg:w-[40%] flex items-center justify-center">
+          <div className="new-hp-hero__illustration relative">
+            <svg
+              aria-hidden="true"
+              className="w-full max-w-[420px] h-auto"
+              viewBox="0 0 420 360"
+            >
+              {/* Background Circle */}
+              <circle cx="210" cy="180" r="160" fill="#f8faf9" />
+              <circle cx="210" cy="180" r="140" fill="#f0f7f4" />
+
+              {/* Floating Hearts */}
+              <g className="new-hp-hero__float-slow">
+                <path
+                  d="M120 100 C120 85 135 75 150 85 C165 75 180 85 180 100 C180 120 150 145 150 145 C150 145 120 120 120 100Z"
+                  fill="#fb9289"
+                  opacity="0.8"
+                />
+              </g>
+              <g className="new-hp-hero__float-medium">
+                <path
+                  d="M300 80 C300 68 312 60 324 68 C336 60 348 68 348 80 C348 95 324 115 324 115 C324 115 300 95 300 80Z"
+                  fill="#73cfa8"
+                  opacity="0.6"
+                />
+              </g>
+              <g className="new-hp-hero__float-fast">
+                <path
+                  d="M80 200 C80 190 90 183 100 190 C110 183 120 190 120 200 C120 212 100 228 100 228 C100 228 80 212 80 200Z"
+                  fill="#fb9289"
+                  opacity="0.5"
+                />
+              </g>
+
+              {/* Central Hands with Heart */}
+              <g transform="translate(130, 120)">
+                {/* Left Hand */}
+                <path
+                  d="M40 100 C20 100 10 80 15 60 C20 40 35 35 50 40 L60 45 L60 120 C60 130 50 140 40 140 C30 140 20 130 20 120 L20 100 Z"
+                  fill="#fcd9b6"
+                  stroke="#e8c9a0"
+                  strokeWidth="2"
+                />
+                {/* Right Hand */}
+                <path
+                  d="M120 100 C140 100 150 80 145 60 C140 40 125 35 110 40 L100 45 L100 120 C100 130 110 140 120 140 C130 140 140 130 140 120 L140 100 Z"
+                  fill="#fcd9b6"
+                  stroke="#e8c9a0"
+                  strokeWidth="2"
+                />
+                {/* Heart in Hands */}
+                <path
+                  d="M80 50 C80 30 95 15 110 30 C125 15 140 30 140 50 C140 80 110 110 110 110 C110 110 80 80 80 50Z"
+                  fill="#fb9289"
+                  stroke="#e07a72"
+                  strokeWidth="2"
+                />
+                {/* Heart Shine */}
+                <ellipse cx="95" cy="45" rx="8" ry="6" fill="white" opacity="0.4" />
+              </g>
+
+              {/* Floating Coins */}
+              <g className="new-hp-hero__float-medium">
+                <ellipse cx="320" cy="220" rx="25" ry="8" fill="#d4a853" />
+                <ellipse cx="320" cy="215" rx="25" ry="8" fill="#f4c663" />
+                <text x="320" y="219" textAnchor="middle" fontSize="12" fill="#b8923d" fontWeight="bold">€</text>
+              </g>
+              <g className="new-hp-hero__float-slow">
+                <ellipse cx="340" cy="250" rx="20" ry="6" fill="#d4a853" />
+                <ellipse cx="340" cy="246" rx="20" ry="6" fill="#f4c663" />
+                <text x="340" y="250" textAnchor="middle" fontSize="10" fill="#b8923d" fontWeight="bold">€</text>
+              </g>
+
+              {/* Decorative Elements */}
+              <circle cx="70" cy="280" r="6" fill="#73cfa8" opacity="0.4" />
+              <circle cx="350" cy="140" r="8" fill="#73cfa8" opacity="0.3" />
+              <circle cx="90" cy="140" r="4" fill="#fb9289" opacity="0.4" />
+
+              {/* Sparkles */}
+              <g fill="#73cfa8" opacity="0.6">
+                <path d="M280 160 L283 167 L290 167 L284 172 L286 180 L280 175 L274 180 L276 172 L270 167 L277 167 Z" />
+                <path d="M150 260 L152 265 L157 265 L153 268 L154 273 L150 270 L146 273 L147 268 L143 265 L148 265 Z" />
+              </g>
+            </svg>
+          </div>
+        </div>
+      </div>
+
+      {/* Scroll Indicator */}
+      <div
+        role="img"
+        aria-label="Défiler vers le bas"
+        className="new-hp-hero__scroll-indicator absolute bottom-8 left-1/2 -translate-x-1/2"
+      >
+        <svg
+          width="28"
+          height="44"
+          viewBox="0 0 28 44"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            x="1"
+            y="1"
+            width="26"
+            height="42"
+            rx="13"
+            stroke="currentColor"
+            strokeWidth="2"
+          />
+          <circle
+            className="new-hp-hero__scroll-dot"
+            cx="14"
+            cy="14"
+            r="5"
+            fill="currentColor"
+          />
+        </svg>
+      </div>
+    </section>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.tsx
@@ -1,5 +1,24 @@
 import Link from 'next/link';
+import HeroIllustration from './HeroIllustration';
 import './index.scss';
+
+const TRUST_INDICATORS = ['100% Gratuit', 'Reçu fiscal', 'Sécurisé'] as const;
+
+function CheckmarkIcon() {
+  return (
+    <svg
+      className="w-4 h-4 text-[#73cfa8]"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path
+        fillRule="evenodd"
+        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
 
 export default function NewHpHero() {
   return (
@@ -18,8 +37,9 @@ export default function NewHpHero() {
           </h1>
 
           <p className="text-lg md:text-xl text-gray-600 leading-relaxed max-w-[540px] mx-auto lg:mx-0">
-            Créez des collectes de dons pour votre association et mobilisez votre
-            communauté autour de vos projets. Simple, transparent et efficace.
+            Créez des collectes de dons pour votre association et mobilisez
+            votre communauté autour de vos projets. Simple, transparent et
+            efficace.
           </p>
 
           {/* CTA Buttons */}
@@ -34,112 +54,19 @@ export default function NewHpHero() {
 
           {/* Trust Indicators */}
           <div className="flex items-center gap-6 mt-4 text-sm text-gray-500 justify-center lg:justify-start">
-            <span className="flex items-center gap-2">
-              <svg className="w-4 h-4 text-[#73cfa8]" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-              </svg>
-              100% Gratuit
-            </span>
-            <span className="flex items-center gap-2">
-              <svg className="w-4 h-4 text-[#73cfa8]" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-              </svg>
-              Reçu fiscal
-            </span>
-            <span className="flex items-center gap-2">
-              <svg className="w-4 h-4 text-[#73cfa8]" fill="currentColor" viewBox="0 0 20 20">
-                <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-              </svg>
-              Sécurisé
-            </span>
+            {TRUST_INDICATORS.map((text) => (
+              <span key={text} className="flex items-center gap-2">
+                <CheckmarkIcon />
+                {text}
+              </span>
+            ))}
           </div>
         </div>
 
         {/* Illustration - 40% */}
         <div className="lg:w-[40%] flex items-center justify-center">
           <div className="new-hp-hero__illustration relative">
-            <svg
-              aria-hidden="true"
-              className="w-full max-w-[420px] h-auto"
-              viewBox="0 0 420 360"
-            >
-              {/* Background Circle */}
-              <circle cx="210" cy="180" r="160" fill="#f8faf9" />
-              <circle cx="210" cy="180" r="140" fill="#f0f7f4" />
-
-              {/* Floating Hearts */}
-              <g className="new-hp-hero__float-slow">
-                <path
-                  d="M120 100 C120 85 135 75 150 85 C165 75 180 85 180 100 C180 120 150 145 150 145 C150 145 120 120 120 100Z"
-                  fill="#fb9289"
-                  opacity="0.8"
-                />
-              </g>
-              <g className="new-hp-hero__float-medium">
-                <path
-                  d="M300 80 C300 68 312 60 324 68 C336 60 348 68 348 80 C348 95 324 115 324 115 C324 115 300 95 300 80Z"
-                  fill="#73cfa8"
-                  opacity="0.6"
-                />
-              </g>
-              <g className="new-hp-hero__float-fast">
-                <path
-                  d="M80 200 C80 190 90 183 100 190 C110 183 120 190 120 200 C120 212 100 228 100 228 C100 228 80 212 80 200Z"
-                  fill="#fb9289"
-                  opacity="0.5"
-                />
-              </g>
-
-              {/* Central Hands with Heart */}
-              <g transform="translate(130, 120)">
-                {/* Left Hand */}
-                <path
-                  d="M40 100 C20 100 10 80 15 60 C20 40 35 35 50 40 L60 45 L60 120 C60 130 50 140 40 140 C30 140 20 130 20 120 L20 100 Z"
-                  fill="#fcd9b6"
-                  stroke="#e8c9a0"
-                  strokeWidth="2"
-                />
-                {/* Right Hand */}
-                <path
-                  d="M120 100 C140 100 150 80 145 60 C140 40 125 35 110 40 L100 45 L100 120 C100 130 110 140 120 140 C130 140 140 130 140 120 L140 100 Z"
-                  fill="#fcd9b6"
-                  stroke="#e8c9a0"
-                  strokeWidth="2"
-                />
-                {/* Heart in Hands */}
-                <path
-                  d="M80 50 C80 30 95 15 110 30 C125 15 140 30 140 50 C140 80 110 110 110 110 C110 110 80 80 80 50Z"
-                  fill="#fb9289"
-                  stroke="#e07a72"
-                  strokeWidth="2"
-                />
-                {/* Heart Shine */}
-                <ellipse cx="95" cy="45" rx="8" ry="6" fill="white" opacity="0.4" />
-              </g>
-
-              {/* Floating Coins */}
-              <g className="new-hp-hero__float-medium">
-                <ellipse cx="320" cy="220" rx="25" ry="8" fill="#d4a853" />
-                <ellipse cx="320" cy="215" rx="25" ry="8" fill="#f4c663" />
-                <text x="320" y="219" textAnchor="middle" fontSize="12" fill="#b8923d" fontWeight="bold">€</text>
-              </g>
-              <g className="new-hp-hero__float-slow">
-                <ellipse cx="340" cy="250" rx="20" ry="6" fill="#d4a853" />
-                <ellipse cx="340" cy="246" rx="20" ry="6" fill="#f4c663" />
-                <text x="340" y="250" textAnchor="middle" fontSize="10" fill="#b8923d" fontWeight="bold">€</text>
-              </g>
-
-              {/* Decorative Elements */}
-              <circle cx="70" cy="280" r="6" fill="#73cfa8" opacity="0.4" />
-              <circle cx="350" cy="140" r="8" fill="#73cfa8" opacity="0.3" />
-              <circle cx="90" cy="140" r="4" fill="#fb9289" opacity="0.4" />
-
-              {/* Sparkles */}
-              <g fill="#73cfa8" opacity="0.6">
-                <path d="M280 160 L283 167 L290 167 L284 172 L286 180 L280 175 L274 180 L276 172 L270 167 L277 167 Z" />
-                <path d="M150 260 L152 265 L157 265 L153 268 L154 273 L150 270 L146 273 L147 268 L143 265 L148 265 Z" />
-              </g>
-            </svg>
+            <HeroIllustration />
           </div>
         </div>
       </div>

--- a/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
@@ -1,8 +1,9 @@
+import NewHpHero from './NewHpHero';
+
 export default function NewHomepageContent() {
   return (
-    <main className="flex flex-col items-center justify-center gap-16 text-black w-full min-h-[25rem]">
-      <h1 className="text-3xl font-semibold">New Homepage</h1>
-      <p>Content coming soon...</p>
+    <main className="flex flex-col items-center justify-center text-black w-full">
+      <NewHpHero />
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Implements the NewHpHero section for the new homepage (`/new-hp` route).

**Features:**
- 60/40 text/illustration layout as specified
- Donation-themed SVG illustration with hands holding heart, floating hearts, and euro coins
- Dual CTAs: Primary → `/new-club`, Secondary → `/projets`
- Animated scroll indicator
- Subtle dot pattern background texture
- Trust indicators (100% Gratuit, Reçu fiscal, Sécurisé)
- Float animations on illustration elements
- Prefers-reduced-motion accessibility support

## Test plan

- [x] All 8 existing tests pass
- [x] Visual verification on desktop
- [x] No console errors
- [x] Server Component (no 'use client')

Closes #104