### PR TITLE
feat(frontend): NewHpNeedHelp FAQ section for new homepage (#114)

### DIFF
--- a/docs/tasks/2026_02_11_new_hp_needhelp.review.md
+++ b/docs/tasks/2026_02_11_new_hp_needhelp.review.md
@@ -1,0 +1,96 @@
+# Code Review for NewHpNeedHelp FAQ Section
+
+New FAQ section for the new homepage with split-panel desktop layout, mobile accordion, JSON-LD SEO schema, and CMS-driven content via existing Strapi `page-home.FAQ` field.
+
+- Statuts: **PASS with minor issues**
+- Confidence: **HIGH**
+
+## Main expected Changes
+
+- [x] Data wiring: `getHp()` call in `new-hp/page.tsx`, prop threading to `NewHomepageContent`
+- [x] Server component: `NewHpNeedHelp/index.tsx` with JSON-LD FAQPage schema
+- [x] Client component: `FaqAccordion.tsx` with split-panel (desktop) / accordion (mobile)
+- [x] SCSS: BEM styles, animations, responsive, reduced-motion
+- [x] Tests: 15/15 passing
+
+## Scoring
+
+### Potentially Unnecessary Elements
+
+- [🟢] No dead code or unused imports detected
+- [🟡] **Dual DOM rendering**: `FaqAccordion.tsx` renders BOTH desktop and mobile layouts simultaneously (hidden via CSS). Both share `activeIndex` state. This means the DOM contains 2x the FAQ elements. Acceptable for small FAQ lists (5-8 items), but worth noting for future optimization if lists grow large.
+
+### Standards Compliance
+
+- [🟢] Naming conventions followed (BEM `new-hp-needhelp__*`, PascalCase components, camelCase functions)
+- [🟢] Coding rules ok (Server Component for wrapper, `'use client'` only on interactive `FaqAccordion`)
+- [🟡] **DRY violation**: `index.tsx:8-15` `getPathname()` is duplicated from `mecenatPage/needHelp/index.tsx:8-15`. Also duplicated in `common/breadcrumb/index.tsx`. Should be extracted to a shared helper.
+- [🟡] **DRY violation**: `index.tsx:17-27` `getAnswer()` is duplicated from `mecenatPage/needHelp/index.tsx:34-44`. Should be extracted to a shared utility.
+
+### Architecture
+
+- [🟢] Proper separation: Server Component (data/SEO) + Client Component (interactivity)
+- [🟢] Follows established NewHp section patterns (folder structure, SCSS import, BEM naming)
+- [🟢] Reuses existing types (`FaqI`, `FaqItemsType`, `RichTextBlockEl`) and services (`getHp()`)
+- [🟢] `Promise.all` for parallel data fetching in `page.tsx` -- good optimization over sequential calls
+- [🟢] CSS-only responsive strategy (no JS breakpoint detection)
+
+### Code Health
+
+- [🟢] Functions and file sizes reasonable (largest: `index.scss` at 397 lines, well-organized with section comments)
+- [🟢] No magic numbers -- SCSS variables for all design tokens and timing
+- [🟢] `FaqAccordion.tsx` is 137 lines -- clean, focused
+- [🟢] Error handling: `.catch(() => undefined)` on `getHp()` prevents page crash if CMS unavailable
+- [🟢] Null guard: `if (!faq?.faq_item?.length) return null` prevents empty section rendering
+
+### Security
+
+- [🟢] No SQL injection risk (read-only CMS data)
+- [🟡] **XSS surface**: `index.tsx:56` `dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}` -- safe here because `JSON.stringify` escapes special chars and input is from trusted CMS, but worth noting. This matches the pattern used in the old NeedHelp component.
+- [🟢] No authentication flaws (public page, no user data)
+- [🟢] No data exposure (CMS content only)
+- [🟢] Environment variables secured (`SITE_URL` from env)
+
+### Error management
+
+- [🟢] Graceful degradation when FAQ data unavailable (returns null)
+- [🟢] `getPathname()` try/catch handles both server and client contexts
+
+### Performance
+
+- [🟢] `Promise.all` for parallel fetching -- no waterfall
+- [🟢] Staggered CSS animations via `--item-index` variable (GPU-accelerated `transform` + `opacity`)
+- [🟢] `grid-template-rows: 0fr/1fr` for smooth accordion height animation (no JS measurement)
+- [🟡] **Minor**: `getAnswer()` creates string concatenation in a loop. For large FAQ answers, `Array.join` would be more efficient. Negligible for typical FAQ content.
+
+### Frontend specific
+
+#### State Management
+
+- [🟢] Loading states: N/A (server-fetched data, no client loading)
+- [🟢] Empty states: null render when no FAQ items
+- [🟢] Error states: graceful fallback to no section
+- [🟢] Transition states: smooth crossfade (desktop) and height animation (mobile)
+
+#### UI/UX
+
+- [🟢] Consistent design patterns (matches other NewHp sections)
+- [🟢] Responsive design: 3 breakpoints (mobile, tablet `md:768px`, desktop `lg:1024px`)
+- [🟢] Accessibility: `role="tablist"/"tab"/"tabpanel"` (desktop), `aria-expanded`/`aria-controls` (mobile), `aria-hidden` on decorative SVGs
+- [🟢] Semantic HTML: `<section>`, `<h2>`, `<h3>`, `<button>` elements
+- [🟢] `prefers-reduced-motion: reduce` support
+- [🟢] Hover effects gated behind `@media (hover: hover)` (no ghost-hover on touch)
+
+### Backend specific
+
+- N/A (no backend changes)
+
+## Final Review
+
+- **Score**: 8.5/10
+- **Feedback**: Solid implementation following established patterns. Clean architecture with proper Server/Client component boundary. Good accessibility and responsive design. Two DRY violations should be addressed before merge.
+- **Follow-up Actions**:
+  1. **Extract `getPathname()`** to a shared helper (e.g., `src/core/helpers/getPathname.ts`) -- used in 3 files
+  2. **Extract `getAnswer()`** to a shared utility (e.g., `src/core/helpers/richTextToPlainText.ts`) -- used in 2 files
+  3. Exclude `donaction-saas/index.html` change from this PR (unrelated token rotation)
+- **Additional Notes**: The `donaction-saas/index.html` diff contains a JWT token change that should not be part of this feature branch.

--- a/donaction-frontend/src/app/(main)/new-hp/page.tsx
+++ b/donaction-frontend/src/app/(main)/new-hp/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import NewHomepageContent from '@/partials/newHomepage';
 import { getProjets } from '@/core/services/projet';
+import { getHp } from '@/core/services/cms';
 import { cookies } from 'next/headers';
 import GetServerCookie from '@/core/helpers/getServerCookie';
 
@@ -11,8 +12,17 @@ export const metadata: Metadata = {
 
 export default async function NewHpPage() {
   const isPreview = await GetServerCookie('isPreviewMode');
-  const projets = await getProjets(1, 3, true, !!isPreview, cookies().toString())
-    .catch(() => undefined);
+  const cookieStr = cookies().toString();
 
-  return <NewHomepageContent projets={projets} />;
+  const [projets, hpResult] = await Promise.all([
+    getProjets(1, 3, true, !!isPreview, cookieStr).catch(() => undefined),
+    getHp(cookieStr).catch(() => undefined),
+  ]);
+
+  return (
+    <NewHomepageContent
+      projets={projets}
+      faq={hpResult?.data?.attributes?.FAQ}
+    />
+  );
 }

--- a/donaction-frontend/src/core/helpers/getPathname.ts
+++ b/donaction-frontend/src/core/helpers/getPathname.ts
@@ -1,0 +1,16 @@
+import { headers } from 'next/headers';
+
+/**
+ * Retrieves the current pathname from request headers (server)
+ * or from `document.location` (client fallback).
+ */
+const getPathname = (): string => {
+	try {
+		const headersList = headers();
+		return headersList.get('x-custom-pathname') || '';
+	} catch {
+		return typeof window !== 'undefined' ? document?.location.pathname : '';
+	}
+};
+
+export default getPathname;

--- a/donaction-frontend/src/core/helpers/richTextToPlainText.ts
+++ b/donaction-frontend/src/core/helpers/richTextToPlainText.ts
@@ -1,0 +1,19 @@
+import { RichTextBlockEl } from '@/components/RichTextBlock';
+
+/**
+ * Recursively extracts plain text from a Strapi rich-text blocks array.
+ * Used primarily for JSON-LD structured data where HTML is not allowed.
+ */
+const richTextToPlainText = (data: Array<RichTextBlockEl>): string => {
+	let res = '';
+	data.forEach((_) => {
+		if (_.type === 'text') {
+			res += ' ' + _.text;
+			return;
+		}
+		res += ' ' + richTextToPlainText(_.children);
+	});
+	return res;
+};
+
+export default richTextToPlainText;

--- a/donaction-frontend/src/layouts/partials/common/breadcrumb/index.tsx
+++ b/donaction-frontend/src/layouts/partials/common/breadcrumb/index.tsx
@@ -1,8 +1,8 @@
 'use server';
 import React from 'react';
 import Link from 'next/link';
-import { headers } from 'next/headers';
 import { SITE_URL } from '@/core/services/endpoints';
+import getPathname from '@/core/helpers/getPathname';
 
 const getUnHyphenatedName = (str: string, capAll?: boolean) => {
 	return str
@@ -12,15 +12,6 @@ const getUnHyphenatedName = (str: string, capAll?: boolean) => {
 			return _;
 		})
 		.join(' ');
-};
-
-const getPathname = () => {
-	try {
-		const headersList = headers();
-		return headersList.get('x-custom-pathname') || '';
-	} catch (e: any) {
-		return typeof window !== 'undefined' ? document?.location.pathname : '';
-	}
 };
 
 const Breadcrumb: React.FC<{

--- a/donaction-frontend/src/layouts/partials/mecenatPage/needHelp/index.tsx
+++ b/donaction-frontend/src/layouts/partials/mecenatPage/needHelp/index.tsx
@@ -2,17 +2,8 @@ import React from 'react';
 import FaqItems from '@/partials/common/faqItems';
 import { FaqI } from '@/core/models/hp';
 import { SITE_URL } from '@/core/services/endpoints';
-import { headers } from 'next/headers';
-import { RichTextBlockEl } from '@/components/RichTextBlock';
-
-const getPathname = () => {
-	try {
-		const headersList = headers();
-		return headersList.get('x-custom-pathname') || '';
-	} catch (e: any) {
-		return typeof window !== 'undefined' ? document?.location.pathname : '';
-	}
-};
+import getPathname from '@/core/helpers/getPathname';
+import richTextToPlainText from '@/core/helpers/richTextToPlainText';
 
 const NeedHelp: React.FC<{
 	// GETTER?: () => Promise<{ data: { attributes: { FAQ: FaqI } } }>;
@@ -31,18 +22,6 @@ const NeedHelp: React.FC<{
 	// 	}
 	// }
 
-	const getAnswer = (data: Array<RichTextBlockEl>) => {
-		let res = '';
-		data.forEach((_) => {
-			if (_.type === 'text') {
-				res += ' ' + _.text;
-				return;
-			}
-			res += ' ' + getAnswer(_.children);
-		});
-		return res;
-	};
-
 	const jsonLd = {
 		'@context': 'https://schema.org',
 		'@type': 'FAQPage',
@@ -53,7 +32,7 @@ const NeedHelp: React.FC<{
 				name: _.question,
 				acceptedAnswer: {
 					'@type': 'Answer',
-					text: getAnswer(_.answer),
+					text: richTextToPlainText(_.answer),
 				},
 			})) || []),
 		],

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNeedHelp/FaqAccordion.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNeedHelp/FaqAccordion.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState } from 'react';
+import RichTextBlock from '@/components/RichTextBlock';
+import { FaqItemsType } from '@/core/models/hp';
+import ChevronIcon from './icons/ChevronIcon';
+
+type ItemStyle = React.CSSProperties & { '--item-index': number };
+type FaqStyle = React.CSSProperties & { '--faq-count': number };
+
+type FaqAccordionProps = {
+	faqItems: FaqItemsType;
+};
+
+export default function FaqAccordion({ faqItems }: FaqAccordionProps) {
+	const [activeIndex, setActiveIndex] = useState(0);
+
+	const handleQuestionClick = (index: number) => {
+		setActiveIndex((prev) => (prev === index ? -1 : index));
+	};
+
+	return (
+		<div
+			className="new-hp-needhelp__faq"
+			style={{ '--faq-count': faqItems.length } as FaqStyle}
+		>
+			{/* Desktop answer panel background */}
+			<div className="new-hp-needhelp__faq-panel" aria-hidden="true" />
+
+			{faqItems.map((item, index) => {
+				const isActive = activeIndex === index;
+				return (
+					<div
+						key={item.id}
+						className={`new-hp-needhelp__faq-item ${
+							isActive ? 'new-hp-needhelp__faq-item--active' : ''
+						}`}
+						style={{ '--item-index': index } as ItemStyle}
+					>
+						<button
+							className={`new-hp-needhelp__faq-trigger ${
+								isActive ? 'new-hp-needhelp__faq-trigger--active' : ''
+							}`}
+							aria-expanded={isActive}
+							aria-controls={`faq-answer-${item.id}`}
+							onClick={() => handleQuestionClick(index)}
+						>
+							<span className="new-hp-needhelp__faq-number">
+								{String(index + 1).padStart(2, '0')}
+							</span>
+							<span className="new-hp-needhelp__faq-text">
+								{item.question}
+							</span>
+							<ChevronIcon
+								className={`new-hp-needhelp__faq-chevron ${
+									isActive ? 'new-hp-needhelp__faq-chevron--open' : ''
+								}`}
+							/>
+						</button>
+						<div
+							className={`new-hp-needhelp__faq-body ${
+								isActive ? 'new-hp-needhelp__faq-body--active' : ''
+							}`}
+							id={`faq-answer-${item.id}`}
+						>
+							<div className="new-hp-needhelp__faq-body-inner">
+								<h3 className="new-hp-needhelp__faq-body-title">
+									{item.question}
+								</h3>
+								<RichTextBlock
+									data={item.answer}
+									classCss="new-hp-needhelp__faq-body-content"
+								/>
+							</div>
+						</div>
+					</div>
+				);
+			})}
+		</div>
+	);
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNeedHelp/NewHpNeedHelp.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNeedHelp/NewHpNeedHelp.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import NewHpNeedHelp from './index';
+import { FaqI } from '@/core/models/hp';
+
+// Mock next/headers
+vi.mock('next/headers', () => ({
+	headers: () => ({
+		get: () => '/new-hp',
+	}),
+}));
+
+// Mock next/link
+vi.mock('next/link', () => ({
+	default: ({ children, href, className }: any) => (
+		<a href={href} className={className}>
+			{children}
+		</a>
+	),
+}));
+
+const mockFaq: FaqI = {
+	id: 1,
+	title: 'Questions fr\u00e9quentes',
+	subtitle: 'Tout ce que vous devez savoir',
+	description: '',
+	faq_item: [
+		{
+			id: 10,
+			question: 'Comment fonctionne Donaction ?',
+			answer: [
+				{
+					type: 'paragraph',
+					children: [{ type: 'text', text: 'Donaction est une plateforme de dons.' }],
+				},
+			],
+		},
+		{
+			id: 20,
+			question: 'Les dons sont-ils d\u00e9ductibles ?',
+			answer: [
+				{
+					type: 'paragraph',
+					children: [{ type: 'text', text: '66% du montant est d\u00e9ductible.' }],
+				},
+			],
+		},
+		{
+			id: 30,
+			question: 'Comment contacter le support ?',
+			answer: [
+				{
+					type: 'paragraph',
+					children: [{ type: 'text', text: 'Par email ou formulaire.' }],
+				},
+			],
+		},
+	],
+};
+
+describe('NewHpNeedHelp', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns null when faq is undefined', () => {
+		const { container } = render(<NewHpNeedHelp />);
+		expect(container.innerHTML).toBe('');
+	});
+
+	it('returns null when faq_item is empty', () => {
+		const emptyFaq: FaqI = { id: 1, faq_item: [] };
+		const { container } = render(<NewHpNeedHelp faq={emptyFaq} />);
+		expect(container.innerHTML).toBe('');
+	});
+
+	it('renders section with correct BEM class', () => {
+		const { container } = render(<NewHpNeedHelp faq={mockFaq} />);
+		const section = container.querySelector('.new-hp-needhelp');
+		expect(section).toBeInTheDocument();
+		expect(section).toHaveClass('w-full');
+	});
+
+	it('renders CMS title', () => {
+		render(<NewHpNeedHelp faq={mockFaq} />);
+		const heading = screen.getByRole('heading', { level: 2 });
+		expect(heading).toBeInTheDocument();
+		expect(heading.textContent).toBeTruthy();
+	});
+
+	it('renders subtitle when provided', () => {
+		render(<NewHpNeedHelp faq={mockFaq} />);
+		const subtitle = screen.getByText(/tout ce que vous devez savoir/i);
+		expect(subtitle).toBeInTheDocument();
+	});
+
+	it('does not render subtitle when not provided', () => {
+		const faqNoSubtitle: FaqI = { ...mockFaq, subtitle: undefined };
+		const { container } = render(<NewHpNeedHelp faq={faqNoSubtitle} />);
+		const subtitle = container.querySelector('.new-hp-needhelp__subtitle');
+		expect(subtitle).not.toBeInTheDocument();
+	});
+
+	it('renders JSON-LD script with FAQPage type', () => {
+		const { container } = render(<NewHpNeedHelp faq={mockFaq} />);
+		const script = container.querySelector('script[type="application/ld+json"]');
+		expect(script).toBeInTheDocument();
+
+		const jsonLd = JSON.parse(script!.innerHTML);
+		expect(jsonLd['@type']).toBe('FAQPage');
+		expect(jsonLd['@context']).toBe('https://schema.org');
+		expect(jsonLd.mainEntity).toHaveLength(3);
+		expect(jsonLd.mainEntity[0]['@type']).toBe('Question');
+	});
+
+	it('renders all FAQ items (single DOM, no duplication)', () => {
+		const { container } = render(<NewHpNeedHelp faq={mockFaq} />);
+		const items = container.querySelectorAll('.new-hp-needhelp__faq-item');
+		expect(items).toHaveLength(3);
+	});
+
+	it('renders all trigger buttons', () => {
+		const { container } = render(<NewHpNeedHelp faq={mockFaq} />);
+		const triggers = container.querySelectorAll('.new-hp-needhelp__faq-trigger');
+		expect(triggers).toHaveLength(3);
+	});
+
+	it('first item is active by default', () => {
+		const { container } = render(<NewHpNeedHelp faq={mockFaq} />);
+		const items = container.querySelectorAll('.new-hp-needhelp__faq-item');
+		expect(items[0]).toHaveClass('new-hp-needhelp__faq-item--active');
+		expect(items[1]).not.toHaveClass('new-hp-needhelp__faq-item--active');
+	});
+
+	it('first trigger has aria-expanded true by default', () => {
+		const { container } = render(<NewHpNeedHelp faq={mockFaq} />);
+		const triggers = container.querySelectorAll('.new-hp-needhelp__faq-trigger');
+		expect(triggers[0]).toHaveAttribute('aria-expanded', 'true');
+		expect(triggers[1]).toHaveAttribute('aria-expanded', 'false');
+	});
+
+	it('toggles active item on click', () => {
+		const { container } = render(<NewHpNeedHelp faq={mockFaq} />);
+		const triggers = container.querySelectorAll('.new-hp-needhelp__faq-trigger');
+
+		fireEvent.click(triggers[1]);
+
+		const items = container.querySelectorAll('.new-hp-needhelp__faq-item');
+		expect(items[0]).not.toHaveClass('new-hp-needhelp__faq-item--active');
+		expect(items[1]).toHaveClass('new-hp-needhelp__faq-item--active');
+		expect(triggers[0]).toHaveAttribute('aria-expanded', 'false');
+		expect(triggers[1]).toHaveAttribute('aria-expanded', 'true');
+	});
+
+	it('renders numbered badges for questions', () => {
+		const { container } = render(<NewHpNeedHelp faq={mockFaq} />);
+		const numbers = container.querySelectorAll('.new-hp-needhelp__faq-number');
+		expect(numbers).toHaveLength(3);
+		expect(numbers[0].textContent).toBe('01');
+		expect(numbers[1].textContent).toBe('02');
+		expect(numbers[2].textContent).toBe('03');
+	});
+
+	it('renders desktop panel background element', () => {
+		const { container } = render(<NewHpNeedHelp faq={mockFaq} />);
+		const panel = container.querySelector('.new-hp-needhelp__faq-panel');
+		expect(panel).toBeInTheDocument();
+		expect(panel).toHaveAttribute('aria-hidden', 'true');
+	});
+
+	it('uses default title when CMS title is not provided', () => {
+		const faqNoTitle: FaqI = { ...mockFaq, title: undefined };
+		render(<NewHpNeedHelp faq={faqNoTitle} />);
+		const heading = screen.getByRole('heading', { level: 2 });
+		expect(heading.textContent).toBeTruthy();
+	});
+});

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNeedHelp/icons/ChevronIcon.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNeedHelp/icons/ChevronIcon.tsx
@@ -1,0 +1,22 @@
+interface ChevronIconProps {
+	className?: string;
+}
+
+export default function ChevronIcon({ className }: ChevronIconProps) {
+	return (
+		<svg
+			className={className}
+			width="20"
+			height="20"
+			viewBox="0 0 20 20"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth="2"
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			aria-hidden="true"
+		>
+			<polyline points="6 8 10 12 14 8" />
+		</svg>
+	);
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNeedHelp/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNeedHelp/index.scss
@@ -1,0 +1,352 @@
+// ─── Design Tokens ───────────────────────────────────────────────────────────
+$color-primary: #73cfa8;
+$color-primary-dark: #3d8a6a;
+$color-primary-light: rgba(115, 207, 168, 0.08);
+$color-primary-border: rgba(115, 207, 168, 0.25);
+
+$entrance-duration: 0.6s;
+$entrance-delay-base: 0.1s;
+$entrance-delay-step: 0.06s;
+$hover-duration: 0.25s;
+$answer-transition: 0.35s;
+
+// ─── Section ─────────────────────────────────────────────────────────────────
+.new-hp-needhelp {
+  background: linear-gradient(180deg, #ffffff 0%, #f9fafb 50%, #f3f4f6 100%);
+}
+
+// ─── Header ──────────────────────────────────────────────────────────────────
+.new-hp-needhelp__header {
+  animation: nhp-needhelp-fadeUp $entrance-duration ease both;
+}
+
+.new-hp-needhelp__title {
+  letter-spacing: -0.02em;
+}
+
+.new-hp-needhelp__subtitle {
+  line-height: 1.6;
+}
+
+// ─── FAQ Container (Mobile: Accordion, Desktop: Split Panel via Grid) ───────
+.new-hp-needhelp__faq {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+
+  @media (min-width: 768px) {
+    display: grid;
+    grid-template-columns: 38% 1fr;
+    grid-template-rows: repeat(var(--faq-count), auto);
+    gap: 0.5rem 2rem;
+    align-items: start;
+  }
+
+  @media (min-width: 1024px) {
+    grid-template-columns: 35% 1fr;
+    gap: 0.5rem 2.5rem;
+  }
+}
+
+// ─── Desktop Answer Panel Background ────────────────────────────────────────
+.new-hp-needhelp__faq-panel {
+  display: none;
+
+  @media (min-width: 768px) {
+    display: block;
+    grid-column: 2;
+    grid-row: 1 / -1;
+    background: #ffffff;
+    border-radius: 20px;
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    box-shadow:
+      0 1px 3px rgba(0, 0, 0, 0.04),
+      0 8px 24px rgba(0, 0, 0, 0.03);
+    min-height: 320px;
+    position: relative;
+    overflow: hidden;
+    animation: nhp-needhelp-fadeUp $entrance-duration ease both;
+    animation-delay: 0.3s;
+
+    // Decorative quotation mark
+    &::before {
+      content: '\201C';
+      position: absolute;
+      top: -8px;
+      right: 24px;
+      font-size: 100px;
+      font-family: Georgia, serif;
+      color: $color-primary;
+      opacity: 0.06;
+      pointer-events: none;
+      line-height: 1;
+    }
+  }
+}
+
+// ─── FAQ Item ───────────────────────────────────────────────────────────────
+.new-hp-needhelp__faq-item {
+  border-radius: 16px;
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-left: 3px solid transparent;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+  overflow: hidden;
+  transition: border-color $hover-duration ease, box-shadow $hover-duration ease;
+  animation: nhp-needhelp-fadeUp $entrance-duration ease both;
+  animation-delay: calc(var(--item-index) * #{$entrance-delay-step} + #{$entrance-delay-base});
+
+  &--active {
+    border-left-color: $color-primary;
+    box-shadow:
+      0 1px 3px rgba(0, 0, 0, 0.04),
+      0 4px 12px rgba(0, 0, 0, 0.04);
+  }
+
+  // Desktop: dissolve item wrapper, children become grid items
+  @media (min-width: 768px) {
+    display: contents;
+  }
+}
+
+// ─── Question Trigger Button ────────────────────────────────────────────────
+.new-hp-needhelp__faq-trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 1rem 1.125rem;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  text-align: left;
+
+  @media (min-width: 768px) {
+    grid-column: 1;
+    gap: 0.875rem;
+    padding: 1rem 1.25rem;
+    border-left: 3px solid transparent;
+    border-radius: 12px;
+    transition:
+      background-color $hover-duration ease,
+      border-color $hover-duration ease,
+      transform $hover-duration ease;
+    animation: nhp-needhelp-fadeUp $entrance-duration ease both;
+    animation-delay: calc(var(--item-index) * #{$entrance-delay-step} + #{$entrance-delay-base});
+
+    @media (hover: hover) {
+      &:hover {
+        background-color: rgba(0, 0, 0, 0.03);
+      }
+    }
+
+    &--active {
+      background-color: $color-primary-light;
+      border-left-color: $color-primary;
+
+      @media (hover: hover) {
+        &:hover {
+          background-color: $color-primary-light;
+        }
+      }
+    }
+  }
+}
+
+// ─── Question Number Badge ──────────────────────────────────────────────────
+.new-hp-needhelp__faq-number {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  color: $color-primary-dark;
+  background-color: $color-primary-border;
+  transition: background-color $hover-duration ease, color $hover-duration ease;
+
+  .new-hp-needhelp__faq-trigger--active & {
+    background-color: $color-primary;
+    color: #ffffff;
+  }
+
+  @media (min-width: 768px) {
+    width: 2rem;
+    height: 2rem;
+    font-size: 0.75rem;
+  }
+}
+
+// ─── Question Text ──────────────────────────────────────────────────────────
+.new-hp-needhelp__faq-text {
+  flex: 1;
+  font-size: 0.9375rem;
+  font-weight: 500;
+  color: #374151;
+  line-height: 1.4;
+
+  .new-hp-needhelp__faq-trigger--active & {
+    font-weight: 600;
+    color: #111827;
+  }
+}
+
+// ─── Chevron (mobile only) ──────────────────────────────────────────────────
+.new-hp-needhelp__faq-chevron {
+  flex-shrink: 0;
+  color: #9ca3af;
+  transition: transform $hover-duration ease;
+
+  &--open {
+    transform: rotate(180deg);
+  }
+
+  @media (min-width: 768px) {
+    display: none;
+  }
+}
+
+// ─── Answer Body ────────────────────────────────────────────────────────────
+.new-hp-needhelp__faq-body {
+  // Mobile: accordion animation
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows $answer-transition ease;
+
+  &--active {
+    grid-template-rows: 1fr;
+  }
+
+  // Desktop: overlay in answer panel area
+  @media (min-width: 768px) {
+    grid-column: 2;
+    grid-row: 1 / -1;
+    z-index: 1;
+    display: none;
+    padding: 2rem 2.25rem;
+
+    &--active {
+      display: block;
+    }
+  }
+}
+
+.new-hp-needhelp__faq-body-inner {
+  overflow: hidden;
+
+  @media (min-width: 768px) {
+    overflow: visible;
+  }
+}
+
+// ─── Answer Title (desktop only) ────────────────────────────────────────────
+.new-hp-needhelp__faq-body-title {
+  display: none;
+
+  @media (min-width: 768px) {
+    display: block;
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: #111827;
+    margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 2px solid $color-primary-border;
+  }
+}
+
+// ─── Answer Content ─────────────────────────────────────────────────────────
+.new-hp-needhelp__faq-body-content {
+  font-size: 0.875rem;
+  line-height: 1.7;
+  color: #4b5563;
+  padding: 0 1.125rem 1.25rem 3.625rem;
+
+  @media (min-width: 768px) {
+    padding: 0;
+    font-size: 0.9375rem;
+    line-height: 1.75;
+  }
+
+  p {
+    margin-bottom: 0.625rem;
+
+    @media (min-width: 768px) {
+      margin-bottom: 0.75rem;
+    }
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  a {
+    color: $color-primary-dark;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+
+    @media (hover: hover) {
+      &:hover {
+        color: #2d6a50;
+      }
+    }
+  }
+
+  ul,
+  ol {
+    padding-left: 1.25rem;
+    margin-bottom: 0.625rem;
+
+    @media (min-width: 768px) {
+      margin-bottom: 0.75rem;
+    }
+  }
+
+  li {
+    margin-bottom: 0.25rem;
+
+    @media (min-width: 768px) {
+      margin-bottom: 0.375rem;
+    }
+  }
+}
+
+// ─── Keyframes ───────────────────────────────────────────────────────────────
+@keyframes nhp-needhelp-fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// ─── Reduced Motion ──────────────────────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .new-hp-needhelp__header,
+  .new-hp-needhelp__faq-item,
+  .new-hp-needhelp__faq-panel,
+  .new-hp-needhelp__faq-trigger {
+    animation: none;
+  }
+
+  .new-hp-needhelp__faq-body {
+    transition: none;
+  }
+
+  .new-hp-needhelp__faq-chevron {
+    transition: none;
+  }
+
+  .new-hp-needhelp__faq-trigger {
+    transition: none;
+  }
+
+  .new-hp-needhelp__faq-number {
+    transition: none;
+  }
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNeedHelp/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNeedHelp/index.tsx
@@ -1,0 +1,52 @@
+import { FaqI } from '@/core/models/hp';
+import { SITE_URL } from '@/core/services/endpoints';
+import getPathname from '@/core/helpers/getPathname';
+import richTextToPlainText from '@/core/helpers/richTextToPlainText';
+import FaqAccordion from './FaqAccordion';
+import './index.scss';
+
+type NewHpNeedHelpProps = {
+	faq?: FaqI;
+};
+
+export default function NewHpNeedHelp({ faq }: NewHpNeedHelpProps) {
+	if (!faq?.faq_item?.length) return null;
+
+	const pathname = getPathname();
+
+	const jsonLd = {
+		'@context': 'https://schema.org',
+		'@type': 'FAQPage',
+		url: `${SITE_URL}/${pathname}`,
+		mainEntity: faq.faq_item.map((_) => ({
+			'@type': 'Question',
+			name: _.question,
+			acceptedAnswer: {
+				'@type': 'Answer',
+				text: richTextToPlainText(_.answer),
+			},
+		})),
+	};
+
+	return (
+		<section className="new-hp-needhelp w-full py-16 md:py-20 lg:py-24">
+			<script
+				type="application/ld+json"
+				dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+			/>
+			<div className="max-w-[1320px] mx-auto px-6">
+				<div className="new-hp-needhelp__header text-center mb-12 md:mb-16">
+					<h2 className="new-hp-needhelp__title text-2xl md:text-3xl lg:text-4xl font-bold text-gray-900 mb-4">
+						{faq.title || 'Questions fr\u00e9quentes'}
+					</h2>
+					{faq.subtitle && (
+						<p className="new-hp-needhelp__subtitle text-gray-500 text-base md:text-lg max-w-2xl mx-auto">
+							{faq.subtitle}
+						</p>
+					)}
+				</div>
+				<FaqAccordion faqItems={faq.faq_item} />
+			</div>
+		</section>
+	);
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
@@ -6,14 +6,17 @@ import NewHpTimeline from './NewHpTimeline';
 import NewHpWidgetDemo from './NewHpWidgetDemo';
 import NewHpProjects from './NewHpProjects';
 import NewHpFederations from './NewHpFederations';
+import NewHpNeedHelp from './NewHpNeedHelp';
 import { KlubProjet } from '@/core/models/klub-project';
 import { Pagination } from '@/core/models/misc';
+import { FaqI } from '@/core/models/hp';
 
 type NewHomepageContentProps = {
   projets?: { data: Array<KlubProjet>; meta: { pagination: Pagination } };
+  faq?: FaqI;
 };
 
-export default function NewHomepageContent({ projets }: NewHomepageContentProps) {
+export default function NewHomepageContent({ projets, faq }: NewHomepageContentProps) {
   return (
     <main className="flex flex-col items-center justify-center text-black w-full">
       <NewHpHero />
@@ -24,6 +27,7 @@ export default function NewHomepageContent({ projets }: NewHomepageContentProps)
       <NewHpWidgetDemo />
       <NewHpProjects projets={projets?.data || []} />
       <NewHpFederations />
+      <NewHpNeedHelp faq={faq} />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Add FAQ/NeedHelp section to the new homepage (`/new-hp`) using existing Strapi CMS data
- Unified single-DOM component: split-panel on desktop (CSS Grid + `display: contents`), accordion on mobile (`grid-template-rows` animation)
- Extract shared helpers `getPathname` and `richTextToPlainText` to eliminate DRY violations across 3+ files
- JSON-LD FAQPage schema for SEO, `prefers-reduced-motion` support, BEM naming

## Test plan
- [x] 15/15 Vitest tests passing
- [x] `npm run build` succeeds
- [ ] Visual check on `/new-hp`: desktop split-panel (1440px), tablet (768px), mobile accordion (375px)
- [ ] Verify JSON-LD `<script type="application/ld+json">` in page source
- [ ] Populate Strapi `page-home.FAQ` field with 5-8 items per checklist in plan