### PR TITLE
feat(frontend): implement NewHpReassurance trust badges component (#105)

### DIFF
--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/NewHpReassurance.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/NewHpReassurance.test.tsx
@@ -6,35 +6,48 @@ describe('NewHpReassurance', () => {
   it('renders all 4 trust badges', () => {
     render(<NewHpReassurance />);
 
-    expect(screen.getByText('Paiement sécurisé')).toBeInTheDocument();
-    expect(screen.getByText('Reçu fiscal')).toBeInTheDocument();
-    expect(screen.getByText('Conforme')).toBeInTheDocument();
-    expect(screen.getByText('Activation')).toBeInTheDocument();
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(4);
+
+    // Test structure rather than exact text (i18n-friendly)
+    expect(items[0]).toHaveTextContent(/paiement|payment/i);
+    expect(items[1]).toHaveTextContent(/fiscal|cerfa/i);
+    expect(items[2]).toHaveTextContent(/rgpd|conforme/i);
+    expect(items[3]).toHaveTextContent(/activation|min/i);
   });
 
-  it('renders badge subtitles', () => {
+  it('renders badge subtitles with key terms', () => {
     render(<NewHpReassurance />);
 
-    expect(screen.getByText('Stripe')).toBeInTheDocument();
-    expect(screen.getByText('Cerfa')).toBeInTheDocument();
-    expect(screen.getByText('RGPD')).toBeInTheDocument();
-    expect(screen.getByText('en 5 min')).toBeInTheDocument();
+    const items = screen.getAllByRole('listitem');
+
+    // Check for key terms that identify each badge
+    expect(items[0]).toHaveTextContent(/stripe/i);
+    expect(items[1]).toHaveTextContent(/cerfa/i);
+    expect(items[2]).toHaveTextContent(/rgpd/i);
+    expect(items[3]).toHaveTextContent(/5\s*min/i);
   });
 
   it('renders as a section with proper accessibility', () => {
     render(<NewHpReassurance />);
 
-    const list = screen.getByRole('list', { name: /garanties et avantages/i });
+    const list = screen.getByRole('list');
     expect(list).toBeInTheDocument();
+    expect(list).toHaveAttribute('aria-label');
 
     const items = screen.getAllByRole('listitem');
     expect(items).toHaveLength(4);
   });
 
-  it('renders SVG icons for each badge', () => {
+  it('renders SVG icons for each badge with aria-hidden', () => {
     const { container } = render(<NewHpReassurance />);
 
     const svgIcons = container.querySelectorAll('svg');
-    expect(svgIcons.length).toBe(4);
+    expect(svgIcons).toHaveLength(4);
+
+    // All icons should be decorative (aria-hidden)
+    svgIcons.forEach((svg) => {
+      expect(svg).toHaveAttribute('aria-hidden', 'true');
+    });
   });
 });

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/NewHpReassurance.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/NewHpReassurance.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import NewHpReassurance from './index';
+
+describe('NewHpReassurance', () => {
+  it('renders all 4 trust badges', () => {
+    render(<NewHpReassurance />);
+
+    expect(screen.getByText('Paiement sécurisé')).toBeInTheDocument();
+    expect(screen.getByText('Reçu fiscal')).toBeInTheDocument();
+    expect(screen.getByText('Conforme')).toBeInTheDocument();
+    expect(screen.getByText('Activation')).toBeInTheDocument();
+  });
+
+  it('renders badge subtitles', () => {
+    render(<NewHpReassurance />);
+
+    expect(screen.getByText('Stripe')).toBeInTheDocument();
+    expect(screen.getByText('Cerfa')).toBeInTheDocument();
+    expect(screen.getByText('RGPD')).toBeInTheDocument();
+    expect(screen.getByText('en 5 min')).toBeInTheDocument();
+  });
+
+  it('renders as a section with proper accessibility', () => {
+    render(<NewHpReassurance />);
+
+    const list = screen.getByRole('list', { name: /garanties et avantages/i });
+    expect(list).toBeInTheDocument();
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(4);
+  });
+
+  it('renders SVG icons for each badge', () => {
+    const { container } = render(<NewHpReassurance />);
+
+    const svgIcons = container.querySelectorAll('svg');
+    expect(svgIcons.length).toBe(4);
+  });
+});

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/CerfaDocIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/CerfaDocIcon.tsx
@@ -1,0 +1,64 @@
+export default function CerfaDocIcon({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="48"
+      height="48"
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {/* Document background */}
+      <path
+        d="M12 6C12 4.89543 12.8954 4 14 4H28L38 14V42C38 43.1046 37.1046 44 36 44H14C12.8954 44 12 43.1046 12 42V6Z"
+        fill="url(#docGradient)"
+        opacity="0.15"
+      />
+      {/* Document outline */}
+      <path
+        d="M12 6C12 4.89543 12.8954 4 14 4H28L38 14V42C38 43.1046 37.1046 44 36 44H14C12.8954 44 12 43.1046 12 42V6Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+      {/* Folded corner */}
+      <path
+        d="M28 4V12C28 13.1046 28.8954 14 30 14H38"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Text lines */}
+      <path d="M17 22H33" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <path d="M17 28H29" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      {/* Official stamp/seal */}
+      <circle
+        cx="30"
+        cy="36"
+        r="6"
+        stroke="#73cfa8"
+        strokeWidth="2"
+        fill="none"
+        className="stamp"
+      />
+      <path
+        d="M27.5 36L29.5 38L33 34"
+        stroke="#73cfa8"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="stamp-check"
+      />
+
+      <defs>
+        <linearGradient id="docGradient" x1="25" y1="4" x2="25" y2="44" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#73cfa8" />
+          <stop offset="1" stopColor="#5bb892" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/CerfaDocIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/CerfaDocIcon.tsx
@@ -1,4 +1,8 @@
+import { useId } from 'react';
+
 export default function CerfaDocIcon({ className = '' }: { className?: string }) {
+  const gradientId = useId();
+
   return (
     <svg
       className={className}
@@ -7,11 +11,12 @@ export default function CerfaDocIcon({ className = '' }: { className?: string })
       viewBox="0 0 48 48"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
     >
       {/* Document background */}
       <path
         d="M12 6C12 4.89543 12.8954 4 14 4H28L38 14V42C38 43.1046 37.1046 44 36 44H14C12.8954 44 12 43.1046 12 42V6Z"
-        fill="url(#docGradient)"
+        fill={`url(#${gradientId})`}
         opacity="0.15"
       />
       {/* Document outline */}
@@ -54,7 +59,7 @@ export default function CerfaDocIcon({ className = '' }: { className?: string })
       />
 
       <defs>
-        <linearGradient id="docGradient" x1="25" y1="4" x2="25" y2="44" gradientUnits="userSpaceOnUse">
+        <linearGradient id={gradientId} x1="25" y1="4" x2="25" y2="44" gradientUnits="userSpaceOnUse">
           <stop stopColor="#73cfa8" />
           <stop offset="1" stopColor="#5bb892" />
         </linearGradient>

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/RgpdShieldIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/RgpdShieldIcon.tsx
@@ -1,4 +1,8 @@
+import { useId } from 'react';
+
 export default function RgpdShieldIcon({ className = '' }: { className?: string }) {
+  const gradientId = useId();
+
   return (
     <svg
       className={className}
@@ -7,6 +11,7 @@ export default function RgpdShieldIcon({ className = '' }: { className?: string 
       viewBox="0 0 48 48"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
     >
       {/* Shield shape */}
       <path
@@ -20,7 +25,7 @@ export default function RgpdShieldIcon({ className = '' }: { className?: string 
       {/* Shield fill */}
       <path
         d="M24 6L8 13V22C8 32.02 14.94 41.22 24 43.82C33.06 41.22 40 32.02 40 22V13L24 6Z"
-        fill="url(#rgpdGradient)"
+        fill={`url(#${gradientId})`}
         opacity="0.15"
       />
       {/* EU-inspired star circle */}
@@ -60,7 +65,7 @@ export default function RgpdShieldIcon({ className = '' }: { className?: string 
       />
 
       <defs>
-        <linearGradient id="rgpdGradient" x1="24" y1="6" x2="24" y2="44" gradientUnits="userSpaceOnUse">
+        <linearGradient id={gradientId} x1="24" y1="6" x2="24" y2="44" gradientUnits="userSpaceOnUse">
           <stop stopColor="#73cfa8" />
           <stop offset="1" stopColor="#5bb892" />
         </linearGradient>

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/RgpdShieldIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/RgpdShieldIcon.tsx
@@ -1,0 +1,70 @@
+export default function RgpdShieldIcon({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="48"
+      height="48"
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {/* Shield shape */}
+      <path
+        d="M24 4L6 12V22C6 33.1 13.68 43.32 24 46C34.32 43.32 42 33.1 42 22V12L24 4Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+      {/* Shield fill */}
+      <path
+        d="M24 6L8 13V22C8 32.02 14.94 41.22 24 43.82C33.06 41.22 40 32.02 40 22V13L24 6Z"
+        fill="url(#rgpdGradient)"
+        opacity="0.15"
+      />
+      {/* EU-inspired star circle */}
+      <circle
+        cx="24"
+        cy="24"
+        r="10"
+        stroke="#73cfa8"
+        strokeWidth="1.5"
+        fill="none"
+        className="eu-circle"
+      />
+      {/* Stars arrangement (simplified EU flag motif) */}
+      {[0, 60, 120, 180, 240, 300].map((angle, i) => {
+        const rad = (angle * Math.PI) / 180;
+        const x = 24 + 7 * Math.cos(rad - Math.PI / 2);
+        const y = 24 + 7 * Math.sin(rad - Math.PI / 2);
+        return (
+          <circle
+            key={i}
+            cx={x}
+            cy={y}
+            r="1.5"
+            fill="#73cfa8"
+            className="eu-star"
+          />
+        );
+      })}
+      {/* Center privacy icon (user silhouette) */}
+      <circle cx="24" cy="22" r="3" stroke="currentColor" strokeWidth="1.5" fill="none" />
+      <path
+        d="M19 30C19 27.2386 21.2386 25 24 25C26.7614 25 29 27.2386 29 30"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        fill="none"
+      />
+
+      <defs>
+        <linearGradient id="rgpdGradient" x1="24" y1="6" x2="24" y2="44" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#73cfa8" />
+          <stop offset="1" stopColor="#5bb892" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/ShieldLockIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/ShieldLockIcon.tsx
@@ -1,4 +1,8 @@
+import { useId } from 'react';
+
 export default function ShieldLockIcon({ className = '' }: { className?: string }) {
+  const gradientId = useId();
+
   return (
     <svg
       className={className}
@@ -7,6 +11,7 @@ export default function ShieldLockIcon({ className = '' }: { className?: string 
       viewBox="0 0 48 48"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
     >
       {/* Shield shape */}
       <path
@@ -21,7 +26,7 @@ export default function ShieldLockIcon({ className = '' }: { className?: string 
       {/* Shield fill gradient */}
       <path
         d="M24 6L8 13V22C8 32.02 14.94 41.22 24 43.82C33.06 41.22 40 32.02 40 22V13L24 6Z"
-        fill="url(#shieldGradient)"
+        fill={`url(#${gradientId})`}
         opacity="0.15"
       />
       {/* Lock body */}
@@ -47,7 +52,7 @@ export default function ShieldLockIcon({ className = '' }: { className?: string 
       <path d="M24 27.5V29.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
 
       <defs>
-        <linearGradient id="shieldGradient" x1="24" y1="6" x2="24" y2="44" gradientUnits="userSpaceOnUse">
+        <linearGradient id={gradientId} x1="24" y1="6" x2="24" y2="44" gradientUnits="userSpaceOnUse">
           <stop stopColor="#73cfa8" />
           <stop offset="1" stopColor="#5bb892" />
         </linearGradient>

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/ShieldLockIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/ShieldLockIcon.tsx
@@ -1,0 +1,57 @@
+export default function ShieldLockIcon({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="48"
+      height="48"
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {/* Shield shape */}
+      <path
+        d="M24 4L6 12V22C6 33.1 13.68 43.32 24 46C34.32 43.32 42 33.1 42 22V12L24 4Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+        className="shield-outline"
+      />
+      {/* Shield fill gradient */}
+      <path
+        d="M24 6L8 13V22C8 32.02 14.94 41.22 24 43.82C33.06 41.22 40 32.02 40 22V13L24 6Z"
+        fill="url(#shieldGradient)"
+        opacity="0.15"
+      />
+      {/* Lock body */}
+      <rect
+        x="18"
+        y="22"
+        width="12"
+        height="10"
+        rx="2"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+      />
+      {/* Lock shackle */}
+      <path
+        d="M21 22V18C21 16.3431 22.3431 15 24 15C25.6569 15 27 16.3431 27 18V22"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      {/* Lock keyhole */}
+      <circle cx="24" cy="26" r="1.5" fill="currentColor" />
+      <path d="M24 27.5V29.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+
+      <defs>
+        <linearGradient id="shieldGradient" x1="24" y1="6" x2="24" y2="44" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#73cfa8" />
+          <stop offset="1" stopColor="#5bb892" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/SpeedIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/SpeedIcon.tsx
@@ -1,0 +1,80 @@
+export default function SpeedIcon({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="48"
+      height="48"
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      {/* Stopwatch body */}
+      <circle
+        cx="24"
+        cy="26"
+        r="16"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+      />
+      {/* Fill */}
+      <circle
+        cx="24"
+        cy="26"
+        r="15"
+        fill="url(#speedGradient)"
+        opacity="0.15"
+      />
+      {/* Top button */}
+      <rect
+        x="22"
+        y="4"
+        width="4"
+        height="6"
+        rx="1"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+      />
+      {/* Side button */}
+      <path
+        d="M36 14L38 12"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+      />
+      {/* Clock face markers */}
+      <path d="M24 14V16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <path d="M24 36V38" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <path d="M12 26H14" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <path d="M34 26H36" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      {/* Clock hand pointing to ~5 minutes (1 o'clock position) */}
+      <path
+        d="M24 26L28 18"
+        stroke="#73cfa8"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        className="clock-hand"
+      />
+      {/* Center dot */}
+      <circle cx="24" cy="26" r="2" fill="#73cfa8" />
+      {/* Lightning bolt accent */}
+      <path
+        d="M18 24L21 21L19 26L22 26L19 31"
+        stroke="#73cfa8"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+        className="lightning"
+      />
+
+      <defs>
+        <linearGradient id="speedGradient" x1="24" y1="10" x2="24" y2="42" gradientUnits="userSpaceOnUse">
+          <stop stopColor="#73cfa8" />
+          <stop offset="1" stopColor="#5bb892" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/SpeedIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/icons/SpeedIcon.tsx
@@ -1,4 +1,8 @@
+import { useId } from 'react';
+
 export default function SpeedIcon({ className = '' }: { className?: string }) {
+  const gradientId = useId();
+
   return (
     <svg
       className={className}
@@ -7,6 +11,7 @@ export default function SpeedIcon({ className = '' }: { className?: string }) {
       viewBox="0 0 48 48"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
     >
       {/* Stopwatch body */}
       <circle
@@ -22,7 +27,7 @@ export default function SpeedIcon({ className = '' }: { className?: string }) {
         cx="24"
         cy="26"
         r="15"
-        fill="url(#speedGradient)"
+        fill={`url(#${gradientId})`}
         opacity="0.15"
       />
       {/* Top button */}
@@ -70,7 +75,7 @@ export default function SpeedIcon({ className = '' }: { className?: string }) {
       />
 
       <defs>
-        <linearGradient id="speedGradient" x1="24" y1="10" x2="24" y2="42" gradientUnits="userSpaceOnUse">
+        <linearGradient id={gradientId} x1="24" y1="10" x2="24" y2="42" gradientUnits="userSpaceOnUse">
           <stop stopColor="#73cfa8" />
           <stop offset="1" stopColor="#5bb892" />
         </linearGradient>

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/index.scss
@@ -1,3 +1,11 @@
+// Animation timing variables
+$entrance-duration: 0.6s;
+$entrance-delay-base: 0.2s;
+$entrance-delay-step: 0.1s;
+$hover-duration: 0.3s;
+$shield-pulse-duration: 3s;
+$clock-tick-duration: 2s;
+
 .new-hp-reassurance {
   background: linear-gradient(180deg, #f3f4f6 0%, #f9fafb 50%, #ffffff 100%);
   position: relative;
@@ -25,8 +33,8 @@
 
   &__badge {
     opacity: 0;
-    animation: badge-entrance 0.6s ease-out forwards;
-    animation-delay: calc(var(--badge-index) * 0.1s + 0.2s);
+    animation: badge-entrance $entrance-duration ease-out forwards;
+    animation-delay: calc(var(--badge-index) * #{$entrance-delay-step} + #{$entrance-delay-base});
   }
 
   &__badge-content {
@@ -34,7 +42,11 @@
     border-radius: 12px;
     background: rgba(255, 255, 255, 0.7);
     border: 1px solid rgba(229, 231, 235, 0.8);
-    transition: all 0.3s ease;
+    transition:
+      transform $hover-duration ease,
+      background $hover-duration ease,
+      border-color $hover-duration ease,
+      box-shadow $hover-duration ease;
 
     &:hover {
       transform: translateY(-4px);
@@ -64,7 +76,7 @@
         transparent 70%
       );
       opacity: 0;
-      transition: opacity 0.3s ease;
+      transition: opacity $hover-duration ease;
     }
   }
 
@@ -75,7 +87,7 @@
   &__icon {
     width: 48px;
     height: 48px;
-    transition: transform 0.3s ease;
+    transition: transform $hover-duration ease;
   }
 
   &__badge-content:hover &__icon {
@@ -84,13 +96,13 @@
 
   // Shield pulse animation for security badge
   &__badge:first-child &__icon .shield-outline {
-    animation: shield-pulse 3s ease-in-out infinite;
+    animation: shield-pulse $shield-pulse-duration ease-in-out infinite;
   }
 
   // Clock hand tick animation for speed badge
   &__badge:last-child &__icon .clock-hand {
     transform-origin: 24px 26px;
-    animation: clock-tick 2s ease-in-out infinite;
+    animation: clock-tick $clock-tick-duration ease-in-out infinite;
   }
 }
 

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/index.scss
@@ -1,0 +1,176 @@
+.new-hp-reassurance {
+  background: linear-gradient(180deg, #f3f4f6 0%, #f9fafb 50%, #ffffff 100%);
+  position: relative;
+  overflow: hidden;
+
+  // Subtle top border
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 80%;
+    max-width: 800px;
+    height: 1px;
+    background: linear-gradient(
+      90deg,
+      transparent 0%,
+      #e5e7eb 20%,
+      #d1d5db 50%,
+      #e5e7eb 80%,
+      transparent 100%
+    );
+  }
+
+  &__badge {
+    opacity: 0;
+    animation: badge-entrance 0.6s ease-out forwards;
+    animation-delay: calc(var(--badge-index) * 0.1s + 0.2s);
+  }
+
+  &__badge-content {
+    padding: 1.5rem 1rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.7);
+    border: 1px solid rgba(229, 231, 235, 0.8);
+    transition: all 0.3s ease;
+
+    &:hover {
+      transform: translateY(-4px);
+      background: rgba(255, 255, 255, 0.95);
+      border-color: rgba(115, 207, 168, 0.3);
+      box-shadow:
+        0 8px 24px -8px rgba(115, 207, 168, 0.15),
+        0 4px 12px -4px rgba(0, 0, 0, 0.05);
+    }
+  }
+
+  &__icon-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    // Subtle glow on hover
+    &::after {
+      content: '';
+      position: absolute;
+      inset: -8px;
+      border-radius: 50%;
+      background: radial-gradient(
+        circle,
+        rgba(115, 207, 168, 0.15) 0%,
+        transparent 70%
+      );
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+  }
+
+  &__badge-content:hover &__icon-wrapper::after {
+    opacity: 1;
+  }
+
+  &__icon {
+    width: 48px;
+    height: 48px;
+    transition: transform 0.3s ease;
+  }
+
+  &__badge-content:hover &__icon {
+    transform: scale(1.05);
+  }
+
+  // Shield pulse animation for security badge
+  &__badge:first-child &__icon .shield-outline {
+    animation: shield-pulse 3s ease-in-out infinite;
+  }
+
+  // Clock hand tick animation for speed badge
+  &__badge:last-child &__icon .clock-hand {
+    transform-origin: 24px 26px;
+    animation: clock-tick 2s ease-in-out infinite;
+  }
+}
+
+// Keyframe animations
+@keyframes badge-entrance {
+  0% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes shield-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}
+
+@keyframes clock-tick {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  10% {
+    transform: rotate(6deg);
+  }
+  20% {
+    transform: rotate(0deg);
+  }
+}
+
+// Responsive adjustments
+@media (max-width: 1023px) {
+  .new-hp-reassurance {
+    &__badge-content {
+      padding: 1.25rem 0.75rem;
+    }
+
+    &__icon {
+      width: 40px;
+      height: 40px;
+    }
+  }
+}
+
+@media (max-width: 639px) {
+  .new-hp-reassurance {
+    &__badge-content {
+      padding: 1rem 0.5rem;
+    }
+
+    &__icon {
+      width: 36px;
+      height: 36px;
+    }
+  }
+}
+
+// Reduced motion preference
+@media (prefers-reduced-motion: reduce) {
+  .new-hp-reassurance {
+    &__badge {
+      animation: none;
+      opacity: 1;
+    }
+
+    &__badge-content {
+      transition: none;
+    }
+
+    &__badge:first-child &__icon .shield-outline,
+    &__badge:last-child &__icon .clock-hand {
+      animation: none;
+    }
+  }
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/index.tsx
@@ -1,0 +1,68 @@
+import ShieldLockIcon from './icons/ShieldLockIcon';
+import CerfaDocIcon from './icons/CerfaDocIcon';
+import RgpdShieldIcon from './icons/RgpdShieldIcon';
+import SpeedIcon from './icons/SpeedIcon';
+import './index.scss';
+
+const TRUST_BADGES = [
+  {
+    id: 'secure-payment',
+    Icon: ShieldLockIcon,
+    title: 'Paiement sécurisé',
+    subtitle: 'Stripe',
+  },
+  {
+    id: 'cerfa',
+    Icon: CerfaDocIcon,
+    title: 'Reçu fiscal',
+    subtitle: 'Cerfa',
+  },
+  {
+    id: 'rgpd',
+    Icon: RgpdShieldIcon,
+    title: 'Conforme',
+    subtitle: 'RGPD',
+  },
+  {
+    id: 'fast-setup',
+    Icon: SpeedIcon,
+    title: 'Activation',
+    subtitle: 'en 5 min',
+  },
+] as const;
+
+export default function NewHpReassurance() {
+  return (
+    <section className="new-hp-reassurance w-full py-12 md:py-16">
+      <div className="max-w-[1320px] mx-auto px-6">
+        <ul
+          className="new-hp-reassurance__grid grid grid-cols-2 lg:grid-cols-4 gap-6 md:gap-8"
+          role="list"
+          aria-label="Garanties et avantages"
+        >
+          {TRUST_BADGES.map((badge, index) => (
+            <li
+              key={badge.id}
+              className="new-hp-reassurance__badge"
+              style={{ '--badge-index': index } as React.CSSProperties}
+            >
+              <div className="new-hp-reassurance__badge-content flex flex-col items-center text-center gap-3">
+                <div className="new-hp-reassurance__icon-wrapper">
+                  <badge.Icon className="new-hp-reassurance__icon text-gray-700" />
+                </div>
+                <div className="flex flex-col gap-0.5">
+                  <span className="text-sm md:text-base font-semibold text-gray-800">
+                    {badge.title}
+                  </span>
+                  <span className="text-xs md:text-sm text-gray-500">
+                    {badge.subtitle}
+                  </span>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpReassurance/index.tsx
@@ -4,6 +4,8 @@ import RgpdShieldIcon from './icons/RgpdShieldIcon';
 import SpeedIcon from './icons/SpeedIcon';
 import './index.scss';
 
+type BadgeStyle = React.CSSProperties & { '--badge-index': number };
+
 const TRUST_BADGES = [
   {
     id: 'secure-payment',
@@ -44,7 +46,7 @@ export default function NewHpReassurance() {
             <li
               key={badge.id}
               className="new-hp-reassurance__badge"
-              style={{ '--badge-index': index } as React.CSSProperties}
+              style={{ '--badge-index': index } as BadgeStyle}
             >
               <div className="new-hp-reassurance__badge-content flex flex-col items-center text-center gap-3">
                 <div className="new-hp-reassurance__icon-wrapper">

--- a/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
@@ -1,9 +1,11 @@
 import NewHpHero from './NewHpHero';
+import NewHpReassurance from './NewHpReassurance';
 
 export default function NewHomepageContent() {
   return (
     <main className="flex flex-col items-center justify-center text-black w-full">
       <NewHpHero />
+      <NewHpReassurance />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Add NewHpReassurance component with 4 trust badges below Hero section
- Custom SVG icons (shield/lock, document/stamp, RGPD shield, stopwatch)
- Responsive grid: 4 cols desktop, 2x2 mobile
- Subtle animations: staggered entrance, hover effects, shield pulse

## Test plan
- [x] Component renders 4 badges
- [x] Accessibility: list with proper ARIA label
- [x] SVG icons render correctly
- [x] All tests pass (4/4)

Closes #105