### PR TITLE
feat(frontend): implement NewHpProjects featured projects section (#110)

### DIFF
--- a/donaction-frontend/src/app/(main)/new-hp/page.tsx
+++ b/donaction-frontend/src/app/(main)/new-hp/page.tsx
@@ -11,7 +11,8 @@ export const metadata: Metadata = {
 
 export default async function NewHpPage() {
   const isPreview = await GetServerCookie('isPreviewMode');
-  const projets = await getProjets(1, 3, true, !!isPreview, cookies().toString());
+  const projets = await getProjets(1, 3, true, !!isPreview, cookies().toString())
+    .catch(() => undefined);
 
   return <NewHomepageContent projets={projets} />;
 }

--- a/donaction-frontend/src/app/(main)/new-hp/page.tsx
+++ b/donaction-frontend/src/app/(main)/new-hp/page.tsx
@@ -1,5 +1,8 @@
 import { Metadata } from 'next';
 import NewHomepageContent from '@/partials/newHomepage';
+import { getProjets } from '@/core/services/projet';
+import { cookies } from 'next/headers';
+import GetServerCookie from '@/core/helpers/getServerCookie';
 
 export const metadata: Metadata = {
   title: 'Donaction - New Homepage',
@@ -7,5 +10,8 @@ export const metadata: Metadata = {
 };
 
 export default async function NewHpPage() {
-  return <NewHomepageContent />;
+  const isPreview = await GetServerCookie('isPreviewMode');
+  const projets = await getProjets(1, 3, true, !!isPreview, cookies().toString());
+
+  return <NewHomepageContent projets={projets} />;
 }

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/NewHpProjectCard.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/NewHpProjectCard.tsx
@@ -1,0 +1,137 @@
+import { KlubProjet } from '@/core/models/klub-project';
+import { formatCurrency } from '@/core/helpers/currency/CurrencyHelpers';
+import { endOfDay, isAfter, differenceInDays } from 'date-fns';
+import ImageHtml from '@/components/media/ImageHtml';
+import Link from 'next/link';
+
+type CardStyle = React.CSSProperties & { '--card-index': number };
+
+type NewHpProjectCardProps = {
+  projet: KlubProjet;
+  index: number;
+  className?: string;
+};
+
+export default function NewHpProjectCard({ projet, index, className }: NewHpProjectCardProps) {
+  const klubSlug = projet.klubr?.slug;
+  const projectUrl = klubSlug ? `/${klubSlug}/nos-projets/${projet.slug}` : '#';
+  const progress = projet.montantAFinancer
+    ? Math.min((projet.montantTotalDonations / projet.montantAFinancer) * 100, 100)
+    : 0;
+  const progressWidth = progress > 0 ? Math.max(progress, 3) : 0;
+
+  const deadline = projet.dateLimiteFinancementProjet
+    ? new Date(projet.dateLimiteFinancementProjet)
+    : null;
+  const isExpired = deadline ? isAfter(new Date(), endOfDay(deadline)) : false;
+  const daysLeft = deadline && !isExpired ? differenceInDays(deadline, new Date()) : null;
+
+  return (
+    <article
+      className={`new-hp-projects__card ${className || ''}`}
+      style={{ '--card-index': index } as CardStyle}
+    >
+      <Link href={projectUrl} className="new-hp-projects__card-link block h-full">
+        <div className="new-hp-projects__card-content flex flex-col h-full">
+          {/* Cover image */}
+          <div className="new-hp-projects__card-image relative overflow-hidden rounded-t-2xl aspect-video">
+            <ImageHtml
+              className="w-full h-full object-cover"
+              width={420}
+              height={236}
+              src={projet.couverture?.url || ''}
+              alt={projet.couverture?.alternativeText || projet.titre}
+              namedtransformation="project_card"
+              nosizes={true}
+            />
+
+            {/* Status badge */}
+            <span
+              className={`new-hp-projects__status-badge absolute top-3 left-3 text-xs font-semibold px-3 py-1 rounded-full backdrop-blur-sm ${
+                isExpired
+                  ? 'bg-gray-800/70 text-white'
+                  : 'bg-emerald-500/80 text-white'
+              }`}
+            >
+              {isExpired ? 'Terminé' : 'En cours'}
+            </span>
+
+            {/* Days left badge */}
+            {daysLeft !== null && daysLeft >= 0 && (
+              <span className="new-hp-projects__deadline-badge absolute top-3 right-3 bg-black/60 backdrop-blur-sm text-white text-xs font-bold px-3 py-1 rounded-full">
+                J-{daysLeft}
+              </span>
+            )}
+
+            {/* Sport badge */}
+            {projet.sportType && (
+              <span className="new-hp-projects__badge absolute bottom-3 left-3 bg-white/90 backdrop-blur-sm text-xs font-medium text-gray-700 px-3 py-1 rounded-full">
+                {projet.sportType}
+              </span>
+            )}
+          </div>
+
+          {/* Card body */}
+          <div className="new-hp-projects__card-body flex flex-col flex-1 p-5">
+            {/* Club info */}
+            {projet.klubr && (
+              <div className="flex items-center gap-2 mb-3">
+                <ImageHtml
+                  className="w-8 h-8 rounded-full object-contain"
+                  width={32}
+                  height={32}
+                  src={projet.klubr.logo?.url || ''}
+                  alt={projet.klubr.logo?.alt || projet.klubr.denomination}
+                  namedtransformation="logo"
+                  nosizes={true}
+                />
+                <span className="text-xs text-gray-500 truncate">
+                  {projet.klubr.denomination}
+                </span>
+              </div>
+            )}
+
+            {/* Title */}
+            <h3 className="text-base md:text-lg font-semibold text-gray-900 mb-3 line-clamp-2 leading-snug">
+              {projet.titre}
+            </h3>
+
+            {/* Progress section - pushed to bottom */}
+            <div className="mt-auto">
+              {/* Progress bar */}
+              <div className="new-hp-projects__progress relative w-full h-2 bg-gray-200 rounded-full overflow-hidden mb-3">
+                <div
+                  className="new-hp-projects__progress-fill absolute left-0 top-0 h-full rounded-full"
+                  style={{ width: `${progressWidth}%` }}
+                />
+              </div>
+
+              {/* Amounts */}
+              <div className="flex justify-between items-center text-sm">
+                <span className="font-semibold text-gray-900">
+                  {formatCurrency(projet.montantTotalDonations)}
+                </span>
+                <span className="text-gray-400">
+                  sur {formatCurrency(projet.montantAFinancer)}
+                </span>
+              </div>
+
+              {/* Social proof */}
+              {projet.nbDons > 0 && (
+                <div className="new-hp-projects__social-proof flex items-center gap-1.5 mt-2 text-xs text-gray-500">
+                  <svg className="w-3.5 h-3.5" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                    <path d="M8 7a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM14 12.5c0 1.38-2.69 2.5-6 2.5S2 13.88 2 12.5 4.69 10 8 10s6 1.12 6 2.5Z" fill="currentColor" />
+                  </svg>
+                  <span>
+                    <strong className="font-semibold text-gray-700">{projet.nbDons}</strong>{' '}
+                    {projet.nbDons > 1 ? 'mécènes' : 'mécène'}
+                  </span>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </Link>
+    </article>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/NewHpProjectCard.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/NewHpProjectCard.tsx
@@ -1,8 +1,8 @@
 import { KlubProjet } from '@/core/models/klub-project';
 import { formatCurrency } from '@/core/helpers/currency/CurrencyHelpers';
-import { endOfDay, isAfter, differenceInDays } from 'date-fns';
 import ImageHtml from '@/components/media/ImageHtml';
 import Link from 'next/link';
+import { getProjectDeadlineInfo } from './helpers';
 
 type CardStyle = React.CSSProperties & { '--card-index': number };
 
@@ -14,24 +14,29 @@ type NewHpProjectCardProps = {
 
 export default function NewHpProjectCard({ projet, index, className }: NewHpProjectCardProps) {
   const klubSlug = projet.klubr?.slug;
-  const projectUrl = klubSlug ? `/${klubSlug}/nos-projets/${projet.slug}` : '#';
-  const progress = projet.montantAFinancer
+  const projectUrl = klubSlug ? `/${klubSlug}/nos-projets/${projet.slug}` : null;
+  const progress = projet.montantAFinancer > 0
     ? Math.min((projet.montantTotalDonations / projet.montantAFinancer) * 100, 100)
     : 0;
   const progressWidth = progress > 0 ? Math.max(progress, 3) : 0;
+  const { isExpired, daysLeft } = getProjectDeadlineInfo(projet.dateLimiteFinancementProjet);
 
-  const deadline = projet.dateLimiteFinancementProjet
-    ? new Date(projet.dateLimiteFinancementProjet)
-    : null;
-  const isExpired = deadline ? isAfter(new Date(), endOfDay(deadline)) : false;
-  const daysLeft = deadline && !isExpired ? differenceInDays(deadline, new Date()) : null;
+  const CardWrapper = projectUrl
+    ? ({ children }: { children: React.ReactNode }) => (
+        <Link href={projectUrl} className="new-hp-projects__card-link block h-full">
+          {children}
+        </Link>
+      )
+    : ({ children }: { children: React.ReactNode }) => (
+        <div className="new-hp-projects__card-link block h-full">{children}</div>
+      );
 
   return (
     <article
       className={`new-hp-projects__card ${className || ''}`}
       style={{ '--card-index': index } as CardStyle}
     >
-      <Link href={projectUrl} className="new-hp-projects__card-link block h-full">
+      <CardWrapper>
         <div className="new-hp-projects__card-content flex flex-col h-full">
           {/* Cover image */}
           <div className="new-hp-projects__card-image relative overflow-hidden rounded-t-2xl aspect-video">
@@ -43,6 +48,7 @@ export default function NewHpProjectCard({ projet, index, className }: NewHpProj
               alt={projet.couverture?.alternativeText || projet.titre}
               namedtransformation="project_card"
               nosizes={true}
+              loading="lazy"
             />
 
             {/* Status badge */}
@@ -84,6 +90,7 @@ export default function NewHpProjectCard({ projet, index, className }: NewHpProj
                   alt={projet.klubr.logo?.alt || projet.klubr.denomination}
                   namedtransformation="logo"
                   nosizes={true}
+                  loading="lazy"
                 />
                 <span className="text-xs text-gray-500 truncate">
                   {projet.klubr.denomination}
@@ -131,7 +138,7 @@ export default function NewHpProjectCard({ projet, index, className }: NewHpProj
             </div>
           </div>
         </div>
-      </Link>
+      </CardWrapper>
     </article>
   );
 }

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/NewHpProjectCard.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/NewHpProjectCard.tsx
@@ -40,16 +40,18 @@ export default function NewHpProjectCard({ projet, index, className }: NewHpProj
         <div className="new-hp-projects__card-content flex flex-col h-full">
           {/* Cover image */}
           <div className="new-hp-projects__card-image relative overflow-hidden rounded-t-2xl aspect-video">
-            <ImageHtml
-              className="w-full h-full object-cover"
-              width={420}
-              height={236}
-              src={projet.couverture?.url || ''}
-              alt={projet.couverture?.alternativeText || projet.titre}
-              namedtransformation="project_card"
-              nosizes={true}
-              loading="lazy"
-            />
+            {projet.couverture?.url && (
+              <ImageHtml
+                className="w-full h-full object-cover"
+                width={420}
+                height={236}
+                src={projet.couverture.url}
+                alt={projet.couverture.alternativeText || projet.titre}
+                namedtransformation="project_card"
+                nosizes={true}
+                loading="lazy"
+              />
+            )}
 
             {/* Status badge */}
             <span
@@ -82,16 +84,18 @@ export default function NewHpProjectCard({ projet, index, className }: NewHpProj
             {/* Club info */}
             {projet.klubr && (
               <div className="flex items-center gap-2 mb-3">
-                <ImageHtml
-                  className="w-8 h-8 rounded-full object-contain"
-                  width={32}
-                  height={32}
-                  src={projet.klubr.logo?.url || ''}
-                  alt={projet.klubr.logo?.alt || projet.klubr.denomination}
-                  namedtransformation="logo"
-                  nosizes={true}
-                  loading="lazy"
-                />
+                {projet.klubr.logo?.url && (
+                  <ImageHtml
+                    className="w-8 h-8 rounded-full object-contain"
+                    width={32}
+                    height={32}
+                    src={projet.klubr.logo.url}
+                    alt={projet.klubr.logo.alt || projet.klubr.denomination}
+                    namedtransformation="logo"
+                    nosizes={true}
+                    loading="lazy"
+                  />
+                )}
                 <span className="text-xs text-gray-500 truncate">
                   {projet.klubr.denomination}
                 </span>

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/NewHpProjects.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/NewHpProjects.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import NewHpProjects from './index';
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, className }: { children: React.ReactNode; href: string; className?: string }) => (
+    <a href={href} className={className}>{children}</a>
+  ),
+}));
+
+vi.mock('@/components/media/ImageHtml', () => ({
+  default: ({ alt, src }: { alt: string; src: string }) => (
+    <img alt={alt} src={src} />
+  ),
+}));
+
+const mockProjets = [
+  {
+    uuid: 'proj-1',
+    slug: 'projet-1',
+    titre: 'Projet Test 1',
+    couverture: { url: '/img1.jpg', alternativeText: 'Image 1', alt: '', width: 420, height: 236, formats: null, ext: '.jpg', mime: 'image/jpeg', provider: 'local' },
+    montantAFinancer: 10000,
+    montantTotalDonations: 3000,
+    nbDons: 5,
+    dateLimiteFinancementProjet: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    sportType: 'Football',
+    klubr: {
+      uuid: 'klubr-1',
+      slug: 'mon-club',
+      denomination: 'Mon Club',
+      logo: { url: '/logo.png', alt: 'Logo' },
+    },
+  },
+  {
+    uuid: 'proj-2',
+    slug: 'projet-2',
+    titre: 'Projet Test 2',
+    couverture: { url: '/img2.jpg', alternativeText: 'Image 2', alt: '', width: 420, height: 236, formats: null, ext: '.jpg', mime: 'image/jpeg', provider: 'local' },
+    montantAFinancer: 5000,
+    montantTotalDonations: 0,
+    nbDons: 0,
+    dateLimiteFinancementProjet: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000),
+    sportType: '',
+    klubr: {
+      uuid: 'klubr-2',
+      slug: 'autre-club',
+      denomination: 'Autre Club',
+      logo: { url: '/logo2.png', alt: 'Logo 2' },
+    },
+  },
+  {
+    uuid: 'proj-3',
+    slug: 'projet-3',
+    titre: 'Projet Test 3',
+    couverture: { url: '/img3.jpg', alternativeText: 'Image 3', alt: '', width: 420, height: 236, formats: null, ext: '.jpg', mime: 'image/jpeg', provider: 'local' },
+    montantAFinancer: 2000,
+    montantTotalDonations: 2000,
+    nbDons: 12,
+    dateLimiteFinancementProjet: new Date(Date.now() + 10 * 24 * 60 * 60 * 1000),
+    sportType: 'Tennis',
+    klubr: {
+      uuid: 'klubr-3',
+      slug: 'club-tennis',
+      denomination: 'Club Tennis',
+      logo: { url: '/logo3.png', alt: 'Logo 3' },
+    },
+  },
+] as any;
+
+describe('NewHpProjects', () => {
+  it('renders section with title', () => {
+    render(<NewHpProjects projets={mockProjets} />);
+
+    const heading = screen.getByRole('heading', { level: 2 });
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent(/projets/i);
+  });
+
+  it('renders project cards in desktop grid', () => {
+    render(<NewHpProjects projets={mockProjets} />);
+
+    const articles = screen.getAllByRole('article');
+    expect(articles.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('renders nothing when no projects', () => {
+    const { container } = render(<NewHpProjects projets={[]} />);
+
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders CTA link to all projects', () => {
+    render(<NewHpProjects projets={mockProjets} />);
+
+    const ctaLink = screen.getByRole('link', { name: /voir tous les projets/i });
+    expect(ctaLink).toBeInTheDocument();
+    expect(ctaLink).toHaveAttribute('href', '/projets');
+  });
+
+  it('renders project titles', () => {
+    render(<NewHpProjects projets={mockProjets} />);
+
+    expect(screen.getAllByText(/projet test 1/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/projet test 2/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders club names', () => {
+    render(<NewHpProjects projets={mockProjets} />);
+
+    expect(screen.getAllByText(/mon club/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/autre club/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders social proof for projects with donations', () => {
+    render(<NewHpProjects projets={mockProjets} />);
+
+    expect(screen.getAllByText(/mécène/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders status badges', () => {
+    render(<NewHpProjects projets={mockProjets} />);
+
+    const enCoursItems = screen.getAllByText(/en cours/i);
+    expect(enCoursItems.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders subtitle', () => {
+    render(<NewHpProjects projets={mockProjets} />);
+
+    expect(screen.getByText(/découvrez les projets/i)).toBeInTheDocument();
+  });
+});

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/NewHpProjects.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/NewHpProjects.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import NewHpProjects from './index';
+import { getProjectDeadlineInfo } from './helpers';
 
 vi.mock('next/link', () => ({
   default: ({ children, href, className }: { children: React.ReactNode; href: string; className?: string }) => (
@@ -129,5 +130,82 @@ describe('NewHpProjects', () => {
     render(<NewHpProjects projets={mockProjets} />);
 
     expect(screen.getByText(/découvrez les projets/i)).toBeInTheDocument();
+  });
+
+  it('renders expired badge for past-deadline projects', () => {
+    render(<NewHpProjects projets={mockProjets} />);
+
+    expect(screen.getAllByText(/terminé/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders deadline badge for active projects', () => {
+    render(<NewHpProjects projets={mockProjets} />);
+
+    const deadlineBadges = screen.getAllByText(/J-\d+/);
+    expect(deadlineBadges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders card as div when klubr slug is missing', () => {
+    const projetsNoSlug = [{
+      ...mockProjets[0],
+      uuid: 'proj-no-slug',
+      klubr: { ...mockProjets[0].klubr, slug: '' },
+    }] as any;
+
+    const { container } = render(<NewHpProjects projets={projetsNoSlug} />);
+
+    const article = container.querySelector('article');
+    expect(article).toBeTruthy();
+    const link = article!.querySelector('a');
+    expect(link).toBeNull();
+  });
+
+  it('handles zero montantAFinancer without division error', () => {
+    const projetsZero = [{
+      ...mockProjets[0],
+      uuid: 'proj-zero',
+      montantAFinancer: 0,
+      montantTotalDonations: 100,
+    }] as any;
+
+    const { container } = render(<NewHpProjects projets={projetsZero} />);
+
+    const progressFill = container.querySelector('.new-hp-projects__progress-fill') as HTMLElement;
+    expect(progressFill).toBeTruthy();
+    expect(progressFill.style.width).toBe('0%');
+  });
+});
+
+describe('getProjectDeadlineInfo', () => {
+  it('returns not expired with daysLeft for future date', () => {
+    const future = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000);
+    const result = getProjectDeadlineInfo(future);
+
+    expect(result.isExpired).toBe(false);
+    expect(result.daysLeft).toBeGreaterThanOrEqual(9);
+    expect(result.daysLeft).toBeLessThanOrEqual(11);
+  });
+
+  it('returns expired with null daysLeft for past date', () => {
+    const past = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+    const result = getProjectDeadlineInfo(past);
+
+    expect(result.isExpired).toBe(true);
+    expect(result.daysLeft).toBeNull();
+  });
+
+  it('returns defaults for null input', () => {
+    const result = getProjectDeadlineInfo(null);
+
+    expect(result.isExpired).toBe(false);
+    expect(result.daysLeft).toBeNull();
+  });
+
+  it('handles string date input', () => {
+    const future = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString();
+    const result = getProjectDeadlineInfo(future);
+
+    expect(result.isExpired).toBe(false);
+    expect(result.daysLeft).toBeGreaterThanOrEqual(4);
   });
 });

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/ProjectsCarousel.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/ProjectsCarousel.tsx
@@ -4,6 +4,8 @@ import { KlubProjet } from '@/core/models/klub-project';
 import { useRef, useState, useCallback, useEffect } from 'react';
 import NewHpProjectCard from './NewHpProjectCard';
 
+const SLIDE_WIDTH_PERCENT = 0.82;
+
 type ProjectsCarouselProps = {
   projets: Array<KlubProjet>;
 };
@@ -15,7 +17,7 @@ export default function ProjectsCarousel({ projets }: ProjectsCarouselProps) {
   const handleScroll = useCallback(() => {
     if (!scrollRef.current) return;
     const { scrollLeft, clientWidth } = scrollRef.current;
-    const index = Math.round(scrollLeft / (clientWidth * 0.82));
+    const index = Math.round(scrollLeft / (clientWidth * SLIDE_WIDTH_PERCENT));
     setActiveIndex(Math.min(index, projets.length - 1));
   }, [projets.length]);
 

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/ProjectsCarousel.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/ProjectsCarousel.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { KlubProjet } from '@/core/models/klub-project';
+import { useRef, useState, useCallback, useEffect } from 'react';
+import NewHpProjectCard from './NewHpProjectCard';
+
+type ProjectsCarouselProps = {
+  projets: Array<KlubProjet>;
+};
+
+export default function ProjectsCarousel({ projets }: ProjectsCarouselProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const handleScroll = useCallback(() => {
+    if (!scrollRef.current) return;
+    const { scrollLeft, clientWidth } = scrollRef.current;
+    const index = Math.round(scrollLeft / (clientWidth * 0.82));
+    setActiveIndex(Math.min(index, projets.length - 1));
+  }, [projets.length]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.addEventListener('scroll', handleScroll, { passive: true });
+    return () => el.removeEventListener('scroll', handleScroll);
+  }, [handleScroll]);
+
+  const scrollTo = (index: number) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const slide = el.children[index] as HTMLElement | undefined;
+    if (!slide) return;
+    el.scrollTo({
+      left: slide.offsetLeft - el.offsetLeft,
+      behavior: 'smooth',
+    });
+  };
+
+  const canGoPrev = activeIndex > 0;
+  const canGoNext = activeIndex < projets.length - 1;
+
+  return (
+    <div className="new-hp-projects__carousel relative">
+      <div
+        ref={scrollRef}
+        className="new-hp-projects__carousel-track flex gap-4 overflow-x-auto snap-x snap-mandatory pb-4 -mx-6 px-6"
+        role="region"
+        aria-label="Projets à la une"
+      >
+        {projets.map((projet, index) => (
+          <div
+            key={projet.uuid || index}
+            className="new-hp-projects__carousel-slide flex-none w-[82%] snap-start"
+          >
+            <NewHpProjectCard projet={projet} index={index} />
+          </div>
+        ))}
+      </div>
+
+      {/* Navigation: arrows + dots */}
+      {projets.length > 1 && (
+        <div className="flex items-center justify-center gap-4 mt-4">
+          {/* Prev arrow */}
+          <button
+            className={`new-hp-projects__arrow flex items-center justify-center w-8 h-8 rounded-full border border-gray-300 transition-all duration-200 ${
+              canGoPrev
+                ? 'text-gray-700 hover:bg-gray-100 hover:border-gray-400'
+                : 'text-gray-300 cursor-default'
+            }`}
+            onClick={() => canGoPrev && scrollTo(activeIndex - 1)}
+            disabled={!canGoPrev}
+            aria-label="Projet précédent"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M10 12L6 8l4-4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+
+          {/* Dot indicators */}
+          <div className="flex gap-2" role="tablist" aria-label="Navigation projets">
+            {projets.map((_, index) => (
+              <button
+                key={index}
+                className={`new-hp-projects__dot w-2 h-2 rounded-full transition-all duration-300 ${
+                  index === activeIndex
+                    ? 'bg-gray-900 w-6'
+                    : 'bg-gray-300'
+                }`}
+                onClick={() => scrollTo(index)}
+                role="tab"
+                aria-selected={index === activeIndex}
+                aria-label={`Projet ${index + 1}`}
+              />
+            ))}
+          </div>
+
+          {/* Next arrow */}
+          <button
+            className={`new-hp-projects__arrow flex items-center justify-center w-8 h-8 rounded-full border border-gray-300 transition-all duration-200 ${
+              canGoNext
+                ? 'text-gray-700 hover:bg-gray-100 hover:border-gray-400'
+                : 'text-gray-300 cursor-default'
+            }`}
+            onClick={() => canGoNext && scrollTo(activeIndex + 1)}
+            disabled={!canGoNext}
+            aria-label="Projet suivant"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M6 4l4 4-4 4" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+            </svg>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/helpers.ts
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/helpers.ts
@@ -1,0 +1,18 @@
+/**
+ * Calculates deadline info for a project based on its funding deadline date.
+ */
+export function getProjectDeadlineInfo(dateLimiteFinancementProjet: Date | string | null | undefined) {
+  if (!dateLimiteFinancementProjet) {
+    return { isExpired: false, daysLeft: null };
+  }
+
+  const deadline = new Date(dateLimiteFinancementProjet);
+  const now = new Date();
+  const diffMs = deadline.getTime() - now.getTime();
+  const daysLeft = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+
+  return {
+    isExpired: daysLeft < 0,
+    daysLeft: daysLeft >= 0 ? daysLeft : null,
+  };
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/index.scss
@@ -1,0 +1,230 @@
+// Design tokens
+$color-primary: #73cfa8;
+$color-dark: #000;
+
+// Animation timing
+$entrance-duration: 0.6s;
+$entrance-delay-base: 0.15s;
+$entrance-delay-step: 0.1s;
+$hover-duration: 0.3s;
+
+.new-hp-projects {
+  background: linear-gradient(180deg, #f3f4f6 0%, #f9fafb 40%, #ffffff 100%);
+  position: relative;
+  overflow: hidden;
+
+  // Decorative background blobs
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    border-radius: 50%;
+    pointer-events: none;
+    opacity: 0.4;
+  }
+
+  &::before {
+    width: 400px;
+    height: 400px;
+    background: radial-gradient(circle, rgba($color-primary, 0.15) 0%, transparent 70%);
+    top: -100px;
+    right: -120px;
+  }
+
+  &::after {
+    width: 300px;
+    height: 300px;
+    background: radial-gradient(circle, rgba($color-primary, 0.1) 0%, transparent 70%);
+    bottom: -80px;
+    left: -80px;
+  }
+
+  &__title {
+    opacity: 0;
+    animation: nhp-title-entrance $entrance-duration ease-out forwards;
+  }
+
+  &__subtitle {
+    opacity: 0;
+    animation: nhp-title-entrance $entrance-duration ease-out 0.1s forwards;
+  }
+
+  // Card animations
+  &__card {
+    opacity: 0;
+    animation: nhp-card-entrance $entrance-duration ease-out forwards;
+    animation-delay: calc(
+      var(--card-index) * #{$entrance-delay-step} + #{$entrance-delay-base}
+    );
+  }
+
+  &__card-content {
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.95);
+    border: 1px solid rgba(229, 231, 235, 0.8);
+    overflow: hidden;
+    height: 100%;
+    transition:
+      transform $hover-duration ease,
+      border-color $hover-duration ease,
+      box-shadow $hover-duration ease;
+
+    &:hover {
+      transform: translateY(-6px);
+      border-color: rgba($color-primary, 0.4);
+      box-shadow:
+        0 12px 32px -12px rgba($color-primary, 0.2),
+        0 6px 16px -6px rgba(0, 0, 0, 0.06);
+    }
+  }
+
+  &__card-image {
+    img {
+      transition: transform $hover-duration ease;
+    }
+  }
+
+  &__card-content:hover &__card-image img {
+    transform: scale(1.05);
+  }
+
+  // Progress bar
+  &__progress-fill {
+    background: linear-gradient(90deg, $color-primary 0%, #5cb893 100%);
+    transition: width 0.8s ease-out;
+  }
+
+  // Badges
+  &__badge,
+  &__status-badge,
+  &__deadline-badge {
+    transition:
+      background $hover-duration ease,
+      transform $hover-duration ease;
+  }
+
+  &__card-content:hover &__badge {
+    background: rgba(255, 255, 255, 0.95);
+  }
+
+  // Social proof
+  &__social-proof {
+    opacity: 0;
+    animation: nhp-fade-in 0.4s ease-out 0.6s forwards;
+  }
+
+  // Carousel
+  &__carousel-track {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  &__carousel-slide {
+    .new-hp-projects__card {
+      opacity: 1;
+      animation: none;
+    }
+
+    .new-hp-projects__social-proof {
+      opacity: 1;
+      animation: none;
+    }
+  }
+
+  // Arrows
+  &__arrow {
+    flex-shrink: 0;
+
+    &:disabled {
+      opacity: 0.4;
+    }
+  }
+
+  // CTA
+  &__cta {
+    opacity: 0;
+    animation: nhp-title-entrance $entrance-duration ease-out 0.5s forwards;
+  }
+}
+
+// Keyframes
+@keyframes nhp-title-entrance {
+  0% {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes nhp-card-entrance {
+  0% {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes nhp-fade-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+// Responsive
+@media (max-width: 767px) {
+  .new-hp-projects {
+    &__card-body {
+      padding: 1rem;
+    }
+
+    &::before {
+      width: 250px;
+      height: 250px;
+      top: -60px;
+      right: -80px;
+    }
+
+    &::after {
+      width: 200px;
+      height: 200px;
+      bottom: -50px;
+      left: -50px;
+    }
+  }
+}
+
+// Reduced motion
+@media (prefers-reduced-motion: reduce) {
+  .new-hp-projects {
+    &__title,
+    &__subtitle,
+    &__card,
+    &__cta,
+    &__social-proof {
+      animation: none;
+      opacity: 1;
+    }
+
+    &__card-content,
+    &__card-image img,
+    &__badge,
+    &__status-badge,
+    &__deadline-badge,
+    &__progress-fill {
+      transition: none;
+    }
+  }
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpProjects/index.tsx
@@ -1,0 +1,54 @@
+import { KlubProjet } from '@/core/models/klub-project';
+import Link from 'next/link';
+import NewHpProjectCard from './NewHpProjectCard';
+import ProjectsCarousel from './ProjectsCarousel';
+import './index.scss';
+
+type NewHpProjectsProps = {
+  projets: Array<KlubProjet>;
+};
+
+export default function NewHpProjects({ projets }: NewHpProjectsProps) {
+  if (!projets.length) return null;
+
+  return (
+    <section className="new-hp-projects w-full py-16 md:py-20 lg:py-24">
+      <div className="max-w-[1320px] mx-auto px-6">
+        <div className="new-hp-projects__header text-center mb-12 md:mb-16">
+          <h2 className="new-hp-projects__title text-2xl md:text-3xl lg:text-4xl font-bold text-gray-900 mb-4">
+            Projets à la une
+          </h2>
+          <p className="new-hp-projects__subtitle text-base md:text-lg text-gray-500 max-w-2xl mx-auto">
+            Découvrez les projets qui font vibrer le sport associatif
+          </p>
+        </div>
+
+        {/* Desktop/Tablet grid: 2 cols on tablet, 3 on desktop */}
+        <div className="new-hp-projects__grid hidden md:grid md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
+          {projets.map((projet, index) => (
+            <NewHpProjectCard
+              key={projet.uuid || index}
+              projet={projet}
+              index={index}
+              className={index >= 2 ? 'hidden lg:block' : ''}
+            />
+          ))}
+        </div>
+
+        {/* Mobile: horizontal scroll carousel */}
+        <div className="md:hidden">
+          <ProjectsCarousel projets={projets} />
+        </div>
+
+        <div className="new-hp-projects__cta flex justify-center mt-10 md:mt-14">
+          <Link
+            href="/projets"
+            className="btn btn-outline-primary py-[10px] px-8 rounded-xl font-semibold"
+          >
+            Voir tous les projets
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
@@ -4,8 +4,15 @@ import NewHpWhyDonaction from './NewHpWhyDonaction';
 import NewHpFeatures from './NewHpFeatures';
 import NewHpTimeline from './NewHpTimeline';
 import NewHpWidgetDemo from './NewHpWidgetDemo';
+import NewHpProjects from './NewHpProjects';
+import { KlubProjet } from '@/core/models/klub-project';
+import { Pagination } from '@/core/models/misc';
 
-export default function NewHomepageContent() {
+type NewHomepageContentProps = {
+  projets?: { data: Array<KlubProjet>; meta: { pagination: Pagination } };
+};
+
+export default function NewHomepageContent({ projets }: NewHomepageContentProps) {
   return (
     <main className="flex flex-col items-center justify-center text-black w-full">
       <NewHpHero />
@@ -14,6 +21,7 @@ export default function NewHomepageContent() {
       <NewHpFeatures />
       <NewHpTimeline />
       <NewHpWidgetDemo />
+      <NewHpProjects projets={projets?.data || []} />
     </main>
   );
 }

--- a/donaction-frontend/vitest.config.ts
+++ b/donaction-frontend/vitest.config.ts
@@ -28,6 +28,11 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      '@/components': resolve(__dirname, './src/layouts/components'),
+      '@/partials': resolve(__dirname, './src/layouts/partials'),
+      '@/helpers': resolve(__dirname, './src/layouts/helpers'),
+      '@/shortcodes': resolve(__dirname, './src/layouts/shortcodes'),
+      '@/shapes': resolve(__dirname, './src/shapes'),
       '@': resolve(__dirname, './src'),
     },
   },


### PR DESCRIPTION
## Summary
- Implement `NewHpProjects` component showing up to 3 latest featured projects on the new homepage
- Compact project cards with cover image, club info, progress bar, status badges, deadline countdown (J-XX), and social proof (mécènes count)
- Mobile carousel with CSS scroll-snap, arrow buttons, and dot indicators
- Responsive: 3 columns desktop, 2 columns tablet, carousel mobile
- Decorative background blobs and entrance animations matching existing NewHp design language
- Fix vitest aliases to match tsconfig path mappings

## Test plan
- [x] 9 unit tests passing (render, empty state, CTA, titles, clubs, social proof, status badges)
- [x] All 69 existing NewHp tests still passing (no regressions)
- [x] TypeScript compilation clean
- [x] Browser validated at 375px (mobile), 768px (tablet), 1440px (desktop)
- [x] Mobile carousel scroll fixed (no layout shift on 3rd card)
- [x] Console: no errors

Closes #110