### PR TITLE
feat(frontend): merge pricing into NewHpFeatures (#112)

### DIFF
--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/NewHpFeatures.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/NewHpFeatures.test.tsx
@@ -22,19 +22,68 @@ vi.mock("next/link", () => ({
 }));
 
 describe("NewHpFeatures", () => {
+  it("renders as a section element with correct BEM class", () => {
+    const { container } = render(<NewHpFeatures />);
+
+    const section = container.querySelector("section");
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveClass("new-hp-features");
+  });
+
   it("renders section title", () => {
     render(<NewHpFeatures />);
 
     const heading = screen.getByRole("heading", { level: 2 });
     expect(heading).toBeInTheDocument();
-    expect(heading).toHaveTextContent(/fonctionnalités/i);
+    expect(heading).toHaveTextContent(/nos offres/i);
   });
 
   it("renders both tier badges", () => {
     render(<NewHpFeatures />);
 
-    expect(screen.getByText(/gratuit/i)).toBeInTheDocument();
-    expect(screen.getByText(/premium/i)).toBeInTheDocument();
+    const gratuitElements = screen.getAllByText(/gratuit/i);
+    expect(gratuitElements.length).toBeGreaterThanOrEqual(1);
+
+    const premiumElements = screen.getAllByText(/premium/i);
+    expect(premiumElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders free tier price as 0\u20ac", () => {
+    render(<NewHpFeatures />);
+
+    const priceElements = screen.getAllByText("0\u20ac");
+    expect(priceElements.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders premium tier price as 69\u20ac", () => {
+    render(<NewHpFeatures />);
+
+    expect(screen.getByText("69\u20ac")).toBeInTheDocument();
+  });
+
+  it("renders fee rates for both tiers", () => {
+    render(<NewHpFeatures />);
+
+    expect(screen.getByText("6%")).toBeInTheDocument();
+    expect(screen.getByText("1,75%")).toBeInTheDocument();
+  });
+
+  it("renders fee labels with asterisk", () => {
+    render(<NewHpFeatures />);
+
+    const feeLabels = screen.getAllByText("Frais plateforme*");
+    expect(feeLabels).toHaveLength(2);
+  });
+
+  it("renders footnotes inside each tier card", () => {
+    render(<NewHpFeatures />);
+
+    expect(
+      screen.getByText(/frais bancaires.*fonctionnement/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/uniquement les frais bancaires/i)
+    ).toBeInTheDocument();
   });
 
   it("renders all 4 free feature cards", () => {
@@ -71,28 +120,43 @@ describe("NewHpFeatures", () => {
     expect(screen.getByText(/virement/i)).toBeInTheDocument();
   });
 
-  it("renders feature subtitles", () => {
+  it("renders free CTA linking to /inscription", () => {
     render(<NewHpFeatures />);
 
-    // Free subtitles
-    expect(screen.getByText(/formulaire de don/i)).toBeInTheDocument();
-    expect(screen.getByText(/suivi des dons/i)).toBeInTheDocument();
-    expect(screen.getByText(/alertes/i)).toBeInTheDocument();
-    expect(screen.getByText(/cerfa/i)).toBeInTheDocument();
-
-    // Premium subtitles
-    expect(screen.getByText(/financement participatif/i)).toBeInTheDocument();
-    expect(screen.getByText(/intégration/i)).toBeInTheDocument();
-    expect(screen.getByText(/comptables/i)).toBeInTheDocument();
-    expect(screen.getByText(/automatiques/i)).toBeInTheDocument();
+    const freeLink = screen.getByLabelText(/offre Gratuite/i);
+    expect(freeLink).toHaveAttribute("href", "/inscription");
+    expect(freeLink).toHaveTextContent(/commencer gratuitement/i);
   });
 
-  it("renders SVG icons for each card with aria-hidden", () => {
+  it("renders premium CTA linking to /inscription?plan=premium", () => {
+    render(<NewHpFeatures />);
+
+    const premiumLink = screen.getByLabelText(/offre Premium/i);
+    expect(premiumLink).toHaveAttribute("href", "/inscription?plan=premium");
+    expect(premiumLink).toHaveTextContent(/choisir premium/i);
+  });
+
+  it("renders donation example section", () => {
+    render(<NewHpFeatures />);
+
+    const headings = screen.getAllByRole("heading", { level: 3 });
+    const exampleHeading = headings.find((h) => /100/.test(h.textContent || ""));
+    expect(exampleHeading).toBeDefined();
+    expect(exampleHeading).toHaveTextContent(/100\u20ac/);
+  });
+
+  it("donation example shows correct amounts", () => {
+    render(<NewHpFeatures />);
+
+    expect(screen.getByText("94\u20ac")).toBeInTheDocument();
+    expect(screen.getByText("98.25\u20ac")).toBeInTheDocument();
+  });
+
+  it("SVG icons have aria-hidden", () => {
     const { container } = render(<NewHpFeatures />);
 
     const svgIcons = container.querySelectorAll("svg");
-    // 8 feature icons + 2 badge icons (checkmark and star)
-    expect(svgIcons).toHaveLength(10);
+    expect(svgIcons.length).toBeGreaterThan(0);
 
     svgIcons.forEach((svg) => {
       expect(svg).toHaveAttribute("aria-hidden", "true");
@@ -102,36 +166,14 @@ describe("NewHpFeatures", () => {
   it("has proper accessibility structure", () => {
     render(<NewHpFeatures />);
 
-    // Two lists with aria-labels
     const lists = screen.getAllByRole("list");
     expect(lists.length).toBeGreaterThanOrEqual(2);
 
-    // Lists should have aria-labels
     expect(
       screen.getByRole("list", { name: /gratuites/i })
     ).toBeInTheDocument();
-    expect(screen.getByRole("list", { name: /premium/i })).toBeInTheDocument();
-  });
-
-  it("renders as a section element", () => {
-    const { container } = render(<NewHpFeatures />);
-
-    const section = container.querySelector("section");
-    expect(section).toBeInTheDocument();
-    expect(section).toHaveClass("new-hp-features");
-  });
-
-  it("free tier links to /inscription", () => {
-    render(<NewHpFeatures />);
-
-    const freeLink = screen.getByLabelText(/offre Gratuite/i);
-    expect(freeLink).toHaveAttribute("href", "/inscription");
-  });
-
-  it("premium tier links to /inscription with plan query param", () => {
-    render(<NewHpFeatures />);
-
-    const premiumLink = screen.getByLabelText(/offre Premium/i);
-    expect(premiumLink).toHaveAttribute("href", "/inscription?plan=premium");
+    expect(
+      screen.getByRole("list", { name: /premium/i })
+    ).toBeInTheDocument();
   });
 });

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.scss
@@ -196,11 +196,206 @@ $hover-duration: 0.3s;
     line-height: 1;
   }
 
+  &__price--free {
+    color: $color-primary-dark;
+  }
+
   &__price-period {
     font-size: 1rem;
     font-weight: 500;
-    color: $color-premium-dark;
+    color: #6b7280;
     opacity: 0.8;
+  }
+
+  // Fee badge
+  &__fee {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border-radius: 12px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    margin-top: 0.75rem;
+  }
+
+  &__fee--free {
+    background: rgba(115, 207, 168, 0.1);
+    color: $color-primary-dark;
+  }
+
+  &__fee--premium {
+    background: rgba(245, 158, 11, 0.1);
+    color: $color-premium-dark;
+  }
+
+  &__fee-rate {
+    font-weight: 700;
+    font-size: 1rem;
+  }
+
+  &__fee-label {
+    font-weight: 500;
+  }
+
+  // CTA buttons
+  &__cta {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 1rem 2rem;
+    border-radius: 14px;
+    font-size: 1rem;
+    font-weight: 700;
+    text-decoration: none;
+    transition: all $hover-duration ease;
+    text-align: center;
+    margin-top: 2rem;
+  }
+
+  &__cta--free {
+    background: transparent;
+    color: $color-primary-dark;
+    border: 2px solid rgba(115, 207, 168, 0.4);
+  }
+
+  &__cta--premium {
+    background: linear-gradient(135deg, $color-premium 0%, $color-premium-dark 100%);
+    color: white;
+    border: 2px solid transparent;
+    box-shadow: 0 8px 24px -4px rgba(245, 158, 11, 0.35);
+  }
+
+  &__arrow-icon {
+    width: 18px;
+    height: 18px;
+    transition: transform $hover-duration ease;
+  }
+
+  // Donation example
+  &__example {
+    max-width: 720px;
+    margin: 3rem auto 0;
+    padding: 2rem;
+    border-radius: 20px;
+    background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
+    border: 1.5px solid rgba(0, 0, 0, 0.06);
+    opacity: 0;
+    animation: features-example-entrance $entrance-duration ease-out calc(#{$entrance-delay-base} + 0.5s) forwards;
+
+    @media (min-width: 768px) {
+      padding: 2.5rem 3rem;
+    }
+  }
+
+  &__example-title {
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: #111827;
+    text-align: center;
+    margin-bottom: 1.5rem;
+
+    @media (min-width: 768px) {
+      font-size: 1.25rem;
+    }
+  }
+
+  &__example-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    @media (min-width: 640px) {
+      flex-direction: row;
+      gap: 1.5rem;
+    }
+  }
+
+  &__example-card {
+    flex: 1;
+    padding: 1.25rem;
+    border-radius: 14px;
+    background: white;
+    border: 1.5px solid rgba(0, 0, 0, 0.06);
+  }
+
+  &__example-card--free {
+    border-color: rgba(115, 207, 168, 0.2);
+  }
+
+  &__example-card--premium {
+    border-color: rgba(245, 158, 11, 0.25);
+    background: linear-gradient(135deg, #fffbeb 0%, #ffffff 100%);
+  }
+
+  &__example-tier {
+    display: block;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #6b7280;
+    margin-bottom: 0.75rem;
+  }
+
+  &__example-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.375rem 0;
+    font-size: 0.875rem;
+    color: #4b5563;
+  }
+
+  &__example-row--result {
+    margin-top: 0.5rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid rgba(0, 0, 0, 0.06);
+  }
+
+  &__example-label {
+    font-weight: 500;
+  }
+
+  &__example-value {
+    font-weight: 600;
+  }
+
+  &__example-amount {
+    font-size: 1.25rem;
+    font-weight: 800;
+
+    @media (min-width: 768px) {
+      font-size: 1.5rem;
+    }
+  }
+
+  &__example-amount--free {
+    color: $color-primary-dark;
+  }
+
+  &__example-amount--premium {
+    color: $color-premium-dark;
+  }
+
+  // Footnote (inside each tier card)
+  &__footnote {
+    text-align: center;
+    color: #9ca3af;
+    font-size: 0.75rem;
+    font-style: italic;
+    margin-top: 1.5rem;
+    line-height: 1.4;
+  }
+
+  &__footnote--free {
+    color: rgba($color-primary-dark, 0.5);
+  }
+
+  &__footnote--premium {
+    color: rgba($color-premium-dark, 0.55);
   }
 
   &__tier-badge-highlight {
@@ -472,6 +667,21 @@ $hover-duration: 0.3s;
     &__card-content:hover &__icon {
       transform: scale(1.15) rotate(5deg);
     }
+
+    &__cta--free:hover {
+      background: rgba(115, 207, 168, 0.1);
+      border-color: rgba(115, 207, 168, 0.6);
+      transform: translateY(-2px);
+    }
+
+    &__cta--premium:hover {
+      box-shadow: 0 12px 32px -4px rgba(245, 158, 11, 0.45);
+      transform: translateY(-2px);
+    }
+
+    &__cta:hover &__arrow-icon {
+      transform: translateX(4px);
+    }
   }
 }
 
@@ -524,6 +734,17 @@ $hover-duration: 0.3s;
   }
   50%, 100% {
     left: 100%;
+  }
+}
+
+@keyframes features-example-entrance {
+  0% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 
@@ -637,9 +858,16 @@ $hover-duration: 0.3s;
       animation: none;
     }
 
+    &__example {
+      animation: none;
+      opacity: 1;
+    }
+
     &__card-content,
     &__icon-wrapper,
-    &__icon {
+    &__icon,
+    &__cta,
+    &__arrow-icon {
       transition: none;
     }
   }

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.scss
@@ -689,33 +689,33 @@ $hover-duration: 0.3s;
 @keyframes title-entrance {
   0% {
     opacity: 0;
-    transform: translateY(-30px);
+    transform: translate3d(0, -30px, 0);
   }
   100% {
     opacity: 1;
-    transform: translateY(0);
+    transform: translate3d(0, 0, 0);
   }
 }
 
 @keyframes tier-entrance {
   0% {
     opacity: 0;
-    transform: translateY(30px) scale(0.98);
+    transform: translate3d(0, 30px, 0) scale(0.98);
   }
   100% {
     opacity: 1;
-    transform: translateY(0) scale(1);
+    transform: translate3d(0, 0, 0) scale(1);
   }
 }
 
 @keyframes card-entrance {
   0% {
     opacity: 0;
-    transform: translateY(28px) scale(0.95);
+    transform: translate3d(0, 28px, 0) scale(0.95);
   }
   100% {
     opacity: 1;
-    transform: translateY(0) scale(1);
+    transform: translate3d(0, 0, 0) scale(1);
   }
 }
 
@@ -740,11 +740,11 @@ $hover-duration: 0.3s;
 @keyframes features-example-entrance {
   0% {
     opacity: 0;
-    transform: translateY(20px);
+    transform: translate3d(0, 20px, 0);
   }
   100% {
     opacity: 1;
-    transform: translateY(0);
+    transform: translate3d(0, 0, 0);
   }
 }
 

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.scss
@@ -13,6 +13,14 @@ $entrance-delay-base: 0.15s;
 $entrance-delay-step: 0.08s;
 $hover-duration: 0.3s;
 
+// Borders & shadows
+$border-subtle: 1.5px solid rgba(0, 0, 0, 0.06);
+$border-separator: 1px solid rgba(0, 0, 0, 0.06);
+$shadow-premium: 0 8px 24px -4px rgba($color-premium, 0.35);
+$shadow-premium-hover: 0 12px 32px -4px rgba($color-premium, 0.45);
+$shadow-cta-premium: 0 4px 12px rgba($color-premium, 0.3);
+$shadow-cta-premium-hover: 0 8px 20px rgba($color-premium, 0.3);
+
 .new-hp-features {
   background: linear-gradient(180deg, #ffffff 0%, #f9fafb 50%, #f3f4f6 100%);
   position: relative;
@@ -265,7 +273,7 @@ $hover-duration: 0.3s;
     background: linear-gradient(135deg, $color-premium 0%, $color-premium-dark 100%);
     color: white;
     border: 2px solid transparent;
-    box-shadow: 0 8px 24px -4px rgba(245, 158, 11, 0.35);
+    box-shadow: $shadow-premium;
   }
 
   &__arrow-icon {
@@ -281,7 +289,7 @@ $hover-duration: 0.3s;
     padding: 2rem;
     border-radius: 20px;
     background: linear-gradient(135deg, #f8fafc 0%, #f1f5f9 100%);
-    border: 1.5px solid rgba(0, 0, 0, 0.06);
+    border: $border-subtle;
     opacity: 0;
     animation: features-example-entrance $entrance-duration ease-out calc(#{$entrance-delay-base} + 0.5s) forwards;
 
@@ -318,7 +326,7 @@ $hover-duration: 0.3s;
     padding: 1.25rem;
     border-radius: 14px;
     background: white;
-    border: 1.5px solid rgba(0, 0, 0, 0.06);
+    border: $border-subtle;
   }
 
   &__example-card--free {
@@ -352,7 +360,7 @@ $hover-duration: 0.3s;
   &__example-row--result {
     margin-top: 0.5rem;
     padding-top: 0.75rem;
-    border-top: 1px solid rgba(0, 0, 0, 0.06);
+    border-top: $border-separator;
   }
 
   &__example-label {
@@ -411,7 +419,7 @@ $hover-duration: 0.3s;
     font-size: 0.875rem;
     font-weight: 700;
     letter-spacing: 0.05em;
-    box-shadow: 0 8px 20px rgba(245, 158, 11, 0.3);
+    box-shadow: $shadow-cta-premium-hover;
     animation: float 3s ease-in-out infinite;
     white-space: nowrap;
   }
@@ -438,7 +446,7 @@ $hover-duration: 0.3s;
     background: linear-gradient(135deg, $color-premium 0%, $color-premium-dark 100%);
     color: white;
     border: 1px solid rgba(245, 158, 11, 0.6);
-    box-shadow: 0 4px 12px rgba(245, 158, 11, 0.3);
+    box-shadow: $shadow-cta-premium;
   }
 
   &__badge-icon {
@@ -675,7 +683,7 @@ $hover-duration: 0.3s;
     }
 
     &__cta--premium:hover {
-      box-shadow: 0 12px 32px -4px rgba(245, 158, 11, 0.45);
+      box-shadow: $shadow-premium-hover;
       transform: translateY(-2px);
     }
 

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.tsx
@@ -24,20 +24,33 @@ type CardStyle = React.CSSProperties & { "--card-index": number };
 
 const CURRENCY = "€";
 
-const PRICING = {
-  FREE_MONTHLY: `0${CURRENCY}`,
-  PREMIUM_MONTHLY: `69${CURRENCY}`,
-} as const;
+/** Format a number using French locale (e.g. 1.75 → "1,75") */
+const formatFr = (value: number, decimals = 2): string =>
+  new Intl.NumberFormat("fr-FR", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: decimals,
+  }).format(value);
 
+/** Round to 2 decimals to avoid floating-point drift */
+const round2 = (value: number): number =>
+  Math.round(value * 100) / 100;
+
+/** Transaction fee rates applied per donation (not subscription fees) */
 const FEE_RATES = {
   FREE: 6,
   PREMIUM: 1.75,
 } as const;
 
+/** Monthly subscription price per tier */
+const PRICING = {
+  FREE_MONTHLY: `0${CURRENCY}`,
+  PREMIUM_MONTHLY: `69${CURRENCY}`,
+} as const;
+
 const FEES = {
   FREE_RATE: `${FEE_RATES.FREE}%`,
   FREE_LABEL: "Frais plateforme*",
-  PREMIUM_RATE: `${FEE_RATES.PREMIUM.toFixed(2).replace(".", ",")}%`,
+  PREMIUM_RATE: `${formatFr(FEE_RATES.PREMIUM)}%`,
   PREMIUM_LABEL: "Frais plateforme*",
 } as const;
 
@@ -63,14 +76,14 @@ const DONATION_EXAMPLE = {
     {
       id: "free",
       name: "Gratuit",
-      feeAmount: DONATION_AMOUNT * (FEE_RATES.FREE / 100),
-      netAmount: DONATION_AMOUNT * (1 - FEE_RATES.FREE / 100),
+      feeAmount: round2(DONATION_AMOUNT * (FEE_RATES.FREE / 100)),
+      netAmount: round2(DONATION_AMOUNT * (1 - FEE_RATES.FREE / 100)),
     },
     {
       id: "premium",
       name: "Premium",
-      feeAmount: DONATION_AMOUNT * (FEE_RATES.PREMIUM / 100),
-      netAmount: DONATION_AMOUNT * (1 - FEE_RATES.PREMIUM / 100),
+      feeAmount: round2(DONATION_AMOUNT * (FEE_RATES.PREMIUM / 100)),
+      netAmount: round2(DONATION_AMOUNT * (1 - FEE_RATES.PREMIUM / 100)),
     },
   ] as DonationExampleTier[],
 } as const;

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.tsx
@@ -22,23 +22,32 @@ interface FeatureItem {
 
 type CardStyle = React.CSSProperties & { "--card-index": number };
 
+const CURRENCY = "€";
+
 const PRICING = {
-  FREE_MONTHLY: "0\u20ac",
-  PREMIUM_MONTHLY: "69\u20ac",
+  FREE_MONTHLY: `0${CURRENCY}`,
+  PREMIUM_MONTHLY: `69${CURRENCY}`,
+} as const;
+
+const FEE_RATES = {
+  FREE: 6,
+  PREMIUM: 1.75,
 } as const;
 
 const FEES = {
-  FREE_RATE: "6%",
+  FREE_RATE: `${FEE_RATES.FREE}%`,
   FREE_LABEL: "Frais plateforme*",
-  PREMIUM_RATE: "1,75%",
+  PREMIUM_RATE: `${FEE_RATES.PREMIUM.toFixed(2).replace(".", ",")}%`,
   PREMIUM_LABEL: "Frais plateforme*",
 } as const;
 
 const LABELS = {
-  PREMIUM_BADGE: "\u2b50 Bient\u00f4t disponible",
+  PREMIUM_BADGE: "⭐ Bientôt disponible",
   FREE_FOOTNOTE: "*Frais bancaires + frais de fonctionnement Donaction",
   PREMIUM_FOOTNOTE: "*Uniquement les frais bancaires",
 } as const;
+
+const DONATION_AMOUNT = 100;
 
 interface DonationExampleTier {
   id: string;
@@ -48,11 +57,21 @@ interface DonationExampleTier {
 }
 
 const DONATION_EXAMPLE = {
-  amount: 100,
-  currency: "\u20ac",
+  amount: DONATION_AMOUNT,
+  currency: CURRENCY,
   tiers: [
-    { id: "free", name: "Gratuit", feeAmount: 6, netAmount: 94 },
-    { id: "premium", name: "Premium", feeAmount: 1.75, netAmount: 98.25 },
+    {
+      id: "free",
+      name: "Gratuit",
+      feeAmount: DONATION_AMOUNT * (FEE_RATES.FREE / 100),
+      netAmount: DONATION_AMOUNT * (1 - FEE_RATES.FREE / 100),
+    },
+    {
+      id: "premium",
+      name: "Premium",
+      feeAmount: DONATION_AMOUNT * (FEE_RATES.PREMIUM / 100),
+      netAmount: DONATION_AMOUNT * (1 - FEE_RATES.PREMIUM / 100),
+    },
   ] as DonationExampleTier[],
 } as const;
 
@@ -224,7 +243,7 @@ function DonationExampleBox() {
               </span>
             </div>
             <div className="new-hp-features__example-row new-hp-features__example-row--result">
-              <span className="new-hp-features__example-label">Votre club re&ccedil;oit</span>
+              <span className="new-hp-features__example-label">Votre club reçoit</span>
               <span className={`new-hp-features__example-amount new-hp-features__example-amount--${tier.id}`}>
                 {tier.netAmount}{currency}
               </span>
@@ -243,7 +262,7 @@ export default function NewHpFeatures() {
         <div className="new-hp-features__header">
           <h2 className="new-hp-features__title">Nos offres</h2>
           <p className="new-hp-features__subtitle">
-            Fonctionnalit&eacute;s et tarifs en toute transparence
+            Fonctionnalités et tarifs en toute transparence
           </p>
         </div>
 
@@ -276,7 +295,7 @@ export default function NewHpFeatures() {
               <ul
                 className="new-hp-features__cards"
                 role="list"
-                aria-label="Fonctionnalit&eacute;s gratuites"
+                aria-label="Fonctionnalités gratuites"
               >
                 {FREE_FEATURES.map((feature, index) => (
                   <FeatureCard
@@ -293,7 +312,7 @@ export default function NewHpFeatures() {
               <Link
                 href="/inscription"
                 className="new-hp-features__cta new-hp-features__cta--free"
-                aria-label="S&apos;inscrire &agrave; l&apos;offre Gratuite"
+                aria-label="S'inscrire à l'offre Gratuite"
               >
                 Commencer gratuitement
                 <ArrowIcon />
@@ -326,13 +345,13 @@ export default function NewHpFeatures() {
                   <span className="new-hp-features__fee-label">{FEES.PREMIUM_LABEL}</span>
                 </div>
                 <p className="new-hp-features__tier-description">
-                  Fonctionnalit&eacute;s avanc&eacute;es
+                  Fonctionnalités avancées
                 </p>
               </div>
               <ul
                 className="new-hp-features__cards"
                 role="list"
-                aria-label="Fonctionnalit&eacute;s premium"
+                aria-label="Fonctionnalités premium"
               >
                 {PREMIUM_FEATURES.map((feature, index) => (
                   <FeatureCard
@@ -349,7 +368,7 @@ export default function NewHpFeatures() {
               <Link
                 href="/inscription?plan=premium"
                 className="new-hp-features__cta new-hp-features__cta--premium"
-                aria-label="S&apos;inscrire &agrave; l&apos;offre Premium"
+                aria-label="S'inscrire à l'offre Premium"
               >
                 Choisir Premium
                 <ArrowIcon />

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.tsx
@@ -23,11 +23,37 @@ interface FeatureItem {
 type CardStyle = React.CSSProperties & { "--card-index": number };
 
 const PRICING = {
-  PREMIUM_MONTHLY: "29€",
+  FREE_MONTHLY: "0\u20ac",
+  PREMIUM_MONTHLY: "69\u20ac",
+} as const;
+
+const FEES = {
+  FREE_RATE: "6%",
+  FREE_LABEL: "Frais plateforme*",
+  PREMIUM_RATE: "1,75%",
+  PREMIUM_LABEL: "Frais plateforme*",
 } as const;
 
 const LABELS = {
-  PREMIUM_BADGE: "⭐ Bientôt disponible",
+  PREMIUM_BADGE: "\u2b50 Bient\u00f4t disponible",
+  FREE_FOOTNOTE: "*Frais bancaires + frais de fonctionnement Donaction",
+  PREMIUM_FOOTNOTE: "*Uniquement les frais bancaires",
+} as const;
+
+interface DonationExampleTier {
+  id: string;
+  name: string;
+  feeAmount: number;
+  netAmount: number;
+}
+
+const DONATION_EXAMPLE = {
+  amount: 100,
+  currency: "\u20ac",
+  tiers: [
+    { id: "free", name: "Gratuit", feeAmount: 6, netAmount: 94 },
+    { id: "premium", name: "Premium", feeAmount: 1.75, netAmount: 98.25 },
+  ] as DonationExampleTier[],
 } as const;
 
 const FREE_FEATURES: FeatureItem[] = [
@@ -120,6 +146,23 @@ function StarIcon() {
   );
 }
 
+function ArrowIcon() {
+  return (
+    <svg
+      className="new-hp-features__arrow-icon"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
 function FeatureCard({ feature, index, isFree }: FeatureCardProps) {
   return (
     <li
@@ -159,24 +202,54 @@ function FeatureCard({ feature, index, isFree }: FeatureCardProps) {
   );
 }
 
+function DonationExampleBox() {
+  const { amount, currency, tiers } = DONATION_EXAMPLE;
+
+  return (
+    <div className="new-hp-features__example" aria-label="Exemple de don">
+      <h3 className="new-hp-features__example-title">
+        Exemple concret : pour un don de {amount}{currency}
+      </h3>
+      <div className="new-hp-features__example-grid">
+        {tiers.map((tier) => (
+          <div
+            key={tier.id}
+            className={`new-hp-features__example-card new-hp-features__example-card--${tier.id}`}
+          >
+            <span className="new-hp-features__example-tier">{tier.name}</span>
+            <div className="new-hp-features__example-row">
+              <span className="new-hp-features__example-label">Frais plateforme</span>
+              <span className="new-hp-features__example-value">
+                {tier.feeAmount}{currency}
+              </span>
+            </div>
+            <div className="new-hp-features__example-row new-hp-features__example-row--result">
+              <span className="new-hp-features__example-label">Votre club re&ccedil;oit</span>
+              <span className={`new-hp-features__example-amount new-hp-features__example-amount--${tier.id}`}>
+                {tier.netAmount}{currency}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default function NewHpFeatures() {
   return (
     <section className="new-hp-features">
       <div className="new-hp-features__container">
         <div className="new-hp-features__header">
-          <h2 className="new-hp-features__title">Fonctionnalités par offre</h2>
+          <h2 className="new-hp-features__title">Nos offres</h2>
           <p className="new-hp-features__subtitle">
-            Choisissez l&apos;offre qui correspond à vos besoins
+            Fonctionnalit&eacute;s et tarifs en toute transparence
           </p>
         </div>
 
         <div className="new-hp-features__grid">
           {/* Free Tier */}
-          <Link
-            href="/inscription"
-            className="new-hp-features__tier new-hp-features__tier--free"
-            aria-label="S'inscrire à l'offre Gratuite"
-          >
+          <div className="new-hp-features__tier new-hp-features__tier--free">
             <div className="new-hp-features__tier-container">
               <div className="new-hp-features__tier-header">
                 <div className="new-hp-features__tier-badge-wrapper">
@@ -186,6 +259,16 @@ export default function NewHpFeatures() {
                   </span>
                 </div>
                 <h3 className="new-hp-features__tier-title">Pour commencer</h3>
+                <div className="new-hp-features__pricing">
+                  <span className="new-hp-features__price new-hp-features__price--free">
+                    {PRICING.FREE_MONTHLY}
+                  </span>
+                  <span className="new-hp-features__price-period">/mois</span>
+                </div>
+                <div className="new-hp-features__fee new-hp-features__fee--free">
+                  <span className="new-hp-features__fee-rate">{FEES.FREE_RATE}</span>
+                  <span className="new-hp-features__fee-label">{FEES.FREE_LABEL}</span>
+                </div>
                 <p className="new-hp-features__tier-description">
                   Tout ce dont vous avez besoin
                 </p>
@@ -193,7 +276,7 @@ export default function NewHpFeatures() {
               <ul
                 className="new-hp-features__cards"
                 role="list"
-                aria-label="Fonctionnalités gratuites"
+                aria-label="Fonctionnalit&eacute;s gratuites"
               >
                 {FREE_FEATURES.map((feature, index) => (
                   <FeatureCard
@@ -204,15 +287,22 @@ export default function NewHpFeatures() {
                   />
                 ))}
               </ul>
+              <p className="new-hp-features__footnote new-hp-features__footnote--free">
+                {LABELS.FREE_FOOTNOTE}
+              </p>
+              <Link
+                href="/inscription"
+                className="new-hp-features__cta new-hp-features__cta--free"
+                aria-label="S&apos;inscrire &agrave; l&apos;offre Gratuite"
+              >
+                Commencer gratuitement
+                <ArrowIcon />
+              </Link>
             </div>
-          </Link>
+          </div>
 
           {/* Premium Tier */}
-          <Link
-            href="/inscription?plan=premium"
-            className="new-hp-features__tier new-hp-features__tier--premium"
-            aria-label="S'inscrire à l'offre Premium"
-          >
+          <div className="new-hp-features__tier new-hp-features__tier--premium">
             <div className="new-hp-features__tier-badge-highlight">
               {LABELS.PREMIUM_BADGE}
             </div>
@@ -231,14 +321,18 @@ export default function NewHpFeatures() {
                   </span>
                   <span className="new-hp-features__price-period">/mois</span>
                 </div>
+                <div className="new-hp-features__fee new-hp-features__fee--premium">
+                  <span className="new-hp-features__fee-rate">{FEES.PREMIUM_RATE}</span>
+                  <span className="new-hp-features__fee-label">{FEES.PREMIUM_LABEL}</span>
+                </div>
                 <p className="new-hp-features__tier-description">
-                  Fonctionnalités avancées
+                  Fonctionnalit&eacute;s avanc&eacute;es
                 </p>
               </div>
               <ul
                 className="new-hp-features__cards"
                 role="list"
-                aria-label="Fonctionnalités premium"
+                aria-label="Fonctionnalit&eacute;s premium"
               >
                 {PREMIUM_FEATURES.map((feature, index) => (
                   <FeatureCard
@@ -249,9 +343,22 @@ export default function NewHpFeatures() {
                   />
                 ))}
               </ul>
+              <p className="new-hp-features__footnote new-hp-features__footnote--premium">
+                {LABELS.PREMIUM_FOOTNOTE}
+              </p>
+              <Link
+                href="/inscription?plan=premium"
+                className="new-hp-features__cta new-hp-features__cta--premium"
+                aria-label="S&apos;inscrire &agrave; l&apos;offre Premium"
+              >
+                Choisir Premium
+                <ArrowIcon />
+              </Link>
             </div>
-          </Link>
+          </div>
         </div>
+
+        <DonationExampleBox />
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- Merged pricing content into `NewHpFeatures` instead of creating a separate `NewHpPricing` section (avoids redundancy)
- Added fee badges (Free: 6%, Premium: 1,75%), per-tier footnotes, CTA buttons, and donation comparison example (100€)
- Premium tier visually highlighted with amber background and "Bientôt disponible" badge

## Test plan
- [x] 18 unit tests passing (Vitest + RTL)
- [x] Desktop (1440px): two-column tier layout, donation example below
- [x] Tablet (768px): stacked tiers, 2-col feature cards
- [x] Mobile (375px): stacked tiers, single-col feature cards
- [x] CTAs link to `/inscription` and `/inscription?plan=premium`
- [x] `prefers-reduced-motion` support verified