### PR TITLE
feat(frontend): Responsive tablet layout (768-1024px) (#117)

### DIFF
--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpFeatures/index.scss
@@ -79,7 +79,7 @@ $shadow-cta-premium-hover: 0 8px 20px rgba($color-premium, 0.3);
     flex-direction: column;
     gap: 2rem;
 
-    @media (min-width: 1024px) {
+    @media (min-width: 768px) {
       flex-direction: row;
       gap: 1.5rem;
     }

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.scss
@@ -104,6 +104,14 @@
 }
 
 // Responsive adjustments
+@media (min-width: 768px) and (max-width: 1023px) {
+  .new-hp-hero {
+    &__illustration svg {
+      max-width: 280px;
+    }
+  }
+}
+
 @media (max-width: 1023px) {
   .new-hp-hero {
     &__illustration {

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpHero/index.tsx
@@ -26,9 +26,9 @@ export default function NewHpHero() {
       {/* Background Pattern */}
       <div className="new-hp-hero__pattern absolute inset-0 pointer-events-none" />
 
-      <div className="flex flex-col lg:flex-row items-center justify-between w-full max-w-[1320px] mx-auto px-6 gap-8 md:gap-12 relative z-10">
+      <div className="flex flex-col md:flex-row items-center justify-between w-full max-w-[1320px] mx-auto px-6 gap-8 md:gap-12 relative z-10">
         {/* Text Content - 60% */}
-        <div className="lg:w-[60%] flex flex-col gap-6 text-center lg:text-left">
+        <div className="md:w-[55%] lg:w-[60%] flex flex-col gap-6 text-center md:text-left">
           <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-black leading-[1.1] tracking-tight">
             Transformez vos idées en{' '}
             <span className="text-transparent bg-clip-text bg-gradient-to-r from-[#73cfa8] to-[#5bb892]">
@@ -43,7 +43,7 @@ export default function NewHpHero() {
           </p>
 
           {/* CTA Buttons */}
-          <div className="flex flex-col sm:flex-row gap-4 mt-4 justify-center lg:justify-start">
+          <div className="flex flex-col sm:flex-row gap-4 mt-4 justify-center md:justify-start">
             <Link href="/new-club" className="btn btn-primary">
               Créer mon club
             </Link>
@@ -53,7 +53,7 @@ export default function NewHpHero() {
           </div>
 
           {/* Trust Indicators */}
-          <div className="flex flex-wrap items-center gap-3 sm:gap-6 mt-4 text-sm text-gray-500 justify-center lg:justify-start">
+          <div className="flex flex-wrap items-center gap-3 sm:gap-6 mt-4 text-sm text-gray-500 justify-center md:justify-start">
             {TRUST_INDICATORS.map((text) => (
               <span key={text} className="flex items-center gap-2">
                 <CheckmarkIcon />
@@ -64,7 +64,7 @@ export default function NewHpHero() {
         </div>
 
         {/* Illustration - 40% */}
-        <div className="order-first lg:order-none lg:w-[40%] flex items-center justify-center">
+        <div className="order-first md:order-none md:w-[45%] lg:w-[40%] flex items-center justify-center">
           <div className="new-hp-hero__illustration relative">
             <HeroIllustration />
           </div>

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpWidgetDemo/index.tsx
@@ -33,9 +33,9 @@ export default function NewHpWidgetDemo() {
   return (
     <section className="new-hp-widget-demo w-full py-16 md:py-20 lg:py-24">
       <div className="max-w-[1320px] mx-auto px-6">
-        <div className="flex flex-col lg:flex-row items-center justify-between gap-12 lg:gap-16">
+        <div className="flex flex-col md:flex-row items-center justify-between gap-12 md:gap-12 lg:gap-16">
           {/* Text Content - Left side */}
-          <div className="new-hp-widget-demo__content lg:w-[45%] text-center lg:text-left">
+          <div className="new-hp-widget-demo__content md:w-[45%] text-center md:text-left">
             <span className="inline-block bg-donaction-primary/10 text-donaction-primary-dark px-4 py-1.5 rounded-full text-sm font-semibold mb-6">
               Démo interactive
             </span>
@@ -52,7 +52,7 @@ export default function NewHpWidgetDemo() {
               {SECTION_CONTENT.benefits.map((benefit) => (
                 <li
                   key={benefit}
-                  className="flex items-center gap-3 justify-center lg:justify-start"
+                  className="flex items-center gap-3 justify-center md:justify-start"
                 >
                   <CheckIcon />
                   <span className="text-gray-700 font-medium">{benefit}</span>
@@ -62,7 +62,7 @@ export default function NewHpWidgetDemo() {
           </div>
 
           {/* Widget Demo - Right side */}
-          <div className="new-hp-widget-demo__widget-container lg:w-[50%] w-full max-w-[500px]">
+          <div className="new-hp-widget-demo__widget-container md:w-[50%] w-full max-w-[500px]">
             <DemoWidget />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Hero section: side-by-side 55/45 layout at `md` breakpoint (previously stacked until `lg`)
- Features/Pricing tiers: display side-by-side at `md` (previously column until `lg`)
- Widget Demo: text + widget side-by-side at `md` (previously stacked until `lg`)
- Hero illustration: tablet-specific `max-width: 280px` for balanced proportions

## Test plan
- [ ] Verify tablet layout at 768px viewport width
- [ ] Verify mobile layout at 375px still stacks vertically
- [ ] Verify desktop layout at 1440px unchanged
- [ ] Check hero 50/50 split on iPad/tablet
- [ ] Check pricing tiers side-by-side on tablet
- [ ] Check widget demo side-by-side on tablet

Closes #117