### PR TITLE
fix(frontend): improve responsive mobile layout for all new homepage sections (#116)

### DIFF
--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.scss
@@ -803,6 +803,10 @@ $shadow-cta-premium-hover: 0 8px 20px rgba($color-premium, 0.3);
     &__grid {
       gap: 2.5rem;
     }
+
+    &__example {
+      padding: 1.5rem 1.25rem;
+    }
   }
 }
 
@@ -847,6 +851,20 @@ $shadow-cta-premium-hover: 0 8px 20px rgba($color-premium, 0.3);
     &__badge-icon {
       width: 16px;
       height: 16px;
+    }
+
+    &__example {
+      padding: 1.25rem 1rem;
+      margin-top: 2rem;
+    }
+
+    &__example-title {
+      font-size: 1rem;
+    }
+
+    &__cta {
+      padding: 0.875rem 1.5rem;
+      font-size: 0.9375rem;
     }
   }
 }

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFederations/index.scss
@@ -250,7 +250,7 @@ $hover-duration: 0.3s;
 
     &__cta {
       flex-direction: column;
-      gap: 4rem;
+      gap: 1.5rem;
     }
 
     &__cta-button,

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/NewHpHero.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/NewHpHero.test.tsx
@@ -81,7 +81,7 @@ describe('NewHpHero', () => {
     const { container } = render(<NewHpHero />);
 
     const section = container.querySelector('.new-hp-hero');
-    expect(section).toHaveClass('min-h-[80vh]');
+    expect(section).toHaveClass('min-h-[auto]');
     expect(section).toHaveClass('w-full');
     expect(section).toHaveClass('relative');
 

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.scss
@@ -107,11 +107,29 @@
 @media (max-width: 1023px) {
   .new-hp-hero {
     &__illustration {
-      order: -1;
       margin-bottom: 1rem;
 
       svg {
         max-width: 320px;
+      }
+    }
+  }
+}
+
+@media (max-width: 767px) {
+  .new-hp-hero {
+    padding-top: 2rem;
+    padding-bottom: 2rem;
+
+    &__scroll-indicator {
+      display: none;
+    }
+
+    &__illustration {
+      margin-bottom: 0.5rem;
+
+      svg {
+        max-width: 260px;
       }
     }
   }
@@ -124,7 +142,7 @@
     }
 
     &__illustration svg {
-      max-width: 280px;
+      max-width: 240px;
     }
   }
 }

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.tsx
@@ -22,11 +22,11 @@ function CheckmarkIcon() {
 
 export default function NewHpHero() {
   return (
-    <section className="new-hp-hero min-h-[80vh] w-full relative flex items-center overflow-hidden">
+    <section className="new-hp-hero min-h-[auto] md:min-h-[80vh] w-full relative flex items-center overflow-hidden">
       {/* Background Pattern */}
       <div className="new-hp-hero__pattern absolute inset-0 pointer-events-none" />
 
-      <div className="flex flex-col lg:flex-row items-center justify-between w-full max-w-[1320px] mx-auto px-6 gap-12 relative z-10">
+      <div className="flex flex-col lg:flex-row items-center justify-between w-full max-w-[1320px] mx-auto px-6 gap-8 md:gap-12 relative z-10">
         {/* Text Content - 60% */}
         <div className="lg:w-[60%] flex flex-col gap-6 text-center lg:text-left">
           <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-black leading-[1.1] tracking-tight">
@@ -53,7 +53,7 @@ export default function NewHpHero() {
           </div>
 
           {/* Trust Indicators */}
-          <div className="flex items-center gap-6 mt-4 text-sm text-gray-500 justify-center lg:justify-start">
+          <div className="flex flex-wrap items-center gap-3 sm:gap-6 mt-4 text-sm text-gray-500 justify-center lg:justify-start">
             {TRUST_INDICATORS.map((text) => (
               <span key={text} className="flex items-center gap-2">
                 <CheckmarkIcon />
@@ -64,7 +64,7 @@ export default function NewHpHero() {
         </div>
 
         {/* Illustration - 40% */}
-        <div className="lg:w-[40%] flex items-center justify-center">
+        <div className="order-first lg:order-none lg:w-[40%] flex items-center justify-center">
           <div className="new-hp-hero__illustration relative">
             <HeroIllustration />
           </div>

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpTimeline/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpTimeline/index.scss
@@ -309,7 +309,7 @@ $hover-duration: 0.3s;
 @media (max-width: 767px) {
   .new-hp-timeline {
     &__step {
-      padding-left: 16px;
+      padding-left: 20px;
     }
 
     &__step-bg {

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/DemoWidget/index.scss
@@ -49,6 +49,18 @@
   }
 }
 
+// Mobile adjustments
+@media (max-width: 639px) {
+  .demo-widget {
+    &__badge {
+      top: -8px;
+      right: -4px;
+      font-size: 0.6875rem;
+      padding: 0.2rem 0.5rem;
+    }
+  }
+}
+
 // Demo blocker animation
 .demo-blocker {
   animation: fadeIn 0.2s ease;


### PR DESCRIPTION
## ✅ Type of PR

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## 🗒️ Description

Fix responsive mobile layout (< 768px) for all sections on `/new-hp`. Addresses spacing, ordering, and sizing issues across 6 components. Includes a **bug fix** for the Federations CTA gap (4rem → 1.5rem).

## 🚶‍➡️ Behavior

- Hero illustration now appears **above** text on mobile (was below)
- Hero min-height adapts to content on mobile instead of forcing 80vh
- Trust indicators wrap cleanly on narrow screens
- Features example card and CTA button scale down for small viewports
- Federations CTA button and email link have proper spacing on mobile
- Timeline steps have more breathing room on mobile
- Widget demo badge repositions on small screens
- Scroll indicator hidden on mobile (not useful with touch)

## 🧪 Steps to test

- [ ] Navigate to `/new-hp` on mobile viewport (375px)
- [ ] Verify Hero: illustration above heading, CTAs stacked vertically
- [ ] Verify trust indicators ("100% Gratuit", "Reçu fiscal", "Sécurisé") wrap without overflow
- [ ] Scroll to Features: example card and CTA button fit within viewport
- [ ] Scroll to Federations: CTA button and email link have ~1.5rem gap (not huge gap)
- [ ] Scroll to Timeline: steps have adequate left padding
- [ ] Scroll to Widget Demo: badge doesn't overflow card
- [ ] Check at 768px tablet: no regressions, grids show 2 columns
- [ ] Check at 1440px desktop: no regressions, full layout preserved

Closes #116