### PR TITLE
feat(frontend): implement NewHpWidgetDemo interactive donation widget (#107)

### DIFF
--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/AmountSelector.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/AmountSelector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect } from 'react';
 import { AmountSelectorProps } from '../types';
 import {
   SUGGESTED_AMOUNTS_INDIVIDUAL,
@@ -25,7 +25,7 @@ export default function AmountSelector({
   const [inputValue, setInputValue] = useState<string>(value.toString());
 
   // Sync inputValue when value changes externally (button clicks)
-  useMemo(() => {
+  useEffect(() => {
     setInputValue(value.toString());
   }, [value]);
 
@@ -86,6 +86,13 @@ export default function AmountSelector({
           Montant libre :
         </label>
         <div className="relative">
+          {/*
+            Using type="text" with inputMode="numeric" instead of type="number" because:
+            1. Avoids browser spinner arrows (better UX)
+            2. Better control over validation behavior
+            3. Prevents scientific notation (1e2) issues
+            4. Better mobile keyboard support with pattern="[0-9]*"
+          */}
           <input
             id="custom-amount"
             type="text"
@@ -96,6 +103,7 @@ export default function AmountSelector({
             onBlur={handleBlur}
             aria-label="Montant libre en euros"
             aria-describedby="amount-hint"
+            aria-live="polite"
             className="w-28 text-center border-2 border-gray-200 rounded-lg px-3 py-2 focus:border-donaction-primary focus:outline-none transition-colors"
           />
           <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500" aria-hidden="true">

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/AmountSelector.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/AmountSelector.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { AmountSelectorProps } from '../types';
+import {
+  SUGGESTED_AMOUNTS_INDIVIDUAL,
+  SUGGESTED_AMOUNTS_ORGANIZATION,
+} from '../utils';
+
+export default function AmountSelector({
+  value,
+  onChange,
+  isOrganization,
+}: AmountSelectorProps) {
+  const amounts = isOrganization
+    ? SUGGESTED_AMOUNTS_ORGANIZATION
+    : SUGGESTED_AMOUNTS_INDIVIDUAL;
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = parseInt(e.target.value, 10);
+    if (!isNaN(newValue) && newValue >= 0) {
+      onChange(Math.min(newValue, 100000));
+    }
+  };
+
+  return (
+    <div className="amount-selector">
+      <p className="font-semibold text-gray-800 mb-4">Je souhaite donner :</p>
+
+      <div className="flex flex-wrap gap-2 mb-4">
+        {amounts.map((amount) => (
+          <button
+            key={amount}
+            type="button"
+            className={`amount-selector__btn px-4 py-2 rounded-lg border-2 font-semibold transition-all ${
+              value === amount
+                ? 'border-[#73cfa8] bg-[#73cfa8]/10 text-[#3b9b75]'
+                : 'border-gray-200 hover:border-gray-300 text-gray-700'
+            }`}
+            onClick={() => onChange(amount)}
+          >
+            {amount} €
+          </button>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <label htmlFor="custom-amount" className="text-gray-600">
+          Montant libre :
+        </label>
+        <div className="relative">
+          <input
+            id="custom-amount"
+            type="number"
+            min={1}
+            max={100000}
+            value={value}
+            onChange={handleInputChange}
+            className="w-28 text-center border-2 border-gray-200 rounded-lg px-3 py-2 focus:border-[#73cfa8] focus:outline-none transition-colors"
+          />
+          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500">
+            €
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/AmountSelector.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/AmountSelector.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useMemo, useState } from 'react';
 import { AmountSelectorProps } from '../types';
 import {
   SUGGESTED_AMOUNTS_INDIVIDUAL,
@@ -13,24 +14,45 @@ export default function AmountSelector({
   onChange,
   isOrganization,
 }: AmountSelectorProps) {
-  const amounts = isOrganization
-    ? SUGGESTED_AMOUNTS_ORGANIZATION
-    : SUGGESTED_AMOUNTS_INDIVIDUAL;
+  // Memoize amounts array to avoid recreation on every render
+  const amounts = useMemo(
+    () =>
+      isOrganization ? SUGGESTED_AMOUNTS_ORGANIZATION : SUGGESTED_AMOUNTS_INDIVIDUAL,
+    [isOrganization]
+  );
+
+  // Local state for input display (allows empty while typing)
+  const [inputValue, setInputValue] = useState<string>(value.toString());
+
+  // Sync inputValue when value changes externally (button clicks)
+  useMemo(() => {
+    setInputValue(value.toString());
+  }, [value]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const rawValue = e.target.value;
 
-    // Handle empty string - reset to minimum
+    // Allow empty string while typing
+    setInputValue(rawValue);
+
     if (rawValue === '') {
-      onChange(MIN_DONATION_AMOUNT);
-      return;
+      return; // Don't update parent yet, wait for blur
     }
 
+    // Only whole euros allowed (parseInt ignores decimals)
     const newValue = parseInt(rawValue, 10);
 
-    // Validate: must be a number >= MIN_DONATION_AMOUNT
     if (!isNaN(newValue) && newValue >= MIN_DONATION_AMOUNT) {
       onChange(Math.min(newValue, MAX_DONATION_AMOUNT));
+    }
+  };
+
+  const handleBlur = () => {
+    // On blur, ensure valid value
+    const numValue = parseInt(inputValue, 10);
+    if (isNaN(numValue) || numValue < MIN_DONATION_AMOUNT) {
+      onChange(MIN_DONATION_AMOUNT);
+      setInputValue(MIN_DONATION_AMOUNT.toString());
     }
   };
 
@@ -66,11 +88,12 @@ export default function AmountSelector({
         <div className="relative">
           <input
             id="custom-amount"
-            type="number"
-            min={MIN_DONATION_AMOUNT}
-            max={MAX_DONATION_AMOUNT}
-            value={value}
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            value={inputValue}
             onChange={handleInputChange}
+            onBlur={handleBlur}
             aria-label="Montant libre en euros"
             aria-describedby="amount-hint"
             className="w-28 text-center border-2 border-gray-200 rounded-lg px-3 py-2 focus:border-donaction-primary focus:outline-none transition-colors"

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/AmountSelector.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/AmountSelector.tsx
@@ -4,6 +4,8 @@ import { AmountSelectorProps } from '../types';
 import {
   SUGGESTED_AMOUNTS_INDIVIDUAL,
   SUGGESTED_AMOUNTS_ORGANIZATION,
+  MIN_DONATION_AMOUNT,
+  MAX_DONATION_AMOUNT,
 } from '../utils';
 
 export default function AmountSelector({
@@ -16,24 +18,38 @@ export default function AmountSelector({
     : SUGGESTED_AMOUNTS_INDIVIDUAL;
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = parseInt(e.target.value, 10);
-    if (!isNaN(newValue) && newValue >= 0) {
-      onChange(Math.min(newValue, 100000));
+    const rawValue = e.target.value;
+
+    // Handle empty string - reset to minimum
+    if (rawValue === '') {
+      onChange(MIN_DONATION_AMOUNT);
+      return;
+    }
+
+    const newValue = parseInt(rawValue, 10);
+
+    // Validate: must be a number >= MIN_DONATION_AMOUNT
+    if (!isNaN(newValue) && newValue >= MIN_DONATION_AMOUNT) {
+      onChange(Math.min(newValue, MAX_DONATION_AMOUNT));
     }
   };
 
   return (
-    <div className="amount-selector">
-      <p className="font-semibold text-gray-800 mb-4">Je souhaite donner :</p>
+    <div className="amount-selector" role="group" aria-labelledby="amount-label">
+      <p id="amount-label" className="font-semibold text-gray-800 mb-4">
+        Je souhaite donner :
+      </p>
 
-      <div className="flex flex-wrap gap-2 mb-4">
+      <div className="flex flex-wrap gap-2 mb-4" role="radiogroup" aria-label="Montants suggérés">
         {amounts.map((amount) => (
           <button
             key={amount}
             type="button"
+            role="radio"
+            aria-checked={value === amount}
             className={`amount-selector__btn px-4 py-2 rounded-lg border-2 font-semibold transition-all ${
               value === amount
-                ? 'border-[#73cfa8] bg-[#73cfa8]/10 text-[#3b9b75]'
+                ? 'border-donaction-primary bg-donaction-primary/10 text-donaction-primary-dark'
                 : 'border-gray-200 hover:border-gray-300 text-gray-700'
             }`}
             onClick={() => onChange(amount)}
@@ -51,16 +67,21 @@ export default function AmountSelector({
           <input
             id="custom-amount"
             type="number"
-            min={1}
-            max={100000}
+            min={MIN_DONATION_AMOUNT}
+            max={MAX_DONATION_AMOUNT}
             value={value}
             onChange={handleInputChange}
-            className="w-28 text-center border-2 border-gray-200 rounded-lg px-3 py-2 focus:border-[#73cfa8] focus:outline-none transition-colors"
+            aria-label="Montant libre en euros"
+            aria-describedby="amount-hint"
+            className="w-28 text-center border-2 border-gray-200 rounded-lg px-3 py-2 focus:border-donaction-primary focus:outline-none transition-colors"
           />
-          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500">
+          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500" aria-hidden="true">
             €
           </span>
         </div>
+        <span id="amount-hint" className="sr-only">
+          Entre {MIN_DONATION_AMOUNT} et {MAX_DONATION_AMOUNT} euros
+        </span>
       </div>
     </div>
   );

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/DemoBlocker.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/DemoBlocker.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import Link from 'next/link';
+import { DemoBlockerProps } from '../types';
+
+function LockIcon() {
+  return (
+    <svg
+      className="w-16 h-16 text-[#fb9289]"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z"
+      />
+    </svg>
+  );
+}
+
+export default function DemoBlocker({ onClose }: DemoBlockerProps) {
+  return (
+    <div
+      className="demo-blocker fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        className="demo-blocker__card bg-white rounded-2xl p-8 max-w-md w-full text-center shadow-2xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex justify-center mb-6">
+          <div className="bg-[#fb9289]/10 p-4 rounded-full">
+            <LockIcon />
+          </div>
+        </div>
+
+        <h3 className="text-2xl font-bold text-gray-900 mb-3">
+          Mode Démonstration
+        </h3>
+
+        <p className="text-gray-600 mb-8 leading-relaxed">
+          Cette interface est une démonstration. Pour effectuer un don réel et
+          soutenir une association, découvrez nos projets partenaires.
+        </p>
+
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-6 py-3 border-2 border-gray-200 rounded-lg font-semibold text-gray-700 hover:bg-gray-50 transition-colors"
+          >
+            Fermer
+          </button>
+          <Link
+            href="/projets"
+            className="px-6 py-3 bg-[#73cfa8] text-white rounded-lg font-semibold hover:bg-[#5bb892] transition-colors"
+          >
+            Voir les projets
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/DemoBlocker.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/DemoBlocker.tsx
@@ -1,15 +1,17 @@
 'use client';
 
+import { useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { DemoBlockerProps } from '../types';
 
 function LockIcon() {
   return (
     <svg
-      className="w-16 h-16 text-[#fb9289]"
+      className="w-16 h-16 text-donaction-accent"
       fill="none"
       stroke="currentColor"
       viewBox="0 0 24 24"
+      aria-hidden="true"
     >
       <path
         strokeLinecap="round"
@@ -22,9 +24,30 @@ function LockIcon() {
 }
 
 export default function DemoBlocker({ onClose }: DemoBlockerProps) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Focus trap: focus close button on mount
+  useEffect(() => {
+    closeButtonRef.current?.focus();
+
+    // Handle Escape key
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
   return (
     <div
       className="demo-blocker fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="demo-blocker-title"
+      aria-describedby="demo-blocker-description"
       onClick={onClose}
     >
       <div
@@ -32,22 +55,29 @@ export default function DemoBlocker({ onClose }: DemoBlockerProps) {
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex justify-center mb-6">
-          <div className="bg-[#fb9289]/10 p-4 rounded-full">
+          <div className="bg-donaction-accent/10 p-4 rounded-full">
             <LockIcon />
           </div>
         </div>
 
-        <h3 className="text-2xl font-bold text-gray-900 mb-3">
+        <h3
+          id="demo-blocker-title"
+          className="text-2xl font-bold text-gray-900 mb-3"
+        >
           Mode Démonstration
         </h3>
 
-        <p className="text-gray-600 mb-8 leading-relaxed">
+        <p
+          id="demo-blocker-description"
+          className="text-gray-600 mb-8 leading-relaxed"
+        >
           Cette interface est une démonstration. Pour effectuer un don réel et
           soutenir une association, découvrez nos projets partenaires.
         </p>
 
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
           <button
+            ref={closeButtonRef}
             type="button"
             onClick={onClose}
             className="px-6 py-3 border-2 border-gray-200 rounded-lg font-semibold text-gray-700 hover:bg-gray-50 transition-colors"
@@ -56,7 +86,7 @@ export default function DemoBlocker({ onClose }: DemoBlockerProps) {
           </button>
           <Link
             href="/projets"
-            className="px-6 py-3 bg-[#73cfa8] text-white rounded-lg font-semibold hover:bg-[#5bb892] transition-colors"
+            className="px-6 py-3 bg-donaction-primary text-white rounded-lg font-semibold hover:bg-donaction-primary-dark transition-colors"
           >
             Voir les projets
           </Link>

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/DonorTypeToggle.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/DonorTypeToggle.tsx
@@ -10,12 +10,18 @@ export default function DonorTypeToggle({
     <div className="donor-type-toggle">
       <p className="font-semibold text-gray-800 mb-3">Je suis :</p>
 
-      <div className="flex rounded-lg border-2 border-gray-200 overflow-hidden">
+      <div
+        className="flex rounded-lg border-2 border-gray-200 overflow-hidden"
+        role="radiogroup"
+        aria-label="Type de donateur"
+      >
         <button
           type="button"
+          role="radio"
+          aria-checked={!isOrganization}
           className={`flex-1 px-4 py-2.5 font-medium transition-all ${
             !isOrganization
-              ? 'bg-[#73cfa8] text-white'
+              ? 'bg-donaction-primary text-white'
               : 'bg-white text-gray-600 hover:bg-gray-50'
           }`}
           onClick={() => onChange(false)}
@@ -24,9 +30,11 @@ export default function DonorTypeToggle({
         </button>
         <button
           type="button"
+          role="radio"
+          aria-checked={isOrganization}
           className={`flex-1 px-4 py-2.5 font-medium transition-all ${
             isOrganization
-              ? 'bg-[#73cfa8] text-white'
+              ? 'bg-donaction-primary text-white'
               : 'bg-white text-gray-600 hover:bg-gray-50'
           }`}
           onClick={() => onChange(true)}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/DonorTypeToggle.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/DonorTypeToggle.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { DonorTypeToggleProps } from '../types';
+
+export default function DonorTypeToggle({
+  isOrganization,
+  onChange,
+}: DonorTypeToggleProps) {
+  return (
+    <div className="donor-type-toggle">
+      <p className="font-semibold text-gray-800 mb-3">Je suis :</p>
+
+      <div className="flex rounded-lg border-2 border-gray-200 overflow-hidden">
+        <button
+          type="button"
+          className={`flex-1 px-4 py-2.5 font-medium transition-all ${
+            !isOrganization
+              ? 'bg-[#73cfa8] text-white'
+              : 'bg-white text-gray-600 hover:bg-gray-50'
+          }`}
+          onClick={() => onChange(false)}
+        >
+          Particulier
+        </button>
+        <button
+          type="button"
+          className={`flex-1 px-4 py-2.5 font-medium transition-all ${
+            isOrganization
+              ? 'bg-[#73cfa8] text-white'
+              : 'bg-white text-gray-600 hover:bg-gray-50'
+          }`}
+          onClick={() => onChange(true)}
+        >
+          Entreprise
+        </button>
+      </div>
+
+      <p className="text-sm text-gray-500 mt-2">
+        {isOrganization
+          ? 'Réduction fiscale de 60% (IS)'
+          : 'Réduction fiscale de 66% (IR)'}
+      </p>
+    </div>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/TaxCalculationDisplay.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/TaxCalculationDisplay.tsx
@@ -39,7 +39,7 @@ export default function TaxCalculationDisplay({
       </div>
 
       <div className="flex items-baseline gap-3 mb-3">
-        <span className="text-4xl font-bold text-donaction-primary" aria-live="polite">
+        <span className="text-4xl font-bold text-donaction-primary" aria-live="polite" aria-atomic="true">
           {result.costAfterTax.toFixed(2)} €
         </span>
         <span className="text-gray-400 line-through text-lg" aria-label={`Prix original: ${result.originalAmount.toFixed(2)} euros`}>

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/TaxCalculationDisplay.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/TaxCalculationDisplay.tsx
@@ -24,7 +24,11 @@ export default function TaxCalculationDisplay({
   result,
 }: TaxCalculationDisplayProps) {
   return (
-    <div className="tax-display bg-gradient-to-br from-[#73cfa8]/5 to-[#73cfa8]/10 rounded-xl p-6 border border-[#73cfa8]/20">
+    <div
+      className="tax-display bg-gradient-to-br from-donaction-primary/5 to-donaction-primary/10 rounded-xl p-6 border border-donaction-primary/20"
+      role="region"
+      aria-label="Résultat du calcul fiscal"
+    >
       <div className="flex items-center gap-2 mb-4">
         <h3 className="font-semibold text-gray-800">
           Coût réel après réduction d&apos;impôts
@@ -35,16 +39,16 @@ export default function TaxCalculationDisplay({
       </div>
 
       <div className="flex items-baseline gap-3 mb-3">
-        <span className="text-4xl font-bold text-[#73cfa8]">
+        <span className="text-4xl font-bold text-donaction-primary" aria-live="polite">
           {result.costAfterTax.toFixed(2)} €
         </span>
-        <span className="text-gray-400 line-through text-lg">
+        <span className="text-gray-400 line-through text-lg" aria-label={`Prix original: ${result.originalAmount.toFixed(2)} euros`}>
           {result.originalAmount.toFixed(2)} €
         </span>
       </div>
 
       <div className="flex items-center gap-2 text-gray-600">
-        <svg className="w-5 h-5 text-[#73cfa8]" fill="currentColor" viewBox="0 0 20 20">
+        <svg className="w-5 h-5 text-donaction-primary" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
           <path
             fillRule="evenodd"
             d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
@@ -53,7 +57,7 @@ export default function TaxCalculationDisplay({
         </svg>
         <span>
           Vous économisez{' '}
-          <strong className="text-[#3b9b75]">
+          <strong className="text-donaction-primary-dark">
             {result.taxReduction.toFixed(2)} €
           </strong>
         </span>

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/TaxCalculationDisplay.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/TaxCalculationDisplay.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { TaxCalculationDisplayProps } from '../types';
+
+function InfoIcon() {
+  return (
+    <svg
+      className="w-4 h-4 text-gray-400"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  );
+}
+
+export default function TaxCalculationDisplay({
+  result,
+}: TaxCalculationDisplayProps) {
+  return (
+    <div className="tax-display bg-gradient-to-br from-[#73cfa8]/5 to-[#73cfa8]/10 rounded-xl p-6 border border-[#73cfa8]/20">
+      <div className="flex items-center gap-2 mb-4">
+        <h3 className="font-semibold text-gray-800">
+          Coût réel après réduction d&apos;impôts
+        </h3>
+        <span title="Le montant que vous coûtera réellement ce don après déduction fiscale">
+          <InfoIcon />
+        </span>
+      </div>
+
+      <div className="flex items-baseline gap-3 mb-3">
+        <span className="text-4xl font-bold text-[#73cfa8]">
+          {result.costAfterTax.toFixed(2)} €
+        </span>
+        <span className="text-gray-400 line-through text-lg">
+          {result.originalAmount.toFixed(2)} €
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2 text-gray-600">
+        <svg className="w-5 h-5 text-[#73cfa8]" fill="currentColor" viewBox="0 0 20 20">
+          <path
+            fillRule="evenodd"
+            d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+            clipRule="evenodd"
+          />
+        </svg>
+        <span>
+          Vous économisez{' '}
+          <strong className="text-[#3b9b75]">
+            {result.taxReduction.toFixed(2)} €
+          </strong>
+        </span>
+      </div>
+
+      <p className="text-sm text-gray-500 mt-3">
+        Réduction fiscale de {Math.round(result.taxRate * 100)}% pour les{' '}
+        {result.donorType === 'particulier' ? 'particuliers' : 'entreprises'}
+      </p>
+    </div>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/index.scss
@@ -25,6 +25,17 @@
   }
 }
 
+// Hide number input spinners (arrows)
+.amount-selector input[type='number'] {
+  -moz-appearance: textfield;
+
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+}
+
 // Amount selector button hover effect
 .amount-selector__btn {
   transition: all 0.2s ease;

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/index.scss
@@ -1,0 +1,68 @@
+.demo-widget {
+  &__badge {
+    animation: pulse 2s ease-in-out infinite;
+  }
+
+  &__inner {
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow:
+        0 25px 50px -12px rgba(0, 0, 0, 0.15),
+        0 0 0 1px rgba(115, 207, 168, 0.1);
+    }
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.8;
+  }
+}
+
+// Amount selector button hover effect
+.amount-selector__btn {
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    transform: translateY(-1px);
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(0);
+  }
+}
+
+// Demo blocker animation
+.demo-blocker {
+  animation: fadeIn 0.2s ease;
+
+  &__card {
+    animation: slideUp 0.3s ease;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/index.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useState, useMemo } from 'react';
+import AmountSelector from './AmountSelector';
+import DonorTypeToggle from './DonorTypeToggle';
+import TaxCalculationDisplay from './TaxCalculationDisplay';
+import DemoBlocker from './DemoBlocker';
+import { calculateDemoTaxReduction } from '../utils';
+import './index.scss';
+
+const DEFAULT_AMOUNT = 50;
+
+export default function DemoWidget() {
+  const [amount, setAmount] = useState<number>(DEFAULT_AMOUNT);
+  const [isOrganization, setIsOrganization] = useState<boolean>(false);
+  const [showBlocker, setShowBlocker] = useState<boolean>(false);
+
+  const taxResult = useMemo(
+    () => calculateDemoTaxReduction(amount, isOrganization),
+    [amount, isOrganization]
+  );
+
+  const handleContinue = () => {
+    setShowBlocker(true);
+  };
+
+  return (
+    <>
+      <div className="demo-widget relative">
+        {/* Demo Badge */}
+        <span className="demo-widget__badge absolute -top-3 -right-3 bg-[#fb9289] text-white px-3 py-1 rounded-full text-xs font-bold shadow-lg z-10">
+          Mode Démo
+        </span>
+
+        <div className="demo-widget__inner bg-white rounded-2xl shadow-xl p-6 md:p-8 border border-gray-100">
+          {/* Header */}
+          <div className="mb-6 pb-6 border-b border-gray-100">
+            <h3 className="text-xl font-bold text-gray-900">
+              Simulez votre don
+            </h3>
+            <p className="text-gray-500 text-sm mt-1">
+              Découvrez votre avantage fiscal en temps réel
+            </p>
+          </div>
+
+          {/* Donor Type Toggle */}
+          <div className="mb-6">
+            <DonorTypeToggle
+              isOrganization={isOrganization}
+              onChange={setIsOrganization}
+            />
+          </div>
+
+          {/* Amount Selector */}
+          <div className="mb-6">
+            <AmountSelector
+              value={amount}
+              onChange={setAmount}
+              isOrganization={isOrganization}
+            />
+          </div>
+
+          {/* Tax Calculation Display */}
+          <div className="mb-6">
+            <TaxCalculationDisplay result={taxResult} />
+          </div>
+
+          {/* Continue Button */}
+          <button
+            type="button"
+            onClick={handleContinue}
+            className="w-full bg-[#73cfa8] hover:bg-[#5bb892] text-white font-semibold py-4 rounded-xl transition-colors text-lg shadow-lg shadow-[#73cfa8]/25"
+          >
+            Continuer →
+          </button>
+
+          {/* Security Note */}
+          <p className="text-center text-xs text-gray-400 mt-4 flex items-center justify-center gap-1">
+            <svg
+              className="w-4 h-4"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path
+                fillRule="evenodd"
+                d="M5 9V7a5 5 0 0110 0v2a2 2 0 012 2v5a2 2 0 01-2 2H5a2 2 0 01-2-2v-5a2 2 0 012-2zm8-2v2H7V7a3 3 0 016 0z"
+                clipRule="evenodd"
+              />
+            </svg>
+            Paiement sécurisé par Stripe
+          </p>
+        </div>
+      </div>
+
+      {showBlocker && <DemoBlocker onClose={() => setShowBlocker(false)} />}
+    </>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/index.tsx
@@ -1,16 +1,11 @@
 'use client';
 
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo } from 'react';
 import AmountSelector from './AmountSelector';
 import DonorTypeToggle from './DonorTypeToggle';
 import TaxCalculationDisplay from './TaxCalculationDisplay';
 import DemoBlocker from './DemoBlocker';
-import {
-  calculateDemoTaxReduction,
-  DEFAULT_DONATION_AMOUNT,
-  MIN_DONATION_AMOUNT,
-} from '../utils';
-import { TaxCalculationResult } from '../types';
+import { calculateDemoTaxReduction, DEFAULT_DONATION_AMOUNT } from '../utils';
 import './index.scss';
 
 export default function DemoWidget() {
@@ -18,27 +13,11 @@ export default function DemoWidget() {
   const [isOrganization, setIsOrganization] = useState<boolean>(false);
   const [showBlocker, setShowBlocker] = useState<boolean>(false);
 
-  // Error boundary: safe tax calculation with fallback
-  const taxResult = useMemo((): TaxCalculationResult => {
-    try {
-      return calculateDemoTaxReduction(amount, isOrganization);
-    } catch (error) {
-      console.error('Tax calculation error:', error);
-      // Fallback to safe defaults
-      return {
-        originalAmount: MIN_DONATION_AMOUNT,
-        taxReduction: 0,
-        costAfterTax: MIN_DONATION_AMOUNT,
-        taxRate: 0,
-        donorType: isOrganization ? 'entreprise' : 'particulier',
-      };
-    }
-  }, [amount, isOrganization]);
-
-  // Debounced amount setter for performance
-  const handleAmountChange = useCallback((newAmount: number) => {
-    setAmount(newAmount);
-  }, []);
+  // Tax calculation with built-in validation (see calculateDemoTaxReduction)
+  const taxResult = useMemo(
+    () => calculateDemoTaxReduction(amount, isOrganization),
+    [amount, isOrganization]
+  );
 
   const handleContinue = () => {
     setShowBlocker(true);
@@ -75,7 +54,7 @@ export default function DemoWidget() {
           <div className="mb-6">
             <AmountSelector
               value={amount}
-              onChange={handleAmountChange}
+              onChange={setAmount}
               isOrganization={isOrganization}
             />
           </div>

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/index.tsx
@@ -1,24 +1,44 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import AmountSelector from './AmountSelector';
 import DonorTypeToggle from './DonorTypeToggle';
 import TaxCalculationDisplay from './TaxCalculationDisplay';
 import DemoBlocker from './DemoBlocker';
-import { calculateDemoTaxReduction } from '../utils';
+import {
+  calculateDemoTaxReduction,
+  DEFAULT_DONATION_AMOUNT,
+  MIN_DONATION_AMOUNT,
+} from '../utils';
+import { TaxCalculationResult } from '../types';
 import './index.scss';
 
-const DEFAULT_AMOUNT = 50;
-
 export default function DemoWidget() {
-  const [amount, setAmount] = useState<number>(DEFAULT_AMOUNT);
+  const [amount, setAmount] = useState<number>(DEFAULT_DONATION_AMOUNT);
   const [isOrganization, setIsOrganization] = useState<boolean>(false);
   const [showBlocker, setShowBlocker] = useState<boolean>(false);
 
-  const taxResult = useMemo(
-    () => calculateDemoTaxReduction(amount, isOrganization),
-    [amount, isOrganization]
-  );
+  // Error boundary: safe tax calculation with fallback
+  const taxResult = useMemo((): TaxCalculationResult => {
+    try {
+      return calculateDemoTaxReduction(amount, isOrganization);
+    } catch (error) {
+      console.error('Tax calculation error:', error);
+      // Fallback to safe defaults
+      return {
+        originalAmount: MIN_DONATION_AMOUNT,
+        taxReduction: 0,
+        costAfterTax: MIN_DONATION_AMOUNT,
+        taxRate: 0,
+        donorType: isOrganization ? 'entreprise' : 'particulier',
+      };
+    }
+  }, [amount, isOrganization]);
+
+  // Debounced amount setter for performance
+  const handleAmountChange = useCallback((newAmount: number) => {
+    setAmount(newAmount);
+  }, []);
 
   const handleContinue = () => {
     setShowBlocker(true);
@@ -28,7 +48,7 @@ export default function DemoWidget() {
     <>
       <div className="demo-widget relative">
         {/* Demo Badge */}
-        <span className="demo-widget__badge absolute -top-3 -right-3 bg-[#fb9289] text-white px-3 py-1 rounded-full text-xs font-bold shadow-lg z-10">
+        <span className="demo-widget__badge absolute -top-3 -right-3 bg-donaction-accent text-white px-3 py-1 rounded-full text-xs font-bold shadow-lg z-10">
           Mode Démo
         </span>
 
@@ -55,7 +75,7 @@ export default function DemoWidget() {
           <div className="mb-6">
             <AmountSelector
               value={amount}
-              onChange={setAmount}
+              onChange={handleAmountChange}
               isOrganization={isOrganization}
             />
           </div>
@@ -69,7 +89,7 @@ export default function DemoWidget() {
           <button
             type="button"
             onClick={handleContinue}
-            className="w-full bg-[#73cfa8] hover:bg-[#5bb892] text-white font-semibold py-4 rounded-xl transition-colors text-lg shadow-lg shadow-[#73cfa8]/25"
+            className="w-full bg-donaction-primary hover:bg-donaction-primary-dark text-white font-semibold py-4 rounded-xl transition-colors text-lg shadow-lg shadow-donaction-primary/25"
           >
             Continuer →
           </button>

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/NewHpWidgetDemo.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/NewHpWidgetDemo.test.tsx
@@ -121,7 +121,9 @@ describe('NewHpWidgetDemo', () => {
     render(<NewHpWidgetDemo />);
     const input = screen.getByLabelText(/montant libre/i);
     expect(input).toBeInTheDocument();
-    expect(input).toHaveAttribute('type', 'number');
+    // Using type="text" with inputMode="numeric" for better mobile UX
+    expect(input).toHaveAttribute('type', 'text');
+    expect(input).toHaveAttribute('inputMode', 'numeric');
   });
 
   it('updates calculation when custom amount is entered', () => {
@@ -135,13 +137,17 @@ describe('NewHpWidgetDemo', () => {
 
   // Edge case tests for input validation
   describe('input validation edge cases', () => {
-    it('resets to minimum when empty string is entered', () => {
+    it('allows empty input while typing, resets on blur', () => {
       render(<NewHpWidgetDemo />);
       const input = screen.getByLabelText(/montant libre/i);
-      fireEvent.change(input, { target: { value: '' } });
 
-      // Should reset to 1€ (MIN_DONATION_AMOUNT)
-      expect(input).toHaveValue(1);
+      // Empty while typing is allowed
+      fireEvent.change(input, { target: { value: '' } });
+      expect(input).toHaveValue('');
+
+      // On blur, resets to minimum
+      fireEvent.blur(input);
+      expect(input).toHaveValue('1');
     });
 
     it('caps amounts at maximum (100000)', () => {
@@ -153,13 +159,14 @@ describe('NewHpWidgetDemo', () => {
       expect(screen.getByText('34000.00 €')).toBeInTheDocument();
     });
 
-    it('prevents amounts below minimum', () => {
+    it('validates minimum on blur', () => {
       render(<NewHpWidgetDemo />);
       const input = screen.getByLabelText(/montant libre/i);
       fireEvent.change(input, { target: { value: '0' } });
+      fireEvent.blur(input);
 
-      // Should not update (stays at default 50)
-      expect(input).toHaveValue(50);
+      // Should reset to minimum on blur
+      expect(input).toHaveValue('1');
     });
   });
 
@@ -198,6 +205,18 @@ describe('NewHpWidgetDemo', () => {
       render(<NewHpWidgetDemo />);
       const radiogroup = screen.getByRole('radiogroup', { name: /type de donateur/i });
       expect(radiogroup).toBeInTheDocument();
+    });
+
+    it('closes modal when clicking backdrop', () => {
+      render(<NewHpWidgetDemo />);
+      const continueBtn = screen.getByRole('button', { name: /continuer/i });
+      fireEvent.click(continueBtn);
+
+      // Click the backdrop (dialog element itself, not inner content)
+      const dialog = screen.getByRole('dialog');
+      fireEvent.click(dialog);
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
   });
 });

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/NewHpWidgetDemo.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/NewHpWidgetDemo.test.tsx
@@ -37,32 +37,32 @@ describe('NewHpWidgetDemo', () => {
 
   it('renders donor type toggle with both options', () => {
     render(<NewHpWidgetDemo />);
-    expect(screen.getByRole('button', { name: /particulier/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /entreprise/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /particulier/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /entreprise/i })).toBeInTheDocument();
   });
 
   it('displays default amount selection buttons for individuals', () => {
     render(<NewHpWidgetDemo />);
-    expect(screen.getByRole('button', { name: '10 €' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '20 €' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '50 €' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '100 €' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '10 €' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '20 €' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '50 €' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '100 €' })).toBeInTheDocument();
   });
 
   it('shows organization amounts when enterprise is selected', () => {
     render(<NewHpWidgetDemo />);
-    const entrepriseBtn = screen.getByRole('button', { name: /entreprise/i });
+    const entrepriseBtn = screen.getByRole('radio', { name: /entreprise/i });
     fireEvent.click(entrepriseBtn);
 
-    expect(screen.getByRole('button', { name: '100 €' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '200 €' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '500 €' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: '1000 €' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '100 €' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '200 €' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '500 €' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: '1000 €' })).toBeInTheDocument();
   });
 
   it('updates tax calculation when amount changes', () => {
     render(<NewHpWidgetDemo />);
-    const button100 = screen.getByRole('button', { name: '100 €' });
+    const button100 = screen.getByRole('radio', { name: '100 €' });
     fireEvent.click(button100);
 
     // 100€ - 66% = 34€ cost after tax
@@ -73,11 +73,11 @@ describe('NewHpWidgetDemo', () => {
     render(<NewHpWidgetDemo />);
 
     // First select 100€
-    const button100 = screen.getByRole('button', { name: '100 €' });
+    const button100 = screen.getByRole('radio', { name: '100 €' });
     fireEvent.click(button100);
 
     // Then switch to enterprise
-    const entrepriseBtn = screen.getByRole('button', { name: /entreprise/i });
+    const entrepriseBtn = screen.getByRole('radio', { name: /entreprise/i });
     fireEvent.click(entrepriseBtn);
 
     // 100€ - 60% = 40€ cost after tax
@@ -131,5 +131,73 @@ describe('NewHpWidgetDemo', () => {
 
     // 200€ - 66% = 68€ cost after tax
     expect(screen.getByText('68.00 €')).toBeInTheDocument();
+  });
+
+  // Edge case tests for input validation
+  describe('input validation edge cases', () => {
+    it('resets to minimum when empty string is entered', () => {
+      render(<NewHpWidgetDemo />);
+      const input = screen.getByLabelText(/montant libre/i);
+      fireEvent.change(input, { target: { value: '' } });
+
+      // Should reset to 1€ (MIN_DONATION_AMOUNT)
+      expect(input).toHaveValue(1);
+    });
+
+    it('caps amounts at maximum (100000)', () => {
+      render(<NewHpWidgetDemo />);
+      const input = screen.getByLabelText(/montant libre/i);
+      fireEvent.change(input, { target: { value: '999999' } });
+
+      // 100000€ - 66% = 34000€ cost after tax
+      expect(screen.getByText('34000.00 €')).toBeInTheDocument();
+    });
+
+    it('prevents amounts below minimum', () => {
+      render(<NewHpWidgetDemo />);
+      const input = screen.getByLabelText(/montant libre/i);
+      fireEvent.change(input, { target: { value: '0' } });
+
+      // Should not update (stays at default 50)
+      expect(input).toHaveValue(50);
+    });
+  });
+
+  // Accessibility tests
+  describe('accessibility', () => {
+    it('modal has correct aria attributes', () => {
+      render(<NewHpWidgetDemo />);
+      const continueBtn = screen.getByRole('button', { name: /continuer/i });
+      fireEvent.click(continueBtn);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+      expect(dialog).toHaveAttribute('aria-labelledby', 'demo-blocker-title');
+    });
+
+    it('closes modal on Escape key', () => {
+      render(<NewHpWidgetDemo />);
+      const continueBtn = screen.getByRole('button', { name: /continuer/i });
+      fireEvent.click(continueBtn);
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('amount buttons have aria-checked attribute', () => {
+      render(<NewHpWidgetDemo />);
+      const button50 = screen.getByRole('radio', { name: '50 €' });
+      expect(button50).toHaveAttribute('aria-checked', 'true');
+
+      const button100 = screen.getByRole('radio', { name: '100 €' });
+      expect(button100).toHaveAttribute('aria-checked', 'false');
+    });
+
+    it('donor type toggle has radiogroup role', () => {
+      render(<NewHpWidgetDemo />);
+      const radiogroup = screen.getByRole('radiogroup', { name: /type de donateur/i });
+      expect(radiogroup).toBeInTheDocument();
+    });
   });
 });

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/NewHpWidgetDemo.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/NewHpWidgetDemo.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import NewHpWidgetDemo from './index';
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: React.ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('NewHpWidgetDemo', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders section with heading', () => {
+    render(<NewHpWidgetDemo />);
+    const heading = screen.getByRole('heading', { level: 2 });
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent('Essayez notre widget de don');
+  });
+
+  it('renders demo badge indicator', () => {
+    render(<NewHpWidgetDemo />);
+    expect(screen.getByText(/mode démo/i)).toBeInTheDocument();
+  });
+
+  it('renders donor type toggle with both options', () => {
+    render(<NewHpWidgetDemo />);
+    expect(screen.getByRole('button', { name: /particulier/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /entreprise/i })).toBeInTheDocument();
+  });
+
+  it('displays default amount selection buttons for individuals', () => {
+    render(<NewHpWidgetDemo />);
+    expect(screen.getByRole('button', { name: '10 €' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '20 €' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '50 €' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '100 €' })).toBeInTheDocument();
+  });
+
+  it('shows organization amounts when enterprise is selected', () => {
+    render(<NewHpWidgetDemo />);
+    const entrepriseBtn = screen.getByRole('button', { name: /entreprise/i });
+    fireEvent.click(entrepriseBtn);
+
+    expect(screen.getByRole('button', { name: '100 €' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '200 €' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '500 €' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '1000 €' })).toBeInTheDocument();
+  });
+
+  it('updates tax calculation when amount changes', () => {
+    render(<NewHpWidgetDemo />);
+    const button100 = screen.getByRole('button', { name: '100 €' });
+    fireEvent.click(button100);
+
+    // 100€ - 66% = 34€ cost after tax
+    expect(screen.getByText('34.00 €')).toBeInTheDocument();
+  });
+
+  it('changes tax rate when toggling to enterprise', () => {
+    render(<NewHpWidgetDemo />);
+
+    // First select 100€
+    const button100 = screen.getByRole('button', { name: '100 €' });
+    fireEvent.click(button100);
+
+    // Then switch to enterprise
+    const entrepriseBtn = screen.getByRole('button', { name: /entreprise/i });
+    fireEvent.click(entrepriseBtn);
+
+    // 100€ - 60% = 40€ cost after tax
+    expect(screen.getByText('40.00 €')).toBeInTheDocument();
+    // Check for enterprise tax info in tax display
+    expect(screen.getByText(/entreprises/)).toBeInTheDocument();
+  });
+
+  it('shows blocker when clicking continue button', () => {
+    render(<NewHpWidgetDemo />);
+    const continueBtn = screen.getByRole('button', { name: /continuer/i });
+    fireEvent.click(continueBtn);
+
+    expect(screen.getByText(/mode démonstration/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /voir les projets/i })).toHaveAttribute(
+      'href',
+      '/projets'
+    );
+  });
+
+  it('closes blocker when clicking close button', () => {
+    render(<NewHpWidgetDemo />);
+    const continueBtn = screen.getByRole('button', { name: /continuer/i });
+    fireEvent.click(continueBtn);
+
+    const closeBtn = screen.getByRole('button', { name: /fermer/i });
+    fireEvent.click(closeBtn);
+
+    expect(screen.queryByText(/mode démonstration/i)).not.toBeInTheDocument();
+  });
+
+  it('renders benefits list', () => {
+    render(<NewHpWidgetDemo />);
+    expect(screen.getByText('Calcul fiscal en temps réel')).toBeInTheDocument();
+    // Paiement sécurisé appears in two places - use getAllBy
+    expect(screen.getAllByText(/Paiement sécurisé par Stripe/i).length).toBeGreaterThan(0);
+    expect(screen.getByText('Reçu fiscal automatique')).toBeInTheDocument();
+  });
+
+  it('displays custom amount input', () => {
+    render(<NewHpWidgetDemo />);
+    const input = screen.getByLabelText(/montant libre/i);
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('type', 'number');
+  });
+
+  it('updates calculation when custom amount is entered', () => {
+    render(<NewHpWidgetDemo />);
+    const input = screen.getByLabelText(/montant libre/i);
+    fireEvent.change(input, { target: { value: '200' } });
+
+    // 200€ - 66% = 68€ cost after tax
+    expect(screen.getByText('68.00 €')).toBeInTheDocument();
+  });
+});

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/index.scss
@@ -1,0 +1,30 @@
+.new-hp-widget-demo {
+  background: linear-gradient(180deg, #ffffff 0%, #f8faf9 100%);
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: -50%;
+    right: -20%;
+    width: 60%;
+    height: 150%;
+    background: radial-gradient(
+      ellipse at center,
+      rgba(115, 207, 168, 0.08) 0%,
+      transparent 70%
+    );
+    pointer-events: none;
+  }
+
+  &__content {
+    position: relative;
+    z-index: 1;
+  }
+
+  &__widget-container {
+    position: relative;
+    z-index: 1;
+  }
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/index.tsx
@@ -16,7 +16,7 @@ const SECTION_CONTENT = {
 function CheckIcon() {
   return (
     <svg
-      className="w-5 h-5 text-[#73cfa8] flex-shrink-0"
+      className="w-5 h-5 text-donaction-primary flex-shrink-0"
       fill="currentColor"
       viewBox="0 0 20 20"
     >
@@ -36,7 +36,7 @@ export default function NewHpWidgetDemo() {
         <div className="flex flex-col lg:flex-row items-center justify-between gap-12 lg:gap-16">
           {/* Text Content - Left side */}
           <div className="new-hp-widget-demo__content lg:w-[45%] text-center lg:text-left">
-            <span className="inline-block bg-[#73cfa8]/10 text-[#3b9b75] px-4 py-1.5 rounded-full text-sm font-semibold mb-6">
+            <span className="inline-block bg-donaction-primary/10 text-donaction-primary-dark px-4 py-1.5 rounded-full text-sm font-semibold mb-6">
               Démo interactive
             </span>
 

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/index.tsx
@@ -1,0 +1,72 @@
+import DemoWidget from './DemoWidget';
+import './index.scss';
+
+const SECTION_CONTENT = {
+  title: 'Essayez notre widget de don',
+  subtitle: 'Découvrez en direct le fonctionnement de notre plateforme',
+  description:
+    'Simulez un don et visualisez instantanément votre réduction fiscale. Interface simple, transparente et 100% sécurisée.',
+  benefits: [
+    'Calcul fiscal en temps réel',
+    'Paiement sécurisé par Stripe',
+    'Reçu fiscal automatique',
+  ],
+} as const;
+
+function CheckIcon() {
+  return (
+    <svg
+      className="w-5 h-5 text-[#73cfa8] flex-shrink-0"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+    >
+      <path
+        fillRule="evenodd"
+        d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
+export default function NewHpWidgetDemo() {
+  return (
+    <section className="new-hp-widget-demo w-full py-16 md:py-20 lg:py-24">
+      <div className="max-w-[1320px] mx-auto px-6">
+        <div className="flex flex-col lg:flex-row items-center justify-between gap-12 lg:gap-16">
+          {/* Text Content - Left side */}
+          <div className="new-hp-widget-demo__content lg:w-[45%] text-center lg:text-left">
+            <span className="inline-block bg-[#73cfa8]/10 text-[#3b9b75] px-4 py-1.5 rounded-full text-sm font-semibold mb-6">
+              Démo interactive
+            </span>
+
+            <h2 className="text-3xl md:text-4xl lg:text-5xl font-bold text-black leading-tight mb-6">
+              {SECTION_CONTENT.title}
+            </h2>
+
+            <p className="text-lg text-gray-600 leading-relaxed mb-8 max-w-[480px] mx-auto lg:mx-0">
+              {SECTION_CONTENT.description}
+            </p>
+
+            <ul className="flex flex-col gap-4 mb-8">
+              {SECTION_CONTENT.benefits.map((benefit) => (
+                <li
+                  key={benefit}
+                  className="flex items-center gap-3 justify-center lg:justify-start"
+                >
+                  <CheckIcon />
+                  <span className="text-gray-700 font-medium">{benefit}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+
+          {/* Widget Demo - Right side */}
+          <div className="new-hp-widget-demo__widget-container lg:w-[50%] w-full max-w-[500px]">
+            <DemoWidget />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/types.ts
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/types.ts
@@ -1,0 +1,26 @@
+export interface TaxCalculationResult {
+  originalAmount: number;
+  taxReduction: number;
+  costAfterTax: number;
+  taxRate: number;
+  donorType: 'particulier' | 'entreprise';
+}
+
+export interface AmountSelectorProps {
+  value: number;
+  onChange: (amount: number) => void;
+  isOrganization: boolean;
+}
+
+export interface TaxCalculationDisplayProps {
+  result: TaxCalculationResult;
+}
+
+export interface DemoBlockerProps {
+  onClose: () => void;
+}
+
+export interface DonorTypeToggleProps {
+  isOrganization: boolean;
+  onChange: (isOrganization: boolean) => void;
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/utils.ts
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/utils.ts
@@ -4,18 +4,38 @@ import {
 } from '@/core/constants/dons';
 import { TaxCalculationResult } from './types';
 
+export const MIN_DONATION_AMOUNT = 1;
+export const MAX_DONATION_AMOUNT = 100000;
+export const DEFAULT_DONATION_AMOUNT = 50;
+
 export function calculateDemoTaxReduction(
   amount: number,
   isOrganization: boolean
 ): TaxCalculationResult {
+  // Type safety: validate amount is a finite positive number
+  if (!Number.isFinite(amount) || amount < MIN_DONATION_AMOUNT) {
+    const safeAmount = MIN_DONATION_AMOUNT;
+    const taxRate = isOrganization
+      ? TAUX_DEDUCTION_FISCALE_PRO
+      : TAUX_DEDUCTION_FISCALE_PART;
+    return {
+      originalAmount: safeAmount,
+      taxReduction: Math.round(safeAmount * taxRate * 100) / 100,
+      costAfterTax: Math.round(safeAmount * (1 - taxRate) * 100) / 100,
+      taxRate,
+      donorType: isOrganization ? 'entreprise' : 'particulier',
+    };
+  }
+
+  const clampedAmount = Math.min(amount, MAX_DONATION_AMOUNT);
   const taxRate = isOrganization
     ? TAUX_DEDUCTION_FISCALE_PRO
     : TAUX_DEDUCTION_FISCALE_PART;
-  const taxReduction = amount * taxRate;
-  const costAfterTax = amount - taxReduction;
+  const taxReduction = clampedAmount * taxRate;
+  const costAfterTax = clampedAmount - taxReduction;
 
   return {
-    originalAmount: amount,
+    originalAmount: clampedAmount,
     taxReduction: Math.round(taxReduction * 100) / 100,
     costAfterTax: Math.round(costAfterTax * 100) / 100,
     taxRate,

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/utils.ts
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/utils.ts
@@ -1,0 +1,27 @@
+import {
+  TAUX_DEDUCTION_FISCALE_PART,
+  TAUX_DEDUCTION_FISCALE_PRO,
+} from '@/core/constants/dons';
+import { TaxCalculationResult } from './types';
+
+export function calculateDemoTaxReduction(
+  amount: number,
+  isOrganization: boolean
+): TaxCalculationResult {
+  const taxRate = isOrganization
+    ? TAUX_DEDUCTION_FISCALE_PRO
+    : TAUX_DEDUCTION_FISCALE_PART;
+  const taxReduction = amount * taxRate;
+  const costAfterTax = amount - taxReduction;
+
+  return {
+    originalAmount: amount,
+    taxReduction: Math.round(taxReduction * 100) / 100,
+    costAfterTax: Math.round(costAfterTax * 100) / 100,
+    taxRate,
+    donorType: isOrganization ? 'entreprise' : 'particulier',
+  };
+}
+
+export const SUGGESTED_AMOUNTS_INDIVIDUAL = [10, 20, 50, 100] as const;
+export const SUGGESTED_AMOUNTS_ORGANIZATION = [100, 200, 500, 1000] as const;

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/utils.ts
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/utils.ts
@@ -12,22 +12,12 @@ export function calculateDemoTaxReduction(
   amount: number,
   isOrganization: boolean
 ): TaxCalculationResult {
-  // Type safety: validate amount is a finite positive number
-  if (!Number.isFinite(amount) || amount < MIN_DONATION_AMOUNT) {
-    const safeAmount = MIN_DONATION_AMOUNT;
-    const taxRate = isOrganization
-      ? TAUX_DEDUCTION_FISCALE_PRO
-      : TAUX_DEDUCTION_FISCALE_PART;
-    return {
-      originalAmount: safeAmount,
-      taxReduction: Math.round(safeAmount * taxRate * 100) / 100,
-      costAfterTax: Math.round(safeAmount * (1 - taxRate) * 100) / 100,
-      taxRate,
-      donorType: isOrganization ? 'entreprise' : 'particulier',
-    };
-  }
+  // Clamp amount to valid range, defaulting to MIN if invalid
+  const clampedAmount =
+    Number.isFinite(amount) && amount >= MIN_DONATION_AMOUNT
+      ? Math.min(amount, MAX_DONATION_AMOUNT)
+      : MIN_DONATION_AMOUNT;
 
-  const clampedAmount = Math.min(amount, MAX_DONATION_AMOUNT);
   const taxRate = isOrganization
     ? TAUX_DEDUCTION_FISCALE_PRO
     : TAUX_DEDUCTION_FISCALE_PART;

--- a/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
@@ -1,6 +1,7 @@
 import NewHpHero from './NewHpHero';
 import NewHpReassurance from './NewHpReassurance';
 import NewHpWhyDonaction from './NewHpWhyDonaction';
+import NewHpWidgetDemo from './NewHpWidgetDemo';
 
 export default function NewHomepageContent() {
   return (
@@ -8,6 +9,7 @@ export default function NewHomepageContent() {
       <NewHpHero />
       <NewHpReassurance />
       <NewHpWhyDonaction />
+      <NewHpWidgetDemo />
     </main>
   );
 }

--- a/donaction-frontend/tailwind.config.js
+++ b/donaction-frontend/tailwind.config.js
@@ -52,6 +52,10 @@ module.exports = {
 				border: theme.colors.default.theme_color.border,
 				'theme-dark': theme.colors.default.theme_color.theme_dark,
 				'theme-light': theme.colors.default.theme_color.theme_light,
+				// Donaction semantic colors for interactive components
+				'donaction-primary': '#73cfa8',
+				'donaction-primary-dark': '#5bb892',
+				'donaction-accent': '#fb9289',
 			},
 			fontSize: {
 				base: font_base + 'px',

--- a/donaction-frontend/tailwind.config.js
+++ b/donaction-frontend/tailwind.config.js
@@ -52,10 +52,11 @@ module.exports = {
 				border: theme.colors.default.theme_color.border,
 				'theme-dark': theme.colors.default.theme_color.theme_dark,
 				'theme-light': theme.colors.default.theme_color.theme_light,
-				// Donaction semantic colors for interactive components
-				'donaction-primary': '#73cfa8',
-				'donaction-primary-dark': '#5bb892',
-				'donaction-accent': '#fb9289',
+				// Donaction semantic aliases for interactive components
+				// Using theme values to maintain single source of truth
+				'donaction-primary': theme.colors.default.theme_color.secondary,
+				'donaction-primary-dark': '#5bb892', // Darker shade of secondary
+				'donaction-accent': theme.colors.default.theme_color.tertiary,
 			},
 			fontSize: {
 				base: font_base + 'px',


### PR DESCRIPTION
## Summary
- Add interactive demo widget section for /new-hp page
- Real-time tax calculation display (66% individuals, 60% enterprises)
- Demo blocker modal preventing actual payment flow
- Responsive two-column layout with benefits list

## Changes
- **NewHpWidgetDemo/index.tsx** - Server component section wrapper
- **DemoWidget/index.tsx** - Client component with interactive state
- **AmountSelector.tsx** - Amount buttons (10€, 20€, 50€, 100€) + free input
- **TaxCalculationDisplay.tsx** - Real-time cost after tax calculation
- **DonorTypeToggle.tsx** - Particulier/Entreprise switch
- **DemoBlocker.tsx** - Modal blocking payment with CTA to projects
- **utils.ts** - Tax calculation logic using existing constants
- **types.ts** - TypeScript interfaces
- **12 unit tests** covering all functionality

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 12 tests pass (`npm test`)
- [x] Desktop view verified (1440px)
- [x] Amount selection updates tax calculation in real-time
- [x] Enterprise/Individual toggle switches tax rates correctly
- [x] Demo blocker appears when clicking "Continuer"

Closes #107