### PR TITLE
feat(frontend): implement NewHpWhyDonaction advantages section (#106)

### DIFF
--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/NewHpWhyDonaction.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/NewHpWhyDonaction.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import NewHpWhyDonaction from './index';
+
+describe('NewHpWhyDonaction', () => {
+  it('renders all 6 advantage cards', () => {
+    render(<NewHpWhyDonaction />);
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(6);
+  });
+
+  it('renders section title', () => {
+    render(<NewHpWhyDonaction />);
+
+    const heading = screen.getByRole('heading', { level: 2 });
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent(/donaction/i);
+  });
+
+  it('renders card titles with key terms', () => {
+    render(<NewHpWhyDonaction />);
+
+    const items = screen.getAllByRole('listitem');
+
+    expect(items[0]).toHaveTextContent(/100%|transparent/i);
+    expect(items[1]).toHaveTextContent(/zéro|abonnement/i);
+    expect(items[2]).toHaveTextContent(/5\s*min|prêt/i);
+    expect(items[3]).toHaveTextContent(/fiscal|cerfa|reçu/i);
+    expect(items[4]).toHaveTextContent(/sport|pensé/i);
+    expect(items[5]).toHaveTextContent(/tableau|bord|dashboard/i);
+  });
+
+  it('renders as a section with proper accessibility', () => {
+    render(<NewHpWhyDonaction />);
+
+    const list = screen.getByRole('list');
+    expect(list).toBeInTheDocument();
+    expect(list).toHaveAttribute('aria-label');
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(6);
+  });
+
+  it('renders SVG icons for each card with aria-hidden', () => {
+    const { container } = render(<NewHpWhyDonaction />);
+
+    const svgIcons = container.querySelectorAll('svg');
+    expect(svgIcons).toHaveLength(6);
+
+    svgIcons.forEach((svg) => {
+      expect(svg).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  it('renders card subtitles', () => {
+    render(<NewHpWhyDonaction />);
+
+    const items = screen.getAllByRole('listitem');
+
+    expect(items[0]).toHaveTextContent(/suivi|temps réel/i);
+    expect(items[1]).toHaveTextContent(/paiement|usage/i);
+    expect(items[2]).toHaveTextContent(/configuration|rapide/i);
+    expect(items[3]).toHaveTextContent(/génération|automatique/i);
+    expect(items[4]).toHaveTextContent(/adapté|clubs/i);
+    expect(items[5]).toHaveTextContent(/statistiques|complètes/i);
+  });
+});

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/icons/DashboardIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/icons/DashboardIcon.tsx
@@ -1,0 +1,38 @@
+interface IconProps {
+  className?: string;
+}
+
+export default function DashboardIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+    >
+      <rect
+        x="4"
+        y="4"
+        width="40"
+        height="40"
+        rx="4"
+        stroke="currentColor"
+        strokeWidth="2.5"
+      />
+      <rect x="10" y="26" width="6" height="12" rx="1" fill="currentColor" fillOpacity="0.5" />
+      <rect x="21" y="18" width="6" height="20" rx="1" fill="currentColor" fillOpacity="0.7" />
+      <rect x="32" y="10" width="6" height="28" rx="1" fill="currentColor" />
+      <line
+        x1="10"
+        y1="14"
+        x2="38"
+        y2="14"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeDasharray="2 2"
+        opacity="0.3"
+      />
+    </svg>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/icons/NoSubscriptionIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/icons/NoSubscriptionIcon.tsx
@@ -1,0 +1,44 @@
+interface IconProps {
+  className?: string;
+}
+
+export default function NoSubscriptionIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+    >
+      <rect
+        x="4"
+        y="12"
+        width="40"
+        height="28"
+        rx="4"
+        stroke="currentColor"
+        strokeWidth="2.5"
+      />
+      <line
+        x1="4"
+        y1="20"
+        x2="44"
+        y2="20"
+        stroke="currentColor"
+        strokeWidth="2.5"
+      />
+      <circle cx="36" cy="32" r="3" fill="currentColor" />
+      <circle cx="28" cy="32" r="3" fill="currentColor" opacity="0.5" />
+      <line
+        x1="6"
+        y1="42"
+        x2="42"
+        y2="10"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/icons/QuickSetupIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/icons/QuickSetupIcon.tsx
@@ -1,0 +1,29 @@
+interface IconProps {
+  className?: string;
+}
+
+export default function QuickSetupIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M26 4L8 28h14l-2 16 18-24H24l2-16z"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+      <path
+        d="M26 4L8 28h14l-2 16 18-24H24l2-16z"
+        fill="currentColor"
+        fillOpacity="0.15"
+      />
+    </svg>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/icons/SportsFocusedIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/icons/SportsFocusedIcon.tsx
@@ -1,0 +1,29 @@
+interface IconProps {
+  className?: string;
+}
+
+export default function SportsFocusedIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M24 6l5.18 10.5L40 18.27l-8 7.8 1.89 11.01L24 32l-9.89 5.08L16 26.07l-8-7.8 10.82-1.77L24 6z"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M24 6l5.18 10.5L40 18.27l-8 7.8 1.89 11.01L24 32l-9.89 5.08L16 26.07l-8-7.8 10.82-1.77L24 6z"
+        fill="currentColor"
+        fillOpacity="0.15"
+      />
+      <circle cx="24" cy="21" r="4" fill="currentColor" />
+    </svg>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/icons/TaxReceiptIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/icons/TaxReceiptIcon.tsx
@@ -1,0 +1,47 @@
+interface IconProps {
+  className?: string;
+}
+
+export default function TaxReceiptIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d="M12 4h18l10 10v30a2 2 0 01-2 2H12a2 2 0 01-2-2V6a2 2 0 012-2z"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M30 4v10h10"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M18 28l4 4 8-8"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <line
+        x1="16"
+        y1="20"
+        x2="26"
+        y2="20"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        opacity="0.5"
+      />
+    </svg>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/icons/TransparentIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/icons/TransparentIcon.tsx
@@ -1,0 +1,25 @@
+interface IconProps {
+  className?: string;
+}
+
+export default function TransparentIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+    >
+      <circle cx="24" cy="24" r="10" stroke="currentColor" strokeWidth="2.5" />
+      <circle cx="24" cy="24" r="4" fill="currentColor" />
+      <path
+        d="M24 6C14.059 6 5.607 12.337 3 21c2.607 8.663 11.059 15 21 15s18.393-6.337 21-15C42.393 12.337 33.941 6 24 6z"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/index.scss
@@ -1,0 +1,169 @@
+// Animation timing variables
+$entrance-duration: 0.6s;
+$entrance-delay-base: 0.15s;
+$entrance-delay-step: 0.08s;
+$hover-duration: 0.3s;
+
+.new-hp-why-donaction {
+  background: linear-gradient(180deg, #ffffff 0%, #f9fafb 50%, #f3f4f6 100%);
+  position: relative;
+  overflow: hidden;
+
+  &__title {
+    opacity: 0;
+    animation: title-entrance $entrance-duration ease-out forwards;
+  }
+
+  &__card {
+    opacity: 0;
+    animation: card-entrance $entrance-duration ease-out forwards;
+    animation-delay: calc(
+      var(--card-index) * #{$entrance-delay-step} + #{$entrance-delay-base}
+    );
+  }
+
+  &__card-content {
+    padding: 2rem 1.5rem;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(229, 231, 235, 0.8);
+    height: 100%;
+    transition:
+      transform $hover-duration ease,
+      background $hover-duration ease,
+      border-color $hover-duration ease,
+      box-shadow $hover-duration ease;
+
+    &:hover {
+      transform: translateY(-6px);
+      background: rgba(255, 255, 255, 1);
+      border-color: rgba(115, 207, 168, 0.4);
+      box-shadow:
+        0 12px 32px -12px rgba(115, 207, 168, 0.2),
+        0 6px 16px -6px rgba(0, 0, 0, 0.06);
+    }
+  }
+
+  &__icon-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 72px;
+    height: 72px;
+    border-radius: 16px;
+    background: linear-gradient(135deg, #f3f4f6 0%, #e5e7eb 100%);
+    transition: background $hover-duration ease;
+
+    &::after {
+      content: '';
+      position: absolute;
+      inset: -4px;
+      border-radius: 20px;
+      background: radial-gradient(
+        circle,
+        rgba(115, 207, 168, 0.2) 0%,
+        transparent 70%
+      );
+      opacity: 0;
+      transition: opacity $hover-duration ease;
+    }
+  }
+
+  &__card-content:hover &__icon-wrapper {
+    background: linear-gradient(135deg, #e5e7eb 0%, #d1d5db 100%);
+
+    &::after {
+      opacity: 1;
+    }
+  }
+
+  &__icon {
+    width: 40px;
+    height: 40px;
+    transition: transform $hover-duration ease;
+  }
+
+  &__card-content:hover &__icon {
+    transform: scale(1.1);
+  }
+}
+
+// Keyframe animations
+@keyframes title-entrance {
+  0% {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes card-entrance {
+  0% {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// Responsive adjustments
+@media (max-width: 1023px) {
+  .new-hp-why-donaction {
+    &__card-content {
+      padding: 1.5rem 1.25rem;
+    }
+
+    &__icon-wrapper {
+      width: 64px;
+      height: 64px;
+      border-radius: 14px;
+    }
+
+    &__icon {
+      width: 36px;
+      height: 36px;
+    }
+  }
+}
+
+@media (max-width: 639px) {
+  .new-hp-why-donaction {
+    &__card-content {
+      padding: 1.25rem 1rem;
+    }
+
+    &__icon-wrapper {
+      width: 56px;
+      height: 56px;
+      border-radius: 12px;
+    }
+
+    &__icon {
+      width: 32px;
+      height: 32px;
+    }
+  }
+}
+
+// Reduced motion preference
+@media (prefers-reduced-motion: reduce) {
+  .new-hp-why-donaction {
+    &__title,
+    &__card {
+      animation: none;
+      opacity: 1;
+    }
+
+    &__card-content,
+    &__icon-wrapper,
+    &__icon {
+      transition: none;
+    }
+  }
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/index.scss
@@ -1,3 +1,6 @@
+// Design tokens
+$color-primary: #73cfa8;
+
 // Animation timing variables
 $entrance-duration: 0.6s;
 $entrance-delay-base: 0.15s;
@@ -37,9 +40,9 @@ $hover-duration: 0.3s;
     &:hover {
       transform: translateY(-6px);
       background: rgba(255, 255, 255, 1);
-      border-color: rgba(115, 207, 168, 0.4);
+      border-color: rgba($color-primary, 0.4);
       box-shadow:
-        0 12px 32px -12px rgba(115, 207, 168, 0.2),
+        0 12px 32px -12px rgba($color-primary, 0.2),
         0 6px 16px -6px rgba(0, 0, 0, 0.06);
     }
   }
@@ -62,7 +65,7 @@ $hover-duration: 0.3s;
       border-radius: 20px;
       background: radial-gradient(
         circle,
-        rgba(115, 207, 168, 0.2) 0%,
+        rgba($color-primary, 0.2) 0%,
         transparent 70%
       );
       opacity: 0;

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/index.tsx
@@ -1,0 +1,87 @@
+import TransparentIcon from './icons/TransparentIcon';
+import NoSubscriptionIcon from './icons/NoSubscriptionIcon';
+import QuickSetupIcon from './icons/QuickSetupIcon';
+import TaxReceiptIcon from './icons/TaxReceiptIcon';
+import SportsFocusedIcon from './icons/SportsFocusedIcon';
+import DashboardIcon from './icons/DashboardIcon';
+import './index.scss';
+
+type CardStyle = React.CSSProperties & { '--card-index': number };
+
+const ADVANTAGES = [
+  {
+    id: 'transparent',
+    Icon: TransparentIcon,
+    title: '100% Transparent',
+    subtitle: 'Suivi des dons en temps réel',
+  },
+  {
+    id: 'no-subscription',
+    Icon: NoSubscriptionIcon,
+    title: 'Zéro abonnement',
+    subtitle: 'Paiement uniquement à l\'usage',
+  },
+  {
+    id: 'quick-setup',
+    Icon: QuickSetupIcon,
+    title: 'Prêt en 5 min',
+    subtitle: 'Configuration ultra-rapide',
+  },
+  {
+    id: 'tax-receipts',
+    Icon: TaxReceiptIcon,
+    title: 'Reçus fiscaux auto',
+    subtitle: 'Génération automatique Cerfa',
+  },
+  {
+    id: 'sports-focused',
+    Icon: SportsFocusedIcon,
+    title: 'Pensé pour le sport',
+    subtitle: 'Adapté aux clubs sportifs',
+  },
+  {
+    id: 'dashboard',
+    Icon: DashboardIcon,
+    title: 'Tableau de bord',
+    subtitle: 'Statistiques complètes',
+  },
+] as const;
+
+export default function NewHpWhyDonaction() {
+  return (
+    <section className="new-hp-why-donaction w-full py-16 md:py-20 lg:py-24">
+      <div className="max-w-[1320px] mx-auto px-6">
+        <h2 className="new-hp-why-donaction__title text-2xl md:text-3xl lg:text-4xl font-bold text-center text-gray-900 mb-12 md:mb-16">
+          Pourquoi choisir DONACTION ?
+        </h2>
+        <ul
+          className="new-hp-why-donaction__grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8"
+          role="list"
+          aria-label="Avantages de DONACTION"
+        >
+          {ADVANTAGES.map((advantage, index) => (
+            <li
+              key={advantage.id}
+              className="new-hp-why-donaction__card"
+              style={{ '--card-index': index } as CardStyle}
+            >
+              <div className="new-hp-why-donaction__card-content flex flex-col items-center text-center gap-4">
+                <div className="new-hp-why-donaction__icon-wrapper">
+                  <advantage.Icon className="new-hp-why-donaction__icon text-gray-700" />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <span className="text-base md:text-lg font-semibold text-gray-800">
+                    {advantage.title}
+                  </span>
+                  <span className="text-sm md:text-base text-gray-500">
+                    {advantage.subtitle}
+                  </span>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWhyDonaction/index.tsx
@@ -19,7 +19,7 @@ const ADVANTAGES = [
     id: 'no-subscription',
     Icon: NoSubscriptionIcon,
     title: 'Zéro abonnement',
-    subtitle: 'Paiement uniquement à l\'usage',
+    subtitle: "Paiement uniquement à l'usage",
   },
   {
     id: 'quick-setup',

--- a/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
@@ -1,11 +1,13 @@
 import NewHpHero from './NewHpHero';
 import NewHpReassurance from './NewHpReassurance';
+import NewHpWhyDonaction from './NewHpWhyDonaction';
 
 export default function NewHomepageContent() {
   return (
     <main className="flex flex-col items-center justify-center text-black w-full">
       <NewHpHero />
       <NewHpReassurance />
+      <NewHpWhyDonaction />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Add "Pourquoi choisir DONACTION" section with 6 advantage cards
- Responsive 3x2 grid (3 cols desktop, 2 cols tablet, 1 col mobile)
- Custom SVG icons for each advantage
- Staggered entrance animations + hover effects
- Full test coverage (6 tests)

## Test plan
- [ ] Visit `/new-hp` and scroll to advantages section
- [ ] Verify 6 cards display with icons
- [ ] Test responsive layout at 375px, 768px, 1440px
- [ ] Run `npm test NewHpWhyDonaction` - all tests pass

Closes #106