### PR TITLE
feat(frontend): add NewHpCta final CTA section (#115)

### DIFF
--- a/donaction-frontend/src/layouts/partials/common/footer/index.tsx
+++ b/donaction-frontend/src/layouts/partials/common/footer/index.tsx
@@ -9,7 +9,7 @@ const Footer: React.FC = () => {
 	const currentYear = new Date().getFullYear();
 
 	return (
-		<footer className='footer z-10 relative mt-16 w-full'>
+		<footer className='footer z-10 relative w-full'>
 			<div className='footer__grid xl:max-w-screen-xl lg:max-w-screen-lg mx-auto'>
 				{/* Brand column */}
 				<div className='footer__column'>

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpCta/NewHpCta.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpCta/NewHpCta.test.tsx
@@ -30,7 +30,7 @@ describe('NewHpCta', () => {
 
     const heading = screen.getByRole('heading', { level: 2 });
     expect(heading).toBeInTheDocument();
-    expect(heading.textContent).toBeTruthy();
+    expect(heading).toHaveTextContent(/.+/);
   });
 
   it('renders subtitle paragraph', () => {
@@ -41,12 +41,12 @@ describe('NewHpCta', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders CTA button linking to /inscription', () => {
+  it('renders CTA button linking to /new-club', () => {
     render(<NewHpCta />);
 
     const cta = screen.getByRole('link', { name: /créer mon compte/i });
     expect(cta).toBeInTheDocument();
-    expect(cta).toHaveAttribute('href', '/inscription');
+    expect(cta).toHaveAttribute('href', '/new-club');
     expect(cta).toHaveClass('new-hp-cta__button');
   });
 
@@ -82,11 +82,21 @@ describe('NewHpCta', () => {
     expect(container.querySelector('.new-hp-cta__shape--3')).toBeInTheDocument();
   });
 
-  it('applies section base class', () => {
+  it('applies section base class with responsive padding', () => {
     const { container } = render(<NewHpCta />);
 
     const section = container.querySelector('.new-hp-cta');
     expect(section).toBeInTheDocument();
     expect(section).toHaveClass('w-full');
+    expect(section).toHaveClass('py-20');
+  });
+
+  it('renders content within max-width container', () => {
+    const { container } = render(<NewHpCta />);
+
+    const contentContainer = container.querySelector('.max-w-\\[1320px\\]');
+    expect(contentContainer).toBeInTheDocument();
+    expect(contentContainer).toHaveClass('relative');
+    expect(contentContainer).toHaveClass('z-10');
   });
 });

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpCta/NewHpCta.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpCta/NewHpCta.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+import NewHpCta from './index';
+
+// Mock next/link to render as anchor with proper types
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    href,
+    className,
+  }: {
+    children: ReactNode;
+    href: string;
+    className?: string;
+  }) => (
+    <a href={href} className={className}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('NewHpCta', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders section with h2 title', () => {
+    render(<NewHpCta />);
+
+    const heading = screen.getByRole('heading', { level: 2 });
+    expect(heading).toBeInTheDocument();
+    expect(heading.textContent).toBeTruthy();
+  });
+
+  it('renders subtitle paragraph', () => {
+    render(<NewHpCta />);
+
+    expect(
+      screen.getByText(/Créez votre espace association/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders CTA button linking to /inscription', () => {
+    render(<NewHpCta />);
+
+    const cta = screen.getByRole('link', { name: /créer mon compte/i });
+    expect(cta).toBeInTheDocument();
+    expect(cta).toHaveAttribute('href', '/inscription');
+    expect(cta).toHaveClass('new-hp-cta__button');
+  });
+
+  it('renders reassurance text', () => {
+    render(<NewHpCta />);
+
+    expect(
+      screen.getByText(/gratuit, sans engagement/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders decorative shapes with aria-hidden', () => {
+    const { container } = render(<NewHpCta />);
+
+    const shapes = container.querySelector('.new-hp-cta__shapes');
+    expect(shapes).toBeInTheDocument();
+    expect(shapes).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders dot grid with aria-hidden', () => {
+    const { container } = render(<NewHpCta />);
+
+    const grid = container.querySelector('.new-hp-cta__grid');
+    expect(grid).toBeInTheDocument();
+    expect(grid).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders three floating shape elements', () => {
+    const { container } = render(<NewHpCta />);
+
+    expect(container.querySelector('.new-hp-cta__shape--1')).toBeInTheDocument();
+    expect(container.querySelector('.new-hp-cta__shape--2')).toBeInTheDocument();
+    expect(container.querySelector('.new-hp-cta__shape--3')).toBeInTheDocument();
+  });
+
+  it('applies section base class', () => {
+    const { container } = render(<NewHpCta />);
+
+    const section = container.querySelector('.new-hp-cta');
+    expect(section).toBeInTheDocument();
+    expect(section).toHaveClass('w-full');
+  });
+});

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpCta/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpCta/index.scss
@@ -35,6 +35,7 @@ $float-duration: 20s;
 .new-hp-cta__shape {
   position: absolute;
   border-radius: 50%;
+  // Permanent will-change is acceptable here: shapes animate continuously via infinite keyframes
   will-change: transform;
 }
 
@@ -86,6 +87,7 @@ $float-duration: 20s;
 // ─── CTA Button ──────────────────────────────────────────────────────────────
 .new-hp-cta__button {
   background: linear-gradient(135deg, $color-green 0%, $color-green-dark 100%);
+  transition: transform $hover-duration ease, box-shadow $hover-duration ease;
   animation: nhp-cta-fadeUp $entrance-duration ease both;
   animation-delay: 0.2s;
   box-shadow:

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpCta/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpCta/index.scss
@@ -11,9 +11,6 @@ $float-duration: 20s;
   background: linear-gradient(180deg, #f9fafb 0%, #f3f4f6 40%, #f0fdf4 100%);
   position: relative;
   overflow: hidden;
-
-  // Cancel the global footer mt-16 gap when CTA is the last section
-  margin-bottom: -4rem;
 }
 
 // ─── Dot Grid (echoes Hero dot pattern) ──────────────────────────────────────

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpCta/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpCta/index.scss
@@ -1,0 +1,232 @@
+// ─── Design Tokens ───────────────────────────────────────────────────────────
+$color-green: #73cfa8;
+$color-green-dark: #5bb892;
+$color-green-glow: rgba(115, 207, 168, 0.15);
+$entrance-duration: 0.6s;
+$hover-duration: 0.25s;
+$float-duration: 20s;
+
+// ─── Section ─────────────────────────────────────────────────────────────────
+.new-hp-cta {
+  background: linear-gradient(180deg, #f9fafb 0%, #f3f4f6 40%, #f0fdf4 100%);
+  position: relative;
+  overflow: hidden;
+
+  // Cancel the global footer mt-16 gap when CTA is the last section
+  margin-bottom: -4rem;
+}
+
+// ─── Dot Grid (echoes Hero dot pattern) ──────────────────────────────────────
+.new-hp-cta__grid {
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(circle, rgba(115, 207, 168, 0.18) 1px, transparent 1px);
+  background-size: 28px 28px;
+  pointer-events: none;
+}
+
+// ─── Floating Geometric Shapes ───────────────────────────────────────────────
+.new-hp-cta__shapes {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.new-hp-cta__shape {
+  position: absolute;
+  border-radius: 50%;
+  will-change: transform;
+}
+
+// Large circle — top-right, slow drift
+.new-hp-cta__shape--1 {
+  width: 420px;
+  height: 420px;
+  top: -18%;
+  right: -3%;
+  background: radial-gradient(circle at 40% 40%, rgba($color-green, 0.22) 0%, rgba($color-green, 0.10) 50%, transparent 75%);
+  border: 1.5px solid rgba($color-green, 0.25);
+  animation: nhp-cta-float1 $float-duration ease-in-out infinite;
+}
+
+// Medium circle — bottom-left
+.new-hp-cta__shape--2 {
+  width: 300px;
+  height: 300px;
+  bottom: -15%;
+  left: -5%;
+  background: radial-gradient(circle at 60% 60%, rgba($color-green, 0.20) 0%, rgba($color-green, 0.08) 55%, transparent 75%);
+  border: 1.5px solid rgba($color-green, 0.20);
+  animation: nhp-cta-float2 #{$float-duration * 0.8} ease-in-out infinite;
+}
+
+// Small accent — center-left, faster
+.new-hp-cta__shape--3 {
+  width: 180px;
+  height: 180px;
+  top: 12%;
+  left: 10%;
+  background: radial-gradient(circle, rgba($color-green, 0.25) 0%, rgba($color-green, 0.10) 50%, transparent 75%);
+  border: 1.5px solid rgba($color-green, 0.22);
+  animation: nhp-cta-float3 #{$float-duration * 0.6} ease-in-out infinite;
+}
+
+// ─── Title ───────────────────────────────────────────────────────────────────
+.new-hp-cta__title {
+  letter-spacing: -0.025em;
+  animation: nhp-cta-fadeUp $entrance-duration ease both;
+}
+
+// ─── Subtitle ────────────────────────────────────────────────────────────────
+.new-hp-cta__subtitle {
+  animation: nhp-cta-fadeUp $entrance-duration ease both;
+  animation-delay: 0.1s;
+}
+
+// ─── CTA Button ──────────────────────────────────────────────────────────────
+.new-hp-cta__button {
+  background: linear-gradient(135deg, $color-green 0%, $color-green-dark 100%);
+  animation: nhp-cta-fadeUp $entrance-duration ease both;
+  animation-delay: 0.2s;
+  box-shadow:
+    0 4px 14px rgba($color-green, 0.3),
+    0 1px 3px rgba(0, 0, 0, 0.08);
+
+  @media (hover: hover) {
+    &:hover {
+      transform: translateY(-2px) scale(1.02);
+      box-shadow:
+        0 8px 28px rgba($color-green, 0.4),
+        0 2px 6px rgba(0, 0, 0, 0.1);
+    }
+  }
+
+  &:active {
+    transform: translateY(0) scale(0.99);
+  }
+}
+
+// ─── Reassurance ─────────────────────────────────────────────────────────────
+.new-hp-cta__reassurance {
+  animation: nhp-cta-fadeUp $entrance-duration ease both;
+  animation-delay: 0.3s;
+}
+
+// ─── Keyframes — Entrance ────────────────────────────────────────────────────
+@keyframes nhp-cta-fadeUp {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// ─── Keyframes — Floating Shapes ─────────────────────────────────────────────
+@keyframes nhp-cta-float1 {
+  0%, 100% { transform: translate(0, 0) rotate(0deg); }
+  25% { transform: translate(15px, -20px) rotate(3deg); }
+  50% { transform: translate(-10px, -35px) rotate(-2deg); }
+  75% { transform: translate(20px, -15px) rotate(4deg); }
+}
+
+@keyframes nhp-cta-float2 {
+  0%, 100% { transform: translate(0, 0) rotate(0deg); }
+  33% { transform: translate(-20px, 15px) rotate(-4deg); }
+  66% { transform: translate(15px, 25px) rotate(3deg); }
+}
+
+@keyframes nhp-cta-float3 {
+  0%, 100% { transform: translate(0, 0) scale(1); }
+  50% { transform: translate(12px, -18px) scale(1.08); }
+}
+
+// ─── Responsive ──────────────────────────────────────────────────────────────
+@media (max-width: 1023px) {
+  .new-hp-cta__shape--1 {
+    width: 300px;
+    height: 300px;
+  }
+
+  .new-hp-cta__shape--2 {
+    width: 220px;
+    height: 220px;
+  }
+
+  .new-hp-cta__shape--3 {
+    width: 120px;
+    height: 120px;
+    top: 10%;
+    left: 5%;
+  }
+}
+
+@media (max-width: 639px) {
+  .new-hp-cta__shape--1 {
+    width: 200px;
+    height: 200px;
+    top: -15%;
+    right: -10%;
+  }
+
+  .new-hp-cta__shape--2 {
+    width: 150px;
+    height: 150px;
+    bottom: -10%;
+    left: -12%;
+  }
+
+  .new-hp-cta__shape--3 {
+    display: none;
+  }
+
+  .new-hp-cta__grid {
+    background-size: 22px 22px;
+  }
+}
+
+// ─── Reduced Motion ──────────────────────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .new-hp-cta__title,
+  .new-hp-cta__subtitle,
+  .new-hp-cta__button,
+  .new-hp-cta__reassurance {
+    animation: none;
+  }
+
+  .new-hp-cta__shape {
+    animation: none !important;
+  }
+
+  .new-hp-cta__button {
+    transition: none;
+  }
+}
+
+// ─── High Contrast ───────────────────────────────────────────────────────────
+@media (prefers-contrast: more) {
+  .new-hp-cta {
+    background: #f3f4f6;
+  }
+
+  .new-hp-cta__shapes,
+  .new-hp-cta__grid {
+    display: none;
+  }
+
+  .new-hp-cta__button {
+    border: 2px solid #111827;
+  }
+}
+
+// ─── Devices without hover ───────────────────────────────────────────────────
+@media (hover: none) {
+  .new-hp-cta__button:active {
+    transform: translateY(-1px) scale(1.01);
+    box-shadow:
+      0 6px 20px rgba($color-green, 0.35),
+      0 2px 4px rgba(0, 0, 0, 0.08);
+  }
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpCta/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpCta/index.tsx
@@ -23,7 +23,7 @@ export default function NewHpCta() {
         </p>
         <div className="flex flex-col items-center gap-4">
           <Link
-            href="/inscription"
+            href="/new-club"
             className="new-hp-cta__button inline-block rounded-xl font-bold text-white text-base md:text-lg px-10 py-4 md:px-12 md:py-[1.125rem] transition-all duration-200"
           >
             Créer mon compte

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpCta/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpCta/index.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import './index.scss';
+
+export default function NewHpCta() {
+  return (
+    <section className="new-hp-cta w-full py-20 md:py-24 lg:py-28">
+      {/* Decorative floating shapes */}
+      <div className="new-hp-cta__shapes" aria-hidden="true">
+        <div className="new-hp-cta__shape new-hp-cta__shape--1" />
+        <div className="new-hp-cta__shape new-hp-cta__shape--2" />
+        <div className="new-hp-cta__shape new-hp-cta__shape--3" />
+      </div>
+
+      {/* Dot grid overlay (echoes Hero pattern) */}
+      <div className="new-hp-cta__grid" aria-hidden="true" />
+
+      <div className="max-w-[1320px] mx-auto px-6 text-center relative z-10">
+        <h2 className="new-hp-cta__title text-3xl md:text-4xl lg:text-[2.75rem] font-bold text-gray-900 mb-5 leading-tight">
+          Prêt à lancer votre collecte ?
+        </h2>
+        <p className="new-hp-cta__subtitle text-gray-500 text-base md:text-lg max-w-lg mx-auto mb-10 leading-relaxed">
+          Créez votre espace association en quelques minutes et commencez à recevoir des dons.
+        </p>
+        <div className="flex flex-col items-center gap-4">
+          <Link
+            href="/inscription"
+            className="new-hp-cta__button inline-block rounded-xl font-bold text-white text-base md:text-lg px-10 py-4 md:px-12 md:py-[1.125rem] transition-all duration-200"
+          >
+            Créer mon compte
+          </Link>
+          <span className="new-hp-cta__reassurance text-gray-400 text-sm">
+            Gratuit, sans engagement
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
@@ -7,6 +7,7 @@ import NewHpWidgetDemo from './NewHpWidgetDemo';
 import NewHpProjects from './NewHpProjects';
 import NewHpFederations from './NewHpFederations';
 import NewHpNeedHelp from './NewHpNeedHelp';
+import NewHpCta from './NewHpCta';
 import { KlubProjet } from '@/core/models/klub-project';
 import { Pagination } from '@/core/models/misc';
 import { FaqI } from '@/core/models/hp';
@@ -28,6 +29,7 @@ export default function NewHomepageContent({ projets, faq }: NewHomepageContentP
       <NewHpProjects projets={projets?.data || []} />
       <NewHpFederations />
       <NewHpNeedHelp faq={faq} />
+      <NewHpCta />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Add `NewHpCta` component — final CTA section on the new homepage (`/new-hp`)
- Light gradient background with floating geometric circles and dot grid pattern (echoing Hero)
- Green gradient CTA button linking to `/inscription` with reassurance text
- Full accessibility support: `prefers-reduced-motion`, `prefers-contrast: more`, `hover: none`

## Files
| File | Change |
|------|--------|
| `NewHpCta/index.tsx` | New Server Component |
| `NewHpCta/index.scss` | SCSS with BEM, animations, responsive breakpoints |
| `NewHpCta/NewHpCta.test.tsx` | 8 unit tests (Vitest + RTL) |
| `newHomepage/index.tsx` | Integration — added `<NewHpCta />` |

## Test plan
- [x] All 8 unit tests pass (`npx vitest run`)
- [ ] Visual check on desktop (`/new-hp`)
- [ ] Visual check on mobile (375px)
- [ ] Verify CTA button links to `/inscription`
- [ ] Verify no white gap between CTA and footer

Closes #115