### PR TITLE
feat(frontend): implement NewHpFederations B2B section (#113)

### DIFF
--- a/donaction-frontend/src/app/(main)/contact/page.tsx
+++ b/donaction-frontend/src/app/(main)/contact/page.tsx
@@ -1,6 +1,6 @@
 import NeedHelp from '@/partials/mecenatPage/needHelp';
 import ContactUsForm from '@/partials/authentication/contactUsForm';
-import React from 'react';
+import React, { Suspense } from 'react';
 import { getContactPage } from '@/core/services/cms';
 import './page.scss';
 import { Metadata } from 'next';
@@ -77,10 +77,12 @@ export default async function Page() {
                     height={324}
                     className={'md:block hidden mx-auto'}
                 />)}
-				<ContactUsForm
-					title={content.data.attributes.titre}
-					content={content.data.attributes.contenu[0].children[0].text}
-				/>
+				<Suspense fallback={<div className="w-full h-full" />}>
+					<ContactUsForm
+						title={content.data.attributes.titre}
+						content={content.data.attributes.contenu[0].children[0].text}
+					/>
+				</Suspense>
 			</div>
 
 			{content?.data?.attributes?.FAQ && (

--- a/donaction-frontend/src/core/constants/contact.ts
+++ b/donaction-frontend/src/core/constants/contact.ts
@@ -1,0 +1,1 @@
+export const CONTACT_EMAIL = 'contact@donaction.fr';

--- a/donaction-frontend/src/layouts/partials/authentication/contactUsForm/useContactUsForm.ts
+++ b/donaction-frontend/src/layouts/partials/authentication/contactUsForm/useContactUsForm.ts
@@ -12,7 +12,10 @@ export default function useContactUsForm() {
 	const session = useAppSelector(selectSession);
 	const searchParams = useSearchParams();
 	const rawObject = searchParams?.get('objet') || '';
-	const prefilledObject = rawObject.replace(/[<>'"]/g, '').slice(0, 200).trim();
+	const prefilledObject = rawObject
+		.replace(/[<>"'`&;(){}[\]\\]/g, '')
+		.slice(0, 200)
+		.trim();
 	const receivedFeedbacks = useRef<Array<FeedbackParamsType>>([]);
 	const [config, setConfig] = useState({
 		defaultValues: {

--- a/donaction-frontend/src/layouts/partials/authentication/contactUsForm/useContactUsForm.ts
+++ b/donaction-frontend/src/layouts/partials/authentication/contactUsForm/useContactUsForm.ts
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { FeedbackParamsType } from '@/partials/sponsorshipForm/logic/entities';
 import { createReCaptchaToken, postContactUs } from '@/core/services/cms';
 import { pushToast } from '@/core/store/modules/rootSlice';
@@ -9,11 +10,13 @@ import { sendGaEvent } from '@/core/helpers/sendGaEvent';
 export default function useContactUsForm() {
 	const dispatch = useAppDispatch();
 	const session = useAppSelector(selectSession);
+	const searchParams = useSearchParams();
+	const prefilledObject = searchParams?.get('objet') || '';
 	const receivedFeedbacks = useRef<Array<FeedbackParamsType>>([]);
 	const [config, setConfig] = useState({
 		defaultValues: {
 			email: session?.data?.email || '',
-			object: '',
+			object: prefilledObject,
 			msg: '',
 		},
 		triggerValidation: 1,

--- a/donaction-frontend/src/layouts/partials/authentication/contactUsForm/useContactUsForm.ts
+++ b/donaction-frontend/src/layouts/partials/authentication/contactUsForm/useContactUsForm.ts
@@ -11,7 +11,8 @@ export default function useContactUsForm() {
 	const dispatch = useAppDispatch();
 	const session = useAppSelector(selectSession);
 	const searchParams = useSearchParams();
-	const prefilledObject = searchParams?.get('objet') || '';
+	const rawObject = searchParams?.get('objet') || '';
+	const prefilledObject = rawObject.replace(/[<>'"]/g, '').slice(0, 200).trim();
 	const receivedFeedbacks = useRef<Array<FeedbackParamsType>>([]);
 	const [config, setConfig] = useState({
 		defaultValues: {

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/NewHpFederations.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/NewHpFederations.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import NewHpFederations from './index';
+
+// Mock next/link
+vi.mock('next/link', () => ({
+  default: ({ children, href, className }: any) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('NewHpFederations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders all 3 advantage cards', () => {
+    render(<NewHpFederations />);
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+  });
+
+  it('renders section title', () => {
+    render(<NewHpFederations />);
+
+    const heading = screen.getByRole('heading', { level: 2 });
+    expect(heading).toBeInTheDocument();
+    expect(heading).toHaveTextContent(/fédérations|comités/i);
+  });
+
+  it('renders subtitle with federation context', () => {
+    render(<NewHpFederations />);
+
+    const subtitle = screen.getByText(/solution complète|accompagner/i);
+    expect(subtitle).toBeInTheDocument();
+  });
+
+  it('renders card titles with key terms', () => {
+    render(<NewHpFederations />);
+
+    const items = screen.getAllByRole('listitem');
+
+    expect(items[0]).toHaveTextContent(/gestion|multi-clubs/i);
+    expect(items[1]).toHaveTextContent(/reporting|consolidé/i);
+    expect(items[2]).toHaveTextContent(/accompagnement|dédié/i);
+  });
+
+  it('renders card subtitles with correct content', () => {
+    render(<NewHpFederations />);
+
+    const items = screen.getAllByRole('listitem');
+
+    expect(items[0]).toHaveTextContent(/pilotez|interface/i);
+    expect(items[1]).toHaveTextContent(/tableaux|exports|instances/i);
+    expect(items[2]).toHaveTextContent(/interlocuteur|fédération/i);
+  });
+
+  it('renders as section with proper accessibility', () => {
+    render(<NewHpFederations />);
+
+    const list = screen.getByRole('list');
+    expect(list).toBeInTheDocument();
+    expect(list).toHaveAttribute('aria-label', 'Avantages pour les fédérations');
+
+    const items = screen.getAllByRole('listitem');
+    expect(items).toHaveLength(3);
+  });
+
+  it('renders SVG icons for each card with aria-hidden', () => {
+    const { container } = render(<NewHpFederations />);
+
+    const svgIcons = container.querySelectorAll('svg');
+    expect(svgIcons.length).toBeGreaterThanOrEqual(3);
+
+    svgIcons.forEach((svg) => {
+      expect(svg).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+
+  it('renders CTA link to contact page with demo parameter', () => {
+    render(<NewHpFederations />);
+
+    const demoLink = screen.getByRole('link', { name: /demander une démo/i });
+    expect(demoLink).toBeInTheDocument();
+    expect(demoLink).toHaveAttribute(
+      'href',
+      '/contact?objet=Demande+de+D%C3%A9mo'
+    );
+  });
+
+  it('renders contact email as mailto link', () => {
+    render(<NewHpFederations />);
+
+    const emailLink = screen.getByRole('link', {
+      name: /contact@donaction\.fr/i,
+    });
+    expect(emailLink).toBeInTheDocument();
+    expect(emailLink).toHaveAttribute('href', 'mailto:contact@donaction.fr');
+  });
+
+  it('renders both CTA elements together', () => {
+    render(<NewHpFederations />);
+
+    const demoLink = screen.getByRole('link', { name: /demander une démo/i });
+    const emailLink = screen.getByRole('link', {
+      name: /contact@donaction\.fr/i,
+    });
+
+    expect(demoLink).toBeInTheDocument();
+    expect(emailLink).toBeInTheDocument();
+  });
+
+  it('applies correct styling classes', () => {
+    const { container } = render(<NewHpFederations />);
+
+    const section = container.querySelector('.new-hp-federations');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveClass('w-full', 'py-16');
+
+    const grid = container.querySelector('.new-hp-federations__grid');
+    expect(grid).toBeInTheDocument();
+
+    const cards = container.querySelectorAll('.new-hp-federations__card');
+    expect(cards).toHaveLength(3);
+  });
+
+  it('renders icon wrappers with correct styling', () => {
+    const { container } = render(<NewHpFederations />);
+
+    const iconWrappers = container.querySelectorAll(
+      '.new-hp-federations__icon-wrapper'
+    );
+    expect(iconWrappers).toHaveLength(3);
+
+    iconWrappers.forEach((wrapper) => {
+      expect(wrapper).toBeInTheDocument();
+    });
+  });
+
+  it('renders section with dark background styles', () => {
+    const { container } = render(<NewHpFederations />);
+
+    const section = container.querySelector('.new-hp-federations');
+    expect(section).toBeInTheDocument();
+    // Section has gradient background applied via CSS
+  });
+});

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/NewHpFederations.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/NewHpFederations.test.tsx
@@ -91,14 +91,16 @@ describe('NewHpFederations', () => {
     );
   });
 
-  it('renders contact email as mailto link', () => {
+  it('renders contact email as mailto link with aria-label', () => {
     render(<NewHpFederations />);
 
     const emailLink = screen.getByRole('link', {
-      name: /contact@donaction\.fr/i,
+      name: /contacter par email/i,
     });
     expect(emailLink).toBeInTheDocument();
     expect(emailLink).toHaveAttribute('href', 'mailto:contact@donaction.fr');
+    expect(emailLink).toHaveAttribute('aria-label', 'Contacter par email');
+    expect(emailLink).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   it('renders both CTA elements together', () => {
@@ -106,7 +108,7 @@ describe('NewHpFederations', () => {
 
     const demoLink = screen.getByRole('link', { name: /demander une démo/i });
     const emailLink = screen.getByRole('link', {
-      name: /contact@donaction\.fr/i,
+      name: /contacter par email/i,
     });
 
     expect(demoLink).toBeInTheDocument();

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/icons/DedicatedSupportIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/icons/DedicatedSupportIcon.tsx
@@ -11,106 +11,22 @@ export default function DedicatedSupportIcon({ className }: IconProps) {
       className={className}
       aria-hidden="true"
     >
-      {/* Headset/Headphones main structure */}
-      <g>
-        {/* Left ear cup */}
-        <circle
-          cx="12"
-          cy="16"
-          r="4.5"
-          stroke="currentColor"
-          strokeWidth="2"
-          fill="currentColor"
-          fillOpacity="0.2"
-        />
-        {/* Right ear cup */}
-        <circle
-          cx="36"
-          cy="16"
-          r="4.5"
-          stroke="currentColor"
-          strokeWidth="2"
-          fill="currentColor"
-          fillOpacity="0.2"
-        />
+      {/* Headset ear cups */}
+      <circle cx="12" cy="16" r="4.5" stroke="currentColor" strokeWidth="2" fill="currentColor" fillOpacity="0.2" />
+      <circle cx="36" cy="16" r="4.5" stroke="currentColor" strokeWidth="2" fill="currentColor" fillOpacity="0.2" />
 
-        {/* Headband connecting the cups */}
-        <path
-          d="M 12 11.5 Q 24 6 36 11.5"
-          stroke="currentColor"
-          strokeWidth="2.5"
-          fill="none"
-          strokeLinecap="round"
-        />
+      {/* Headband */}
+      <path d="M 12 11.5 Q 24 6 36 11.5" stroke="currentColor" strokeWidth="2.5" fill="none" strokeLinecap="round" />
 
-        {/* Microphone boom */}
-        <line
-          x1="10"
-          y1="18"
-          x2="6"
-          y2="30"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-        />
+      {/* Microphone boom + head */}
+      <line x1="10" y1="18" x2="6" y2="30" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+      <circle cx="6" cy="32" r="2.5" stroke="currentColor" strokeWidth="2" fill="currentColor" fillOpacity="0.3" />
 
-        {/* Microphone head */}
-        <circle
-          cx="6"
-          cy="32"
-          r="2.5"
-          stroke="currentColor"
-          strokeWidth="2"
-          fill="currentColor"
-          fillOpacity="0.3"
-        />
+      {/* Sound waves */}
+      <path d="M 30 28 Q 32 26 34 28 M 28 31 Q 31 27 36 31 M 27 34 Q 31 28 38 34" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" opacity="0.5" />
 
-        {/* Sound waves indicating active support */}
-        <path
-          d="M 30 28 Q 32 26 34 28"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          fill="none"
-          strokeLinecap="round"
-          opacity="0.6"
-        />
-        <path
-          d="M 28 31 Q 31 27 36 31"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          fill="none"
-          strokeLinecap="round"
-          opacity="0.5"
-        />
-        <path
-          d="M 27 34 Q 31 28 38 34"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          fill="none"
-          strokeLinecap="round"
-          opacity="0.4"
-        />
-
-        {/* Inner detail lines for depth */}
-        <line
-          x1="12"
-          y1="13"
-          x2="12"
-          y2="19"
-          stroke="currentColor"
-          strokeWidth="1"
-          opacity="0.3"
-        />
-        <line
-          x1="36"
-          y1="13"
-          x2="36"
-          y2="19"
-          stroke="currentColor"
-          strokeWidth="1"
-          opacity="0.3"
-        />
-      </g>
+      {/* Inner ear cup detail */}
+      <path d="M12,13 L12,19 M36,13 L36,19" stroke="currentColor" strokeWidth="1" opacity="0.3" />
     </svg>
   );
 }

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/icons/DedicatedSupportIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/icons/DedicatedSupportIcon.tsx
@@ -1,0 +1,116 @@
+interface IconProps {
+  className?: string;
+}
+
+export default function DedicatedSupportIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+    >
+      {/* Headset/Headphones main structure */}
+      <g>
+        {/* Left ear cup */}
+        <circle
+          cx="12"
+          cy="16"
+          r="4.5"
+          stroke="currentColor"
+          strokeWidth="2"
+          fill="currentColor"
+          fillOpacity="0.2"
+        />
+        {/* Right ear cup */}
+        <circle
+          cx="36"
+          cy="16"
+          r="4.5"
+          stroke="currentColor"
+          strokeWidth="2"
+          fill="currentColor"
+          fillOpacity="0.2"
+        />
+
+        {/* Headband connecting the cups */}
+        <path
+          d="M 12 11.5 Q 24 6 36 11.5"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          fill="none"
+          strokeLinecap="round"
+        />
+
+        {/* Microphone boom */}
+        <line
+          x1="10"
+          y1="18"
+          x2="6"
+          y2="30"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+
+        {/* Microphone head */}
+        <circle
+          cx="6"
+          cy="32"
+          r="2.5"
+          stroke="currentColor"
+          strokeWidth="2"
+          fill="currentColor"
+          fillOpacity="0.3"
+        />
+
+        {/* Sound waves indicating active support */}
+        <path
+          d="M 30 28 Q 32 26 34 28"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          fill="none"
+          strokeLinecap="round"
+          opacity="0.6"
+        />
+        <path
+          d="M 28 31 Q 31 27 36 31"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          fill="none"
+          strokeLinecap="round"
+          opacity="0.5"
+        />
+        <path
+          d="M 27 34 Q 31 28 38 34"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          fill="none"
+          strokeLinecap="round"
+          opacity="0.4"
+        />
+
+        {/* Inner detail lines for depth */}
+        <line
+          x1="12"
+          y1="13"
+          x2="12"
+          y2="19"
+          stroke="currentColor"
+          strokeWidth="1"
+          opacity="0.3"
+        />
+        <line
+          x1="36"
+          y1="13"
+          x2="36"
+          y2="19"
+          stroke="currentColor"
+          strokeWidth="1"
+          opacity="0.3"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/icons/MultiClubIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/icons/MultiClubIcon.tsx
@@ -1,0 +1,88 @@
+interface IconProps {
+  className?: string;
+}
+
+export default function MultiClubIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+    >
+      {/* Main buildings/clubs structure */}
+      <g>
+        {/* Left building */}
+        <rect
+          x="6"
+          y="12"
+          width="12"
+          height="28"
+          rx="1.5"
+          stroke="currentColor"
+          strokeWidth="2"
+          fill="currentColor"
+          fillOpacity="0.3"
+        />
+        {/* Center top building - taller */}
+        <rect
+          x="20"
+          y="8"
+          width="12"
+          height="32"
+          rx="1.5"
+          stroke="currentColor"
+          strokeWidth="2"
+          fill="currentColor"
+          fillOpacity="0.6"
+        />
+        {/* Right building */}
+        <rect
+          x="34"
+          y="15"
+          width="12"
+          height="25"
+          rx="1.5"
+          stroke="currentColor"
+          strokeWidth="2"
+          fill="currentColor"
+          fillOpacity="0.3"
+        />
+
+        {/* Windows on left building */}
+        <circle cx="9" cy="18" r="1.2" fill="currentColor" fillOpacity="0.5" />
+        <circle cx="15" cy="18" r="1.2" fill="currentColor" fillOpacity="0.5" />
+        <circle cx="9" cy="26" r="1.2" fill="currentColor" fillOpacity="0.5" />
+        <circle cx="15" cy="26" r="1.2" fill="currentColor" fillOpacity="0.5" />
+        <circle cx="9" cy="34" r="1.2" fill="currentColor" fillOpacity="0.5" />
+        <circle cx="15" cy="34" r="1.2" fill="currentColor" fillOpacity="0.5" />
+
+        {/* Windows on center building */}
+        <circle cx="23" cy="15" r="1.2" fill="currentColor" fillOpacity="0.7" />
+        <circle cx="29" cy="15" r="1.2" fill="currentColor" fillOpacity="0.7" />
+        <circle cx="23" cy="23" r="1.2" fill="currentColor" fillOpacity="0.7" />
+        <circle cx="29" cy="23" r="1.2" fill="currentColor" fillOpacity="0.7" />
+        <circle cx="23" cy="31" r="1.2" fill="currentColor" fillOpacity="0.7" />
+        <circle cx="29" cy="31" r="1.2" fill="currentColor" fillOpacity="0.7" />
+
+        {/* Windows on right building */}
+        <circle cx="37" cy="21" r="1.2" fill="currentColor" fillOpacity="0.5" />
+        <circle cx="43" cy="21" r="1.2" fill="currentColor" fillOpacity="0.5" />
+        <circle cx="37" cy="29" r="1.2" fill="currentColor" fillOpacity="0.5" />
+        <circle cx="43" cy="29" r="1.2" fill="currentColor" fillOpacity="0.5" />
+
+        {/* Connection line at bottom representing unity */}
+        <line
+          x1="6"
+          y1="41"
+          x2="46"
+          y2="41"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          opacity="0.4"
+        />
+      </g>
+    </svg>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/icons/MultiClubIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/icons/MultiClubIcon.tsx
@@ -11,78 +11,18 @@ export default function MultiClubIcon({ className }: IconProps) {
       className={className}
       aria-hidden="true"
     >
-      {/* Main buildings/clubs structure */}
-      <g>
-        {/* Left building */}
-        <rect
-          x="6"
-          y="12"
-          width="12"
-          height="28"
-          rx="1.5"
-          stroke="currentColor"
-          strokeWidth="2"
-          fill="currentColor"
-          fillOpacity="0.3"
-        />
-        {/* Center top building - taller */}
-        <rect
-          x="20"
-          y="8"
-          width="12"
-          height="32"
-          rx="1.5"
-          stroke="currentColor"
-          strokeWidth="2"
-          fill="currentColor"
-          fillOpacity="0.6"
-        />
-        {/* Right building */}
-        <rect
-          x="34"
-          y="15"
-          width="12"
-          height="25"
-          rx="1.5"
-          stroke="currentColor"
-          strokeWidth="2"
-          fill="currentColor"
-          fillOpacity="0.3"
-        />
+      {/* Three buildings representing multi-club federation */}
+      <rect x="6" y="12" width="12" height="28" rx="1.5" stroke="currentColor" strokeWidth="2" fill="currentColor" fillOpacity="0.3" />
+      <rect x="20" y="8" width="12" height="32" rx="1.5" stroke="currentColor" strokeWidth="2" fill="currentColor" fillOpacity="0.6" />
+      <rect x="34" y="15" width="12" height="25" rx="1.5" stroke="currentColor" strokeWidth="2" fill="currentColor" fillOpacity="0.3" />
 
-        {/* Windows on left building */}
-        <circle cx="9" cy="18" r="1.2" fill="currentColor" fillOpacity="0.5" />
-        <circle cx="15" cy="18" r="1.2" fill="currentColor" fillOpacity="0.5" />
-        <circle cx="9" cy="26" r="1.2" fill="currentColor" fillOpacity="0.5" />
-        <circle cx="15" cy="26" r="1.2" fill="currentColor" fillOpacity="0.5" />
-        <circle cx="9" cy="34" r="1.2" fill="currentColor" fillOpacity="0.5" />
-        <circle cx="15" cy="34" r="1.2" fill="currentColor" fillOpacity="0.5" />
+      {/* Windows as consolidated path per building */}
+      <path d="M9,18 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M15,18 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M9,26 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M15,26 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M9,34 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M15,34 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0" fill="currentColor" fillOpacity="0.5" />
+      <path d="M23,15 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M29,15 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M23,23 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M29,23 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M23,31 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M29,31 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0" fill="currentColor" fillOpacity="0.7" />
+      <path d="M37,21 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M43,21 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M37,29 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M43,29 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0" fill="currentColor" fillOpacity="0.5" />
 
-        {/* Windows on center building */}
-        <circle cx="23" cy="15" r="1.2" fill="currentColor" fillOpacity="0.7" />
-        <circle cx="29" cy="15" r="1.2" fill="currentColor" fillOpacity="0.7" />
-        <circle cx="23" cy="23" r="1.2" fill="currentColor" fillOpacity="0.7" />
-        <circle cx="29" cy="23" r="1.2" fill="currentColor" fillOpacity="0.7" />
-        <circle cx="23" cy="31" r="1.2" fill="currentColor" fillOpacity="0.7" />
-        <circle cx="29" cy="31" r="1.2" fill="currentColor" fillOpacity="0.7" />
-
-        {/* Windows on right building */}
-        <circle cx="37" cy="21" r="1.2" fill="currentColor" fillOpacity="0.5" />
-        <circle cx="43" cy="21" r="1.2" fill="currentColor" fillOpacity="0.5" />
-        <circle cx="37" cy="29" r="1.2" fill="currentColor" fillOpacity="0.5" />
-        <circle cx="43" cy="29" r="1.2" fill="currentColor" fillOpacity="0.5" />
-
-        {/* Connection line at bottom representing unity */}
-        <line
-          x1="6"
-          y1="41"
-          x2="46"
-          y2="41"
-          stroke="currentColor"
-          strokeWidth="1.5"
-          opacity="0.4"
-        />
-      </g>
+      {/* Unity line */}
+      <line x1="6" y1="41" x2="46" y2="41" stroke="currentColor" strokeWidth="1.5" opacity="0.4" />
     </svg>
   );
 }

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/icons/ReportingIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/icons/ReportingIcon.tsx
@@ -11,52 +11,25 @@ export default function ReportingIcon({ className }: IconProps) {
       className={className}
       aria-hidden="true"
     >
-      {/* Dashboard/Chart background */}
-      <rect
-        x="4"
-        y="6"
-        width="40"
-        height="36"
-        rx="3"
-        stroke="currentColor"
-        strokeWidth="2"
-        fill="currentColor"
-        fillOpacity="0.1"
-      />
-
-      {/* Top header bar */}
+      {/* Dashboard frame */}
+      <rect x="4" y="6" width="40" height="36" rx="3" stroke="currentColor" strokeWidth="2" fill="currentColor" fillOpacity="0.1" />
       <rect x="4" y="6" width="40" height="6" rx="3" fill="currentColor" fillOpacity="0.2" />
 
-      {/* Grid title icon */}
+      {/* Header indicator */}
       <circle cx="9" cy="9" r="1.2" fill="currentColor" opacity="0.5" />
       <line x1="11" y1="9" x2="20" y2="9" stroke="currentColor" strokeWidth="1" opacity="0.4" />
 
-      {/* Bar chart left side */}
+      {/* Bar chart */}
       <rect x="8" y="26" width="4" height="10" rx="0.5" fill="currentColor" fillOpacity="0.5" />
       <rect x="14" y="20" width="4" height="16" rx="0.5" fill="currentColor" fillOpacity="0.7" />
       <rect x="20" y="16" width="4" height="20" rx="0.5" fill="currentColor" fillOpacity="0.6" />
 
-      {/* Line chart right side */}
-      <polyline
-        points="28,24 32,18 36,22 40,14"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        fill="none"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        opacity="0.7"
-      />
+      {/* Line chart with data points */}
+      <polyline points="28,24 32,18 36,22 40,14" stroke="currentColor" strokeWidth="1.5" fill="none" strokeLinecap="round" strokeLinejoin="round" opacity="0.7" />
+      <path d="M28,24 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M32,18 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M36,22 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0 M40,14 m-1.2,0 a1.2,1.2 0 1,0 2.4,0 a1.2,1.2 0 1,0 -2.4,0" fill="currentColor" opacity="0.7" />
 
-      {/* Data points on line */}
-      <circle cx="28" cy="24" r="1.2" fill="currentColor" opacity="0.7" />
-      <circle cx="32" cy="18" r="1.2" fill="currentColor" opacity="0.7" />
-      <circle cx="36" cy="22" r="1.2" fill="currentColor" opacity="0.7" />
-      <circle cx="40" cy="14" r="1.2" fill="currentColor" opacity="0.7" />
-
-      {/* Bottom info text indicators */}
-      <line x1="8" y1="40" x2="16" y2="40" stroke="currentColor" strokeWidth="0.8" opacity="0.3" />
-      <line x1="18" y1="40" x2="26" y2="40" stroke="currentColor" strokeWidth="0.8" opacity="0.3" />
-      <line x1="28" y1="40" x2="40" y2="40" stroke="currentColor" strokeWidth="0.8" opacity="0.3" />
+      {/* Footer indicators */}
+      <path d="M8,40 L16,40 M18,40 L26,40 M28,40 L40,40" stroke="currentColor" strokeWidth="0.8" opacity="0.3" />
     </svg>
   );
 }

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/icons/ReportingIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/icons/ReportingIcon.tsx
@@ -1,0 +1,62 @@
+interface IconProps {
+  className?: string;
+}
+
+export default function ReportingIcon({ className }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 48 48"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      aria-hidden="true"
+    >
+      {/* Dashboard/Chart background */}
+      <rect
+        x="4"
+        y="6"
+        width="40"
+        height="36"
+        rx="3"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="currentColor"
+        fillOpacity="0.1"
+      />
+
+      {/* Top header bar */}
+      <rect x="4" y="6" width="40" height="6" rx="3" fill="currentColor" fillOpacity="0.2" />
+
+      {/* Grid title icon */}
+      <circle cx="9" cy="9" r="1.2" fill="currentColor" opacity="0.5" />
+      <line x1="11" y1="9" x2="20" y2="9" stroke="currentColor" strokeWidth="1" opacity="0.4" />
+
+      {/* Bar chart left side */}
+      <rect x="8" y="26" width="4" height="10" rx="0.5" fill="currentColor" fillOpacity="0.5" />
+      <rect x="14" y="20" width="4" height="16" rx="0.5" fill="currentColor" fillOpacity="0.7" />
+      <rect x="20" y="16" width="4" height="20" rx="0.5" fill="currentColor" fillOpacity="0.6" />
+
+      {/* Line chart right side */}
+      <polyline
+        points="28,24 32,18 36,22 40,14"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        fill="none"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        opacity="0.7"
+      />
+
+      {/* Data points on line */}
+      <circle cx="28" cy="24" r="1.2" fill="currentColor" opacity="0.7" />
+      <circle cx="32" cy="18" r="1.2" fill="currentColor" opacity="0.7" />
+      <circle cx="36" cy="22" r="1.2" fill="currentColor" opacity="0.7" />
+      <circle cx="40" cy="14" r="1.2" fill="currentColor" opacity="0.7" />
+
+      {/* Bottom info text indicators */}
+      <line x1="8" y1="40" x2="16" y2="40" stroke="currentColor" strokeWidth="0.8" opacity="0.3" />
+      <line x1="18" y1="40" x2="26" y2="40" stroke="currentColor" strokeWidth="0.8" opacity="0.3" />
+      <line x1="28" y1="40" x2="40" y2="40" stroke="currentColor" strokeWidth="0.8" opacity="0.3" />
+    </svg>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/index.scss
@@ -69,15 +69,19 @@ $hover-duration: 0.3s;
   &__card-content {
     padding: 2rem 1.5rem;
     border-radius: 16px;
-    background: rgba(30, 41, 59, 0.6);
+    background: rgba(30, 41, 59, 0.85);
     border: 1px solid rgba(148, 163, 184, 0.2);
     height: 100%;
-    backdrop-filter: blur(10px);
     transition:
       transform $hover-duration ease,
       background $hover-duration ease,
       border-color $hover-duration ease,
       box-shadow $hover-duration ease;
+
+    @supports (backdrop-filter: blur(10px)) {
+      background: rgba(30, 41, 59, 0.6);
+      backdrop-filter: blur(10px);
+    }
 
     &:hover {
       transform: translateY(-6px);

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/index.scss
@@ -267,7 +267,12 @@ $hover-duration: 0.3s;
       opacity: 1;
     }
 
-    &__card-content,
+    &__card-content {
+      transition: none;
+      backdrop-filter: none;
+      background: rgba(30, 41, 59, 0.95);
+    }
+
     &__icon-wrapper,
     &__icon,
     &__cta-button,

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/index.scss
@@ -1,0 +1,321 @@
+// Design tokens
+$color-primary: #73cfa8;
+$color-dark-bg: #111827;
+
+// Animation timing variables
+$entrance-duration: 0.6s;
+$entrance-delay-base: 0.15s;
+$entrance-delay-step: 0.08s;
+$hover-duration: 0.3s;
+
+.new-hp-federations {
+  background: linear-gradient(135deg, #111827 0%, #1a202c 50%, #0f172a 100%);
+  position: relative;
+  overflow: hidden;
+
+  // Subtle accent elements for depth
+  &::before {
+    content: '';
+    position: absolute;
+    top: -50%;
+    right: -10%;
+    width: 500px;
+    height: 500px;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba($color-primary, 0.05) 0%, transparent 70%);
+    pointer-events: none;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    bottom: -30%;
+    left: -15%;
+    width: 400px;
+    height: 400px;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba($color-primary, 0.03) 0%, transparent 70%);
+    pointer-events: none;
+  }
+
+  &__title {
+    opacity: 0;
+    animation: title-entrance $entrance-duration ease-out forwards;
+    position: relative;
+    z-index: 1;
+  }
+
+  &__subtitle {
+    opacity: 0;
+    animation: subtitle-entrance $entrance-duration ease-out forwards;
+    animation-delay: calc($entrance-delay-base * 0.5);
+    position: relative;
+    z-index: 1;
+  }
+
+  &__grid {
+    position: relative;
+    z-index: 1;
+  }
+
+  &__card {
+    opacity: 0;
+    animation: card-entrance $entrance-duration ease-out forwards;
+    animation-delay: calc(
+      var(--card-index) * #{$entrance-delay-step} + #{$entrance-delay-base}
+    );
+  }
+
+  &__card-content {
+    padding: 2rem 1.5rem;
+    border-radius: 16px;
+    background: rgba(30, 41, 59, 0.6);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    height: 100%;
+    backdrop-filter: blur(10px);
+    transition:
+      transform $hover-duration ease,
+      background $hover-duration ease,
+      border-color $hover-duration ease,
+      box-shadow $hover-duration ease;
+
+    &:hover {
+      transform: translateY(-6px);
+      background: rgba(30, 41, 59, 0.85);
+      border-color: rgba($color-primary, 0.5);
+      box-shadow:
+        0 12px 32px -12px rgba($color-primary, 0.3),
+        0 6px 16px -6px rgba($color-primary, 0.15),
+        inset 0 1px 1px rgba(255, 255, 255, 0.1);
+    }
+  }
+
+  &__icon-wrapper {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 72px;
+    height: 72px;
+    border-radius: 16px;
+    background: linear-gradient(135deg, rgba($color-primary, 0.2) 0%, rgba($color-primary, 0.1) 100%);
+    transition: background $hover-duration ease;
+    border: 1px solid rgba($color-primary, 0.3);
+
+    &::after {
+      content: '';
+      position: absolute;
+      inset: -4px;
+      border-radius: 20px;
+      background: radial-gradient(
+        circle,
+        rgba($color-primary, 0.3) 0%,
+        transparent 70%
+      );
+      opacity: 0;
+      transition: opacity $hover-duration ease;
+    }
+  }
+
+  &__card-content:hover &__icon-wrapper {
+    background: linear-gradient(135deg, rgba($color-primary, 0.35) 0%, rgba($color-primary, 0.2) 100%);
+    border-color: rgba($color-primary, 0.6);
+
+    &::after {
+      opacity: 1;
+    }
+  }
+
+  &__icon {
+    width: 40px;
+    height: 40px;
+    transition: transform $hover-duration ease;
+    position: relative;
+    z-index: 1;
+  }
+
+  &__card-content:hover &__icon {
+    transform: scale(1.1);
+  }
+
+  &__cta {
+    position: relative;
+    z-index: 1;
+  }
+
+  &__cta-button {
+    display: inline-block;
+    transition: all $hover-duration ease;
+    box-shadow: 0 4px 12px rgba($color-primary, 0.3);
+
+    &:hover {
+      box-shadow: 0 8px 24px rgba($color-primary, 0.4);
+      transform: translateY(-2px);
+    }
+
+    &:active {
+      transform: translateY(0);
+    }
+  }
+
+  &__cta-email {
+    display: inline-block;
+  }
+}
+
+// Keyframe animations
+@keyframes title-entrance {
+  0% {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes subtitle-entrance {
+  0% {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes card-entrance {
+  0% {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// Responsive adjustments
+@media (max-width: 1023px) {
+  .new-hp-federations {
+    &__card-content {
+      padding: 1.5rem 1.25rem;
+    }
+
+    &__icon-wrapper {
+      width: 64px;
+      height: 64px;
+      border-radius: 14px;
+
+      &::after {
+        inset: -3px;
+        border-radius: 18px;
+      }
+    }
+
+    &__icon {
+      width: 36px;
+      height: 36px;
+    }
+  }
+}
+
+@media (max-width: 639px) {
+  .new-hp-federations {
+    &__card-content {
+      padding: 1.25rem 1rem;
+    }
+
+    &__icon-wrapper {
+      width: 56px;
+      height: 56px;
+      border-radius: 12px;
+
+      &::after {
+        inset: -2px;
+        border-radius: 16px;
+      }
+    }
+
+    &__icon {
+      width: 32px;
+      height: 32px;
+    }
+
+    &__cta {
+      flex-direction: column;
+      gap: 4rem;
+    }
+
+    &__cta-button,
+    &__cta-email {
+      width: 100%;
+      text-align: center;
+    }
+  }
+}
+
+// Reduced motion preference
+@media (prefers-reduced-motion: reduce) {
+  .new-hp-federations {
+    &__title,
+    &__subtitle,
+    &__card {
+      animation: none;
+      opacity: 1;
+    }
+
+    &__card-content,
+    &__icon-wrapper,
+    &__icon,
+    &__cta-button,
+    &__cta-email {
+      transition: none;
+    }
+  }
+}
+
+// High contrast mode support
+@media (prefers-contrast: more) {
+  .new-hp-federations {
+    &__card-content {
+      border-color: rgba(255, 255, 255, 0.4);
+      background: rgba(30, 41, 59, 0.9);
+    }
+
+    &__icon-wrapper {
+      border-color: rgba($color-primary, 0.6);
+      background: linear-gradient(135deg, rgba($color-primary, 0.3) 0%, rgba($color-primary, 0.15) 100%);
+    }
+  }
+}
+
+// Devices that don't support hover
+@media (hover: none) {
+  .new-hp-federations {
+    &__card-content:active {
+      transform: translateY(-6px);
+      background: rgba(30, 41, 59, 0.85);
+      border-color: rgba($color-primary, 0.5);
+      box-shadow:
+        0 12px 32px -12px rgba($color-primary, 0.3),
+        0 6px 16px -6px rgba($color-primary, 0.15),
+        inset 0 1px 1px rgba(255, 255, 255, 0.1);
+    }
+
+    &__card-content:active &__icon-wrapper {
+      background: linear-gradient(135deg, rgba($color-primary, 0.35) 0%, rgba($color-primary, 0.2) 100%);
+      border-color: rgba($color-primary, 0.6);
+
+      &::after {
+        opacity: 1;
+      }
+    }
+
+    &__card-content:active &__icon {
+      transform: scale(1.1);
+    }
+  }
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/index.tsx
@@ -6,6 +6,8 @@ import './index.scss';
 
 type CardStyle = React.CSSProperties & { '--card-index': number };
 
+const CONTACT_EMAIL = 'contact@donaction.fr';
+
 const FEDERATION_ADVANTAGES = [
   {
     id: 'multi-club',
@@ -72,10 +74,11 @@ export default function NewHpFederations() {
             Demander une démo
           </Link>
           <a
-            href="mailto:contact@donaction.fr"
+            href={`mailto:${CONTACT_EMAIL}`}
+            rel="noopener noreferrer"
             className="new-hp-federations__cta-email text-[#73cfa8] hover:text-[#5ec497] font-medium transition-colors duration-300"
           >
-            contact@donaction.fr
+            {CONTACT_EMAIL}
           </a>
         </div>
       </div>

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/index.tsx
@@ -1,12 +1,11 @@
 import Link from 'next/link';
+import { CONTACT_EMAIL } from '@/core/constants/contact';
 import MultiClubIcon from './icons/MultiClubIcon';
 import ReportingIcon from './icons/ReportingIcon';
 import DedicatedSupportIcon from './icons/DedicatedSupportIcon';
 import './index.scss';
 
-type CardStyle = React.CSSProperties & { '--card-index': number };
-
-const CONTACT_EMAIL = 'contact@donaction.fr';
+const DEMO_CTA_URL = `/contact?${new URLSearchParams({ objet: 'Demande de Démo' }).toString()}`;
 
 const FEDERATION_ADVANTAGES = [
   {
@@ -48,7 +47,7 @@ export default function NewHpFederations() {
             <li
               key={advantage.id}
               className="new-hp-federations__card"
-              style={{ '--card-index': index } as CardStyle}
+              style={{ '--card-index': index }}
             >
               <div className="new-hp-federations__card-content flex flex-col items-center text-center gap-4">
                 <div className="new-hp-federations__icon-wrapper">
@@ -68,7 +67,7 @@ export default function NewHpFederations() {
         </ul>
         <div className="new-hp-federations__cta flex flex-col sm:flex-row items-center justify-center gap-6 sm:gap-8">
           <Link
-            href="/contact?objet=Demande+de+D%C3%A9mo"
+            href={DEMO_CTA_URL}
             className="new-hp-federations__cta-button bg-[#73cfa8] hover:bg-[#5ec497] text-gray-900 font-semibold px-8 py-3 rounded-lg transition-colors duration-300"
           >
             Demander une démo
@@ -76,6 +75,7 @@ export default function NewHpFederations() {
           <a
             href={`mailto:${CONTACT_EMAIL}`}
             rel="noopener noreferrer"
+            aria-label="Contacter par email"
             className="new-hp-federations__cta-email text-[#73cfa8] hover:text-[#5ec497] font-medium transition-colors duration-300"
           >
             {CONTACT_EMAIL}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/index.tsx
@@ -1,0 +1,84 @@
+import Link from 'next/link';
+import MultiClubIcon from './icons/MultiClubIcon';
+import ReportingIcon from './icons/ReportingIcon';
+import DedicatedSupportIcon from './icons/DedicatedSupportIcon';
+import './index.scss';
+
+type CardStyle = React.CSSProperties & { '--card-index': number };
+
+const FEDERATION_ADVANTAGES = [
+  {
+    id: 'multi-club',
+    Icon: MultiClubIcon,
+    title: 'Gestion multi-clubs',
+    subtitle: 'Pilotez tous vos clubs depuis une seule interface',
+  },
+  {
+    id: 'consolidated-reporting',
+    Icon: ReportingIcon,
+    title: 'Reporting consolidé',
+    subtitle: 'Tableaux de bord et exports pour vos instances',
+  },
+  {
+    id: 'dedicated-support',
+    Icon: DedicatedSupportIcon,
+    title: 'Accompagnement dédié',
+    subtitle: 'Un interlocuteur unique pour votre fédération',
+  },
+] as const;
+
+export default function NewHpFederations() {
+  return (
+    <section className="new-hp-federations w-full py-16 md:py-20 lg:py-24">
+      <div className="max-w-[1320px] mx-auto px-6">
+        <h2 className="new-hp-federations__title text-2xl md:text-3xl lg:text-4xl font-bold text-center text-white mb-4 md:mb-6">
+          Pour les fédérations et comités
+        </h2>
+        <p className="new-hp-federations__subtitle text-center text-gray-200 mb-12 md:mb-16 max-w-2xl mx-auto">
+          Une solution complète pour accompagner vos clubs dans leur développement et vos actions de financement
+        </p>
+        <ul
+          className="new-hp-federations__grid grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8 mb-12 md:mb-16"
+          role="list"
+          aria-label="Avantages pour les fédérations"
+        >
+          {FEDERATION_ADVANTAGES.map((advantage, index) => (
+            <li
+              key={advantage.id}
+              className="new-hp-federations__card"
+              style={{ '--card-index': index } as CardStyle}
+            >
+              <div className="new-hp-federations__card-content flex flex-col items-center text-center gap-4">
+                <div className="new-hp-federations__icon-wrapper">
+                  <advantage.Icon className="new-hp-federations__icon text-white" />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <span className="text-base md:text-lg font-semibold text-white">
+                    {advantage.title}
+                  </span>
+                  <span className="text-sm md:text-base text-gray-300">
+                    {advantage.subtitle}
+                  </span>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+        <div className="new-hp-federations__cta flex flex-col sm:flex-row items-center justify-center gap-6 sm:gap-8">
+          <Link
+            href="/contact?objet=Demande+de+D%C3%A9mo"
+            className="new-hp-federations__cta-button bg-[#73cfa8] hover:bg-[#5ec497] text-gray-900 font-semibold px-8 py-3 rounded-lg transition-colors duration-300"
+          >
+            Demander une démo
+          </Link>
+          <a
+            href="mailto:contact@donaction.fr"
+            className="new-hp-federations__cta-email text-[#73cfa8] hover:text-[#5ec497] font-medium transition-colors duration-300"
+          >
+            contact@donaction.fr
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
@@ -5,6 +5,7 @@ import NewHpFeatures from './NewHpFeatures';
 import NewHpTimeline from './NewHpTimeline';
 import NewHpWidgetDemo from './NewHpWidgetDemo';
 import NewHpProjects from './NewHpProjects';
+import NewHpFederations from './NewHpFederations';
 import { KlubProjet } from '@/core/models/klub-project';
 import { Pagination } from '@/core/models/misc';
 
@@ -22,6 +23,7 @@ export default function NewHomepageContent({ projets }: NewHomepageContentProps)
       <NewHpTimeline />
       <NewHpWidgetDemo />
       <NewHpProjects projets={projets?.data || []} />
+      <NewHpFederations />
     </main>
   );
 }

--- a/donaction-frontend/src/types/global.d.ts
+++ b/donaction-frontend/src/types/global.d.ts
@@ -2,6 +2,12 @@ import React from 'react';
 
 export {};
 
+declare module 'react' {
+	interface CSSProperties {
+		[key: `--${string}`]: string | number;
+	}
+}
+
 declare global {
 	interface Window {
 		gtag: (command: 'config' | 'event', trackingId: string, options?: GtagOptions) => void;


### PR DESCRIPTION
## Summary
- Add NewHpFederations B2B section for sports federations and committees
- Dark gradient background with glass-morphism cards for 3 advantages (multi-club management, consolidated reporting, dedicated support)
- CTA "Demander une démo" links to contact page with pre-filled subject field
- Contact form enhanced to read `?objet=` query param for pre-fill

## Test plan
- [x] 13 unit tests passing (render, accessibility, CTA link, email link, icons)
- [x] All 96 NewHp section tests passing
- [x] Browser validation: desktop layout, CTA navigation, pre-filled contact form
- [ ] Manual review: responsive at mobile/tablet breakpoints
- [ ] Visual review: dark section contrast with surrounding sections

Closes #113