### PR TITLE
feat(frontend): add newsletter section to new homepage (#150)

### DIFF
--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/NewHpNewsletter.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/NewHpNewsletter.test.tsx
@@ -175,4 +175,18 @@ describe('NewHpNewsletter', () => {
 		expect(liveRegion).toBeInTheDocument();
 		expect(liveRegion).toHaveAttribute('aria-live', 'polite');
 	});
+
+	it('trims whitespace from email before submission', async () => {
+		render(<NewHpNewsletter />);
+
+		const input = screen.getByPlaceholderText('Saisissez votre e-mail');
+		fireEvent.change(input, { target: { value: '  test@example.com  ' } });
+		fireEvent.submit(screen.getByRole('button', { name: /abonner/i }));
+
+		await waitFor(() => {
+			expect(mockPostNewsletters).toHaveBeenCalledWith({
+				data: { email: 'test@example.com', formToken: 'mock-token' },
+			});
+		});
+	});
 });

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/NewHpNewsletter.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/NewHpNewsletter.test.tsx
@@ -102,7 +102,7 @@ describe('NewHpNewsletter', () => {
 		});
 	});
 
-	it('handles already-subscribed error gracefully', async () => {
+	it('shows already-subscribed message without toast when email exists', async () => {
 		mockPostNewsletters.mockRejectedValue({
 			error: { status: 400, message: 'This attribute must be unique' },
 		});
@@ -114,8 +114,14 @@ describe('NewHpNewsletter', () => {
 		fireEvent.submit(screen.getByRole('button', { name: /abonner/i }));
 
 		await waitFor(() => {
-			expect(screen.getByText('Merci pour votre inscription !')).toBeInTheDocument();
+			expect(screen.getByText('Vous êtes déjà inscrit(e)')).toBeInTheDocument();
 		});
+
+		// No toast dispatched for already-subscribed
+		const toastCalls = mockDispatch.mock.calls.filter(
+			([action]: any) => action?.type === 'root/pushToast',
+		);
+		expect(toastCalls).toHaveLength(0);
 	});
 
 	it('shows generic error toast on unexpected failure', async () => {

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/NewHpNewsletter.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/NewHpNewsletter.test.tsx
@@ -144,4 +144,29 @@ describe('NewHpNewsletter', () => {
 		expect(input).toHaveAttribute('type', 'email');
 		expect(input).toHaveAttribute('required');
 	});
+
+	it('shows spinner during submission', async () => {
+		// Make the token promise hang to keep loading state
+		mockCreateReCaptchaToken.mockReturnValue(new Promise(() => {}));
+
+		render(<NewHpNewsletter />);
+
+		const input = screen.getByPlaceholderText('Saisissez votre e-mail');
+		fireEvent.change(input, { target: { value: 'test@example.com' } });
+		fireEvent.submit(screen.getByRole('button', { name: /abonner/i }));
+
+		await waitFor(() => {
+			const button = screen.getByRole('button');
+			expect(button).toBeDisabled();
+			expect(button.querySelector('.new-hp-newsletter__spinner')).toBeInTheDocument();
+		});
+	});
+
+	it('has aria-live region for screen reader feedback', () => {
+		render(<NewHpNewsletter />);
+
+		const liveRegion = screen.getByRole('status');
+		expect(liveRegion).toBeInTheDocument();
+		expect(liveRegion).toHaveAttribute('aria-live', 'polite');
+	});
 });

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/NewHpNewsletter.test.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/NewHpNewsletter.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock dependencies before import
+const mockDispatch = vi.fn();
+vi.mock('@/core/store/hooks', () => ({
+	useAppDispatch: () => mockDispatch,
+	useAppSelector: () => null,
+}));
+
+const mockPostNewsletters = vi.fn();
+const mockCreateReCaptchaToken = vi.fn();
+vi.mock('@/core/services/cms', () => ({
+	postNewsletters: (...args: any[]) => mockPostNewsletters(...args),
+	createReCaptchaToken: (...args: any[]) => mockCreateReCaptchaToken(...args),
+}));
+
+vi.mock('@/core/store/modules/rootSlice', () => ({
+	pushToast: (payload: any) => ({ type: 'root/pushToast', payload }),
+}));
+
+vi.mock('@/partials/sponsorshipForm/logic/validations', () => ({
+	emailRexExp: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+}));
+
+vi.mock('@/components/ScrollAnimator', () => ({
+	default: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+		<div data-testid="scroll-animator" className={className}>
+			{children}
+		</div>
+	),
+}));
+
+import NewHpNewsletter from './index';
+
+describe('NewHpNewsletter', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockCreateReCaptchaToken.mockResolvedValue('mock-token');
+		mockPostNewsletters.mockResolvedValue({});
+	});
+
+	it('renders section with heading and form', () => {
+		render(<NewHpNewsletter />);
+
+		expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument();
+		expect(screen.getByPlaceholderText('Saisissez votre e-mail')).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /abonner/i })).toBeInTheDocument();
+	});
+
+	it('uses ScrollAnimator wrapper', () => {
+		render(<NewHpNewsletter />);
+
+		expect(screen.getByTestId('scroll-animator')).toBeInTheDocument();
+	});
+
+	it('shows error toast for invalid email', () => {
+		render(<NewHpNewsletter />);
+
+		const input = screen.getByPlaceholderText('Saisissez votre e-mail');
+		fireEvent.change(input, { target: { value: 'invalid-email' } });
+		fireEvent.submit(screen.getByRole('button', { name: /abonner/i }));
+
+		expect(mockDispatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				payload: expect.objectContaining({ type: 'error' }),
+			}),
+		);
+	});
+
+	it('shows error toast for empty email', () => {
+		render(<NewHpNewsletter />);
+
+		fireEvent.submit(screen.getByRole('button', { name: /abonner/i }));
+
+		expect(mockDispatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				payload: expect.objectContaining({ type: 'error' }),
+			}),
+		);
+	});
+
+	it('submits valid email and shows success state', async () => {
+		render(<NewHpNewsletter />);
+
+		const input = screen.getByPlaceholderText('Saisissez votre e-mail');
+		fireEvent.change(input, { target: { value: 'test@example.com' } });
+		fireEvent.submit(screen.getByRole('button', { name: /abonner/i }));
+
+		await waitFor(() => {
+			expect(mockCreateReCaptchaToken).toHaveBeenCalledWith('CREATE_NEWSLETTER_FORM');
+		});
+
+		await waitFor(() => {
+			expect(mockPostNewsletters).toHaveBeenCalledWith({
+				data: { email: 'test@example.com', formToken: 'mock-token' },
+			});
+		});
+
+		await waitFor(() => {
+			expect(screen.getByText('Merci pour votre inscription !')).toBeInTheDocument();
+		});
+	});
+
+	it('handles already-subscribed error gracefully', async () => {
+		mockPostNewsletters.mockRejectedValue({
+			error: { status: 400, message: 'This attribute must be unique' },
+		});
+
+		render(<NewHpNewsletter />);
+
+		const input = screen.getByPlaceholderText('Saisissez votre e-mail');
+		fireEvent.change(input, { target: { value: 'existing@example.com' } });
+		fireEvent.submit(screen.getByRole('button', { name: /abonner/i }));
+
+		await waitFor(() => {
+			expect(screen.getByText('Merci pour votre inscription !')).toBeInTheDocument();
+		});
+	});
+
+	it('shows generic error toast on unexpected failure', async () => {
+		mockPostNewsletters.mockRejectedValue(new Error('Network error'));
+
+		render(<NewHpNewsletter />);
+
+		const input = screen.getByPlaceholderText('Saisissez votre e-mail');
+		fireEvent.change(input, { target: { value: 'test@example.com' } });
+		fireEvent.submit(screen.getByRole('button', { name: /abonner/i }));
+
+		await waitFor(() => {
+			expect(mockDispatch).toHaveBeenCalledWith(
+				expect.objectContaining({
+					payload: expect.objectContaining({ type: 'error' }),
+				}),
+			);
+		});
+	});
+
+	it('has accessible form elements', () => {
+		render(<NewHpNewsletter />);
+
+		const input = screen.getByLabelText('Adresse e-mail pour la newsletter');
+		expect(input).toBeInTheDocument();
+		expect(input).toHaveAttribute('type', 'email');
+		expect(input).toHaveAttribute('required');
+	});
+});

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/index.scss
@@ -1,0 +1,298 @@
+// ─── Design Tokens ───────────────────────────────────────────────────────────
+$color-primary: #73cfa8;
+$color-primary-dark: #3d8a6a;
+$color-primary-hover: #5bb892;
+
+$entrance-duration: 0.6s;
+$entrance-delay-base: 0.1s;
+$entrance-delay-step: 0.06s;
+$hover-duration: 0.25s;
+
+// ─── Section ─────────────────────────────────────────────────────────────────
+.new-hp-newsletter {
+  background: linear-gradient(180deg, #f3f4f6 0%, #f9fafb 50%, #f0fdf4 100%);
+}
+
+// ─── Content wrapper ─────────────────────────────────────────────────────────
+.new-hp-newsletter__content {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity $entrance-duration ease, transform $entrance-duration ease;
+  will-change: opacity, transform;
+}
+
+.new-hp-newsletter__wrapper.is-visible .new-hp-newsletter__content {
+  opacity: 1;
+  transform: translateY(0);
+  will-change: auto;
+}
+
+// ─── Icon ────────────────────────────────────────────────────────────────────
+.new-hp-newsletter__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 4.5rem;
+  height: 4.5rem;
+  margin: 0 auto 1.5rem;
+  border-radius: 50%;
+  background: rgba(115, 207, 168, 0.1);
+  color: $color-primary-dark;
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity $entrance-duration ease, transform $entrance-duration ease;
+  transition-delay: $entrance-delay-base;
+  will-change: opacity, transform;
+
+  .new-hp-newsletter__wrapper.is-visible & {
+    opacity: 1;
+    transform: translateY(0);
+    will-change: auto;
+  }
+}
+
+// ─── Title ───────────────────────────────────────────────────────────────────
+.new-hp-newsletter__title {
+  letter-spacing: -0.02em;
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity $entrance-duration ease, transform $entrance-duration ease;
+  transition-delay: calc(#{$entrance-delay-base} + #{$entrance-delay-step});
+  will-change: opacity, transform;
+
+  .new-hp-newsletter__wrapper.is-visible & {
+    opacity: 1;
+    transform: translateY(0);
+    will-change: auto;
+  }
+}
+
+// ─── Subtitle ────────────────────────────────────────────────────────────────
+.new-hp-newsletter__subtitle {
+  line-height: 1.6;
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity $entrance-duration ease, transform $entrance-duration ease;
+  transition-delay: calc(#{$entrance-delay-base} + 2 * #{$entrance-delay-step});
+  will-change: opacity, transform;
+
+  .new-hp-newsletter__wrapper.is-visible & {
+    opacity: 1;
+    transform: translateY(0);
+    will-change: auto;
+  }
+}
+
+// ─── Form ────────────────────────────────────────────────────────────────────
+.new-hp-newsletter__form {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity $entrance-duration ease, transform $entrance-duration ease;
+  transition-delay: calc(#{$entrance-delay-base} + 3 * #{$entrance-delay-step});
+  will-change: opacity, transform;
+
+  .new-hp-newsletter__wrapper.is-visible & {
+    opacity: 1;
+    transform: translateY(0);
+    will-change: auto;
+  }
+}
+
+// ─── Input Group (inline on md+, stacked on mobile) ─────────────────────────
+.new-hp-newsletter__input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 480px;
+  margin: 0 auto;
+
+  @media (min-width: 640px) {
+    flex-direction: row;
+    gap: 0;
+    position: relative;
+    background: #ffffff;
+    border-radius: 14px;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    box-shadow:
+      0 1px 3px rgba(0, 0, 0, 0.04),
+      0 8px 24px rgba(0, 0, 0, 0.03);
+    padding: 0.3125rem;
+    transition: border-color $hover-duration ease, box-shadow $hover-duration ease;
+
+    &:focus-within {
+      border-color: rgba(115, 207, 168, 0.4);
+      box-shadow:
+        0 1px 3px rgba(0, 0, 0, 0.04),
+        0 8px 24px rgba(0, 0, 0, 0.03),
+        0 0 0 3px rgba(115, 207, 168, 0.12);
+    }
+  }
+}
+
+// ─── Input ───────────────────────────────────────────────────────────────────
+.new-hp-newsletter__input {
+  width: 100%;
+  height: 3.25rem;
+  padding: 0 1rem;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 12px;
+  font-size: 0.9375rem;
+  color: #111827;
+  background: #ffffff;
+  transition: border-color $hover-duration ease, box-shadow $hover-duration ease;
+
+  &::placeholder {
+    color: #9ca3af;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: rgba(115, 207, 168, 0.4);
+    box-shadow: 0 0 0 3px rgba(115, 207, 168, 0.12);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 640px) {
+    border: none;
+    box-shadow: none;
+    height: auto;
+    padding: 0.5rem 1rem;
+    border-radius: 10px;
+    background: transparent;
+
+    &:focus {
+      box-shadow: none;
+      border-color: transparent;
+    }
+  }
+}
+
+// ─── Submit Button ───────────────────────────────────────────────────────────
+.new-hp-newsletter__button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 3.25rem;
+  padding: 0 1.75rem;
+  border: none;
+  border-radius: 12px;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: #ffffff;
+  background: linear-gradient(135deg, $color-primary 0%, $color-primary-dark 100%);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: transform $hover-duration ease, box-shadow $hover-duration ease, opacity $hover-duration ease;
+
+  @media (hover: hover) {
+    &:hover:not(:disabled) {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 12px rgba(115, 207, 168, 0.35);
+    }
+  }
+
+  &:active:not(:disabled) {
+    transform: translateY(0);
+  }
+
+  &:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
+
+  @media (min-width: 640px) {
+    flex-shrink: 0;
+    height: auto;
+    padding: 0.625rem 1.5rem;
+    border-radius: 10px;
+  }
+}
+
+// ─── Spinner ─────────────────────────────────────────────────────────────────
+.new-hp-newsletter__spinner {
+  display: inline-block;
+  width: 1.25rem;
+  height: 1.25rem;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #ffffff;
+  border-radius: 50%;
+  animation: newsletter-spin 0.6s linear infinite;
+}
+
+@keyframes newsletter-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+// ─── Disclaimer ──────────────────────────────────────────────────────────────
+.new-hp-newsletter__disclaimer {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity $entrance-duration ease, transform $entrance-duration ease;
+  transition-delay: calc(#{$entrance-delay-base} + 4 * #{$entrance-delay-step});
+  will-change: opacity, transform;
+
+  .new-hp-newsletter__wrapper.is-visible & {
+    opacity: 1;
+    transform: translateY(0);
+    will-change: auto;
+  }
+}
+
+// ─── Success State ───────────────────────────────────────────────────────────
+.new-hp-newsletter__success {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  background: rgba(115, 207, 168, 0.08);
+  border: 1px solid rgba(115, 207, 168, 0.2);
+  border-radius: 14px;
+  max-width: 480px;
+  margin: 0 auto;
+  animation: newsletter-fadeIn 0.4s ease;
+}
+
+.new-hp-newsletter__success-icon {
+  flex-shrink: 0;
+  color: $color-primary-dark;
+}
+
+@keyframes newsletter-fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// ─── Reduced Motion ──────────────────────────────────────────────────────────
+@media (prefers-reduced-motion: reduce) {
+  .new-hp-newsletter__content,
+  .new-hp-newsletter__icon,
+  .new-hp-newsletter__title,
+  .new-hp-newsletter__subtitle,
+  .new-hp-newsletter__form,
+  .new-hp-newsletter__disclaimer {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+
+  .new-hp-newsletter__spinner {
+    animation: none;
+  }
+
+  .new-hp-newsletter__success {
+    animation: none;
+  }
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/index.scss
@@ -18,13 +18,11 @@ $hover-duration: 0.25s;
   opacity: 0;
   transform: translateY(24px);
   transition: opacity $entrance-duration ease, transform $entrance-duration ease;
-  will-change: opacity, transform;
 }
 
 .new-hp-newsletter__wrapper.is-visible .new-hp-newsletter__content {
   opacity: 1;
   transform: translateY(0);
-  will-change: auto;
 }
 
 // ─── Icon ────────────────────────────────────────────────────────────────────
@@ -42,12 +40,10 @@ $hover-duration: 0.25s;
   transform: translateY(24px);
   transition: opacity $entrance-duration ease, transform $entrance-duration ease;
   transition-delay: $entrance-delay-base;
-  will-change: opacity, transform;
 
   .new-hp-newsletter__wrapper.is-visible & {
     opacity: 1;
     transform: translateY(0);
-    will-change: auto;
   }
 }
 
@@ -58,12 +54,10 @@ $hover-duration: 0.25s;
   transform: translateY(24px);
   transition: opacity $entrance-duration ease, transform $entrance-duration ease;
   transition-delay: calc(#{$entrance-delay-base} + #{$entrance-delay-step});
-  will-change: opacity, transform;
 
   .new-hp-newsletter__wrapper.is-visible & {
     opacity: 1;
     transform: translateY(0);
-    will-change: auto;
   }
 }
 
@@ -74,12 +68,10 @@ $hover-duration: 0.25s;
   transform: translateY(24px);
   transition: opacity $entrance-duration ease, transform $entrance-duration ease;
   transition-delay: calc(#{$entrance-delay-base} + 2 * #{$entrance-delay-step});
-  will-change: opacity, transform;
 
   .new-hp-newsletter__wrapper.is-visible & {
     opacity: 1;
     transform: translateY(0);
-    will-change: auto;
   }
 }
 
@@ -89,12 +81,10 @@ $hover-duration: 0.25s;
   transform: translateY(24px);
   transition: opacity $entrance-duration ease, transform $entrance-duration ease;
   transition-delay: calc(#{$entrance-delay-base} + 3 * #{$entrance-delay-step});
-  will-change: opacity, transform;
 
   .new-hp-newsletter__wrapper.is-visible & {
     opacity: 1;
     transform: translateY(0);
-    will-change: auto;
   }
 }
 
@@ -235,12 +225,10 @@ $hover-duration: 0.25s;
   transform: translateY(24px);
   transition: opacity $entrance-duration ease, transform $entrance-duration ease;
   transition-delay: calc(#{$entrance-delay-base} + 4 * #{$entrance-delay-step});
-  will-change: opacity, transform;
 
   .new-hp-newsletter__wrapper.is-visible & {
     opacity: 1;
     transform: translateY(0);
-    will-change: auto;
   }
 }
 

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/index.scss
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/index.scss
@@ -137,6 +137,9 @@ $hover-duration: 0.25s;
 
   &:focus {
     outline: none;
+  }
+
+  &:focus-visible {
     border-color: rgba(115, 207, 168, 0.4);
     box-shadow: 0 0 0 3px rgba(115, 207, 168, 0.12);
   }
@@ -187,6 +190,11 @@ $hover-duration: 0.25s;
 
   &:active:not(:disabled) {
     transform: translateY(0);
+  }
+
+  &:focus-visible {
+    outline: 2px solid $color-primary;
+    outline-offset: 2px;
   }
 
   &:disabled {

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import ScrollAnimator from '@/components/ScrollAnimator';
 import { useAppDispatch } from '@/core/store/hooks';
 import { createReCaptchaToken, postNewsletters } from '@/core/services/cms';
@@ -8,11 +8,24 @@ import { pushToast } from '@/core/store/modules/rootSlice';
 import { emailRexExp } from '@/partials/sponsorshipForm/logic/validations';
 import './index.scss';
 
+type ApiError = { error?: { status?: number; message?: string } };
+
+const ALREADY_SUBSCRIBED_STATUS = 400;
+const ALREADY_SUBSCRIBED_MESSAGE = 'This attribute must be unique';
+
 export default function NewHpNewsletter() {
 	const dispatch = useAppDispatch();
 	const [email, setEmail] = useState('');
 	const [isLoading, setIsLoading] = useState(false);
 	const [isSubmitted, setIsSubmitted] = useState(false);
+	const [statusMessage, setStatusMessage] = useState('');
+	const isMounted = useRef(true);
+
+	useEffect(() => {
+		return () => {
+			isMounted.current = false;
+		};
+	}, []);
 
 	async function handleSubmit(e: React.FormEvent) {
 		e.preventDefault();
@@ -20,29 +33,41 @@ export default function NewHpNewsletter() {
 		const trimmed = email.trim();
 		if (!trimmed || !emailRexExp.test(trimmed)) {
 			dispatch(pushToast({ type: 'error', title: 'Veuillez saisir un e-mail valide.' }));
+			setStatusMessage('E-mail invalide.');
 			return;
 		}
 
 		setIsLoading(true);
+		setStatusMessage('Envoi en cours...');
 		try {
 			const formToken = await createReCaptchaToken('CREATE_NEWSLETTER_FORM');
 			await postNewsletters({ data: { email: trimmed, formToken } });
+			if (!isMounted.current) return;
 			setIsSubmitted(true);
+			setEmail('');
+			setStatusMessage('Inscription réussie !');
 			dispatch(
 				pushToast({ type: 'success', title: 'Vous êtes désormais abonné à la newsletter !' }),
 			);
-		} catch (error: any) {
+		} catch (error: unknown) {
+			if (!isMounted.current) return;
+			const apiError = error as ApiError;
 			if (
-				error?.error?.status === 400 &&
-				error.error?.message === 'This attribute must be unique'
+				apiError?.error?.status === ALREADY_SUBSCRIBED_STATUS &&
+				apiError.error?.message === ALREADY_SUBSCRIBED_MESSAGE
 			) {
 				setIsSubmitted(true);
+				setEmail('');
+				setStatusMessage('Déjà abonné.');
 				dispatch(pushToast({ type: 'success', title: 'Vous êtes déjà abonné !' }));
 			} else {
+				setStatusMessage('Erreur, veuillez réessayer.');
 				dispatch(pushToast({ type: 'error', title: 'Une erreur est survenue, réessayez.' }));
 			}
 		} finally {
-			setIsLoading(false);
+			if (isMounted.current) {
+				setIsLoading(false);
+			}
 		}
 	}
 
@@ -65,6 +90,10 @@ export default function NewHpNewsletter() {
 						<p className="new-hp-newsletter__subtitle text-gray-500 text-base md:text-lg mb-10 leading-relaxed">
 							Recevez nos dernières actualités et conseils pour optimiser vos collectes.
 						</p>
+
+						<div role="status" aria-live="polite" className="sr-only">
+							{statusMessage}
+						</div>
 
 						{isSubmitted ? (
 							<div className="new-hp-newsletter__success">

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/index.tsx
@@ -17,7 +17,7 @@ export default function NewHpNewsletter() {
 	const dispatch = useAppDispatch();
 	const [email, setEmail] = useState('');
 	const [isLoading, setIsLoading] = useState(false);
-	const [isSubmitted, setIsSubmitted] = useState(false);
+	const [successMessage, setSuccessMessage] = useState('');
 	const [statusMessage, setStatusMessage] = useState('');
 	const isMounted = useRef(true);
 
@@ -43,7 +43,7 @@ export default function NewHpNewsletter() {
 			const formToken = await createReCaptchaToken('CREATE_NEWSLETTER_FORM');
 			await postNewsletters({ data: { email: trimmed, formToken } });
 			if (!isMounted.current) return;
-			setIsSubmitted(true);
+			setSuccessMessage('Merci pour votre inscription !');
 			setEmail('');
 			setStatusMessage('Inscription réussie !');
 			dispatch(
@@ -56,10 +56,9 @@ export default function NewHpNewsletter() {
 				apiError?.error?.status === ALREADY_SUBSCRIBED_STATUS &&
 				apiError.error?.message === ALREADY_SUBSCRIBED_MESSAGE
 			) {
-				setIsSubmitted(true);
+				setSuccessMessage('Vous êtes déjà inscrit(e)');
 				setEmail('');
-				setStatusMessage('Déjà abonné.');
-				dispatch(pushToast({ type: 'success', title: 'Vous êtes déjà abonné !' }));
+				setStatusMessage('Déjà inscrit(e).');
 			} else {
 				setStatusMessage('Erreur, veuillez réessayer.');
 				dispatch(pushToast({ type: 'error', title: 'Une erreur est survenue, réessayez.' }));
@@ -95,12 +94,12 @@ export default function NewHpNewsletter() {
 							{statusMessage}
 						</div>
 
-						{isSubmitted ? (
+						{successMessage ? (
 							<div className="new-hp-newsletter__success">
 								<svg className="new-hp-newsletter__success-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
 									<path d="M20 6 9 17l-5-5" />
 								</svg>
-								<span className="text-gray-600 font-medium">Merci pour votre inscription !</span>
+								<span className="text-gray-600 font-medium">{successMessage}</span>
 							</div>
 						) : (
 							<form

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/index.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useState } from 'react';
+import ScrollAnimator from '@/components/ScrollAnimator';
+import { useAppDispatch } from '@/core/store/hooks';
+import { createReCaptchaToken, postNewsletters } from '@/core/services/cms';
+import { pushToast } from '@/core/store/modules/rootSlice';
+import { emailRexExp } from '@/partials/sponsorshipForm/logic/validations';
+import './index.scss';
+
+export default function NewHpNewsletter() {
+	const dispatch = useAppDispatch();
+	const [email, setEmail] = useState('');
+	const [isLoading, setIsLoading] = useState(false);
+	const [isSubmitted, setIsSubmitted] = useState(false);
+
+	async function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+
+		const trimmed = email.trim();
+		if (!trimmed || !emailRexExp.test(trimmed)) {
+			dispatch(pushToast({ type: 'error', title: 'Veuillez saisir un e-mail valide.' }));
+			return;
+		}
+
+		setIsLoading(true);
+		try {
+			const formToken = await createReCaptchaToken('CREATE_NEWSLETTER_FORM');
+			await postNewsletters({ data: { email: trimmed, formToken } });
+			setIsSubmitted(true);
+			dispatch(
+				pushToast({ type: 'success', title: 'Vous êtes désormais abonné à la newsletter !' }),
+			);
+		} catch (error: any) {
+			if (
+				error?.error?.status === 400 &&
+				error.error?.message === 'This attribute must be unique'
+			) {
+				setIsSubmitted(true);
+				dispatch(pushToast({ type: 'success', title: 'Vous êtes déjà abonné !' }));
+			} else {
+				dispatch(pushToast({ type: 'error', title: 'Une erreur est survenue, réessayez.' }));
+			}
+		} finally {
+			setIsLoading(false);
+		}
+	}
+
+	return (
+		<section className="new-hp-newsletter w-full py-16 md:py-20 lg:py-24">
+			<div className="max-w-[1320px] mx-auto px-6">
+				<ScrollAnimator className="new-hp-newsletter__wrapper">
+					<div className="new-hp-newsletter__content text-center max-w-2xl mx-auto">
+						<div className="new-hp-newsletter__icon" aria-hidden="true">
+							<svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+								<rect x="2" y="4" width="20" height="16" rx="2" />
+								<path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+							</svg>
+						</div>
+
+						<h2 className="new-hp-newsletter__title text-2xl md:text-3xl lg:text-4xl font-bold text-gray-900 mb-4">
+							Restez informé
+						</h2>
+
+						<p className="new-hp-newsletter__subtitle text-gray-500 text-base md:text-lg mb-10 leading-relaxed">
+							Recevez nos dernières actualités et conseils pour optimiser vos collectes.
+						</p>
+
+						{isSubmitted ? (
+							<div className="new-hp-newsletter__success">
+								<svg className="new-hp-newsletter__success-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+									<path d="M20 6 9 17l-5-5" />
+								</svg>
+								<span className="text-gray-600 font-medium">Merci pour votre inscription !</span>
+							</div>
+						) : (
+							<form
+								className="new-hp-newsletter__form"
+								onSubmit={handleSubmit}
+								noValidate
+							>
+								<div className="new-hp-newsletter__input-group">
+									<label htmlFor="newsletter-email" className="sr-only">
+										Adresse e-mail
+									</label>
+									<input
+										id="newsletter-email"
+										type="email"
+										value={email}
+										onChange={(e) => setEmail(e.target.value)}
+										placeholder="Saisissez votre e-mail"
+										className="new-hp-newsletter__input"
+										required
+										disabled={isLoading}
+										aria-label="Adresse e-mail pour la newsletter"
+									/>
+									<button
+										type="submit"
+										className="new-hp-newsletter__button"
+										disabled={isLoading}
+									>
+										{isLoading ? (
+											<span className="new-hp-newsletter__spinner" aria-hidden="true" />
+										) : (
+											"S'abonner"
+										)}
+									</button>
+								</div>
+								<p className="new-hp-newsletter__disclaimer text-gray-400 text-xs mt-4">
+									Pas de spam, désinscription en un clic.
+								</p>
+							</form>
+						)}
+					</div>
+				</ScrollAnimator>
+			</div>
+		</section>
+	);
+}

--- a/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/NewHpNewsletter/index.tsx
@@ -12,6 +12,12 @@ type ApiError = { error?: { status?: number; message?: string } };
 
 const ALREADY_SUBSCRIBED_STATUS = 400;
 const ALREADY_SUBSCRIBED_MESSAGE = 'This attribute must be unique';
+const SUCCESS_TEXT = 'Merci pour votre inscription !';
+const ALREADY_SUBSCRIBED_TEXT = 'Vous êtes déjà inscrit(e)';
+
+function isApiError(error: unknown): error is ApiError {
+	return typeof error === 'object' && error !== null && 'error' in error;
+}
 
 export default function NewHpNewsletter() {
 	const dispatch = useAppDispatch();
@@ -43,7 +49,7 @@ export default function NewHpNewsletter() {
 			const formToken = await createReCaptchaToken('CREATE_NEWSLETTER_FORM');
 			await postNewsletters({ data: { email: trimmed, formToken } });
 			if (!isMounted.current) return;
-			setSuccessMessage('Merci pour votre inscription !');
+			setSuccessMessage(SUCCESS_TEXT);
 			setEmail('');
 			setStatusMessage('Inscription réussie !');
 			dispatch(
@@ -51,12 +57,12 @@ export default function NewHpNewsletter() {
 			);
 		} catch (error: unknown) {
 			if (!isMounted.current) return;
-			const apiError = error as ApiError;
 			if (
-				apiError?.error?.status === ALREADY_SUBSCRIBED_STATUS &&
-				apiError.error?.message === ALREADY_SUBSCRIBED_MESSAGE
+				isApiError(error) &&
+				error.error?.status === ALREADY_SUBSCRIBED_STATUS &&
+				error.error?.message === ALREADY_SUBSCRIBED_MESSAGE
 			) {
-				setSuccessMessage('Vous êtes déjà inscrit(e)');
+				setSuccessMessage(ALREADY_SUBSCRIBED_TEXT);
 				setEmail('');
 				setStatusMessage('Déjà inscrit(e).');
 			} else {

--- a/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
+++ b/donaction-frontend/src/layouts/partials/newHomepage/index.tsx
@@ -7,6 +7,7 @@ import NewHpWidgetDemo from './NewHpWidgetDemo';
 import NewHpProjects from './NewHpProjects';
 import NewHpFederations from './NewHpFederations';
 import NewHpNeedHelp from './NewHpNeedHelp';
+import NewHpNewsletter from './NewHpNewsletter';
 import NewHpCta from './NewHpCta';
 import { KlubProjet } from '@/core/models/klub-project';
 import { Pagination } from '@/core/models/misc';
@@ -29,6 +30,7 @@ export default function NewHomepageContent({ projets, faq }: NewHomepageContentP
       <NewHpProjects projets={projets?.data || []} />
       <NewHpFederations />
       <NewHpNeedHelp faq={faq} />
+      <NewHpNewsletter />
       <NewHpCta />
     </main>
   );


### PR DESCRIPTION
## Summary
- Add `NewHpNewsletter` component between FAQ and CTA sections on the new homepage
- Email subscription form with reCAPTCHA validation and Strapi newsletter API
- ScrollAnimator scroll-triggered animations with staggered entrance delays
- Responsive layout: stacked on mobile, inline input+button on tablet+

## Changes
- **New:** `NewHpNewsletter/index.tsx` - Client component with email form, validation, success state
- **New:** `NewHpNewsletter/index.scss` - SCSS with design tokens, scroll animations, reduced motion support
- **New:** `NewHpNewsletter.test.tsx` - 8 unit tests (render, validation, submit, errors, a11y)
- **Modified:** `newHomepage/index.tsx` - Wire newsletter between NeedHelp and CTA

## Test plan
- [x] 8 unit tests passing (vitest)
- [x] TypeScript type check clean
- [x] Desktop screenshot validated (1440px)
- [x] Tablet screenshot validated (768px)
- [x] Mobile screenshot validated (375px)
- [x] No console errors
- [x] Code review: DRY fix applied (reuses shared email regex)

Closes #150