### PR TITLE
feat(frontend): redesign toast component with glassmorphism style (#153)

### DIFF
--- a/donaction-frontend/src/core/store/modules/rootSlice.ts
+++ b/donaction-frontend/src/core/store/modules/rootSlice.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RootState } from '../index';
 
-interface IToast {
+export interface IToast {
 	title: string;
 	type: 'info' | 'warn' | 'error' | 'success';
 }
@@ -46,7 +46,7 @@ export const rootSlice = createSlice({
 		pushToast: (state, action: PayloadAction<IToast>) => {
 			state.toasts.push({
 				...action.payload,
-				id: Math.random().toString(36).slice(2, 10),
+				id: crypto?.randomUUID?.() ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`,
 			});
 		},
 		popToast: (state, action: PayloadAction<string>) => {

--- a/donaction-frontend/src/layouts/components/toaster/Toaster.test.tsx
+++ b/donaction-frontend/src/layouts/components/toaster/Toaster.test.tsx
@@ -19,13 +19,14 @@ vi.mock('@/core/store/modules/rootSlice', () => ({
 
 import Toaster from './index';
 import * as storeHooks from '@/core/store/hooks';
+import type { IToast } from '@/core/store/modules/rootSlice';
 
-const makeToast = (
-	overrides: Partial<{ id: string; title: string; type: 'success' | 'error' | 'info' | 'warn' }> = {}
-) => ({
+type ToastWithId = IToast & { id: string };
+
+const makeToast = (overrides: Partial<ToastWithId> = {}): ToastWithId => ({
 	id: 'toast-1',
 	title: 'Test message',
-	type: 'success' as const,
+	type: 'success',
 	...overrides,
 });
 
@@ -139,6 +140,20 @@ describe('Toaster', () => {
 
 			const container = screen.getByRole('status');
 			expect(container).toHaveAttribute('aria-live', 'polite');
+		});
+
+		it.each([
+			['success', 'Success notification'],
+			['error', 'Error notification'],
+			['info', 'Information notification'],
+			['warn', 'Warning notification'],
+		])('has aria-label for %s toast', (type, expectedLabel) => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([
+				makeToast({ type: type as IToast['type'] }),
+			]);
+			const { container } = render(<Toaster />);
+			const item = container.querySelector('.toastItem');
+			expect(item).toHaveAttribute('aria-label', expectedLabel);
 		});
 
 		it('icons have aria-hidden="true"', () => {

--- a/donaction-frontend/src/layouts/components/toaster/Toaster.test.tsx
+++ b/donaction-frontend/src/layouts/components/toaster/Toaster.test.tsx
@@ -1,0 +1,473 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock SCSS
+vi.mock('./index.scss', () => ({}));
+
+// Mock Redux hooks before importing component
+vi.mock('@/core/store/hooks', () => ({
+	useAppDispatch: () => vi.fn(),
+	useAppSelector: vi.fn(),
+}));
+
+import Toaster from './index';
+import * as storeHooks from '@/core/store/hooks';
+
+describe('Toaster', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('Rendering', () => {
+		it('renders nothing when no toasts', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([]);
+
+			const { container } = render(<Toaster />);
+
+			expect(container.firstChild).toBeNull();
+		});
+
+		it('renders toast with text', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Success message',
+					type: 'success' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			render(<Toaster />);
+
+			expect(screen.getByText('Success message')).toBeInTheDocument();
+		});
+
+		it('renders multiple toasts', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'First message',
+					type: 'success' as const,
+				},
+				{
+					id: 'toast-2',
+					title: 'Second message',
+					type: 'error' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			render(<Toaster />);
+
+			expect(screen.getByText('First message')).toBeInTheDocument();
+			expect(screen.getByText('Second message')).toBeInTheDocument();
+		});
+	});
+
+	describe('Icons', () => {
+		it('renders correct icon for success type', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Success',
+					type: 'success' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			const iconSpan = container.querySelector('.toastItem__icon');
+			expect(iconSpan).toBeInTheDocument();
+			expect(iconSpan?.querySelector('svg')).toBeInTheDocument();
+		});
+
+		it('renders correct icon for error type', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Error',
+					type: 'error' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			const iconSpan = container.querySelector('.toastItem__icon');
+			expect(iconSpan).toBeInTheDocument();
+			expect(iconSpan?.querySelector('svg')).toBeInTheDocument();
+		});
+
+		it('renders correct icon for info type', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Info',
+					type: 'info' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			const iconSpan = container.querySelector('.toastItem__icon');
+			expect(iconSpan).toBeInTheDocument();
+			expect(iconSpan?.querySelector('svg')).toBeInTheDocument();
+		});
+
+		it('renders correct icon for warn type', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Warning',
+					type: 'warn' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			const iconSpan = container.querySelector('.toastItem__icon');
+			expect(iconSpan).toBeInTheDocument();
+			expect(iconSpan?.querySelector('svg')).toBeInTheDocument();
+		});
+	});
+
+	describe('CSS Classes', () => {
+		it('applies correct CSS class for success type', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Success',
+					type: 'success' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			const toastItem = container.querySelector('.toastItem.success');
+			expect(toastItem).toBeInTheDocument();
+		});
+
+		it('applies correct CSS class for error type', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Error',
+					type: 'error' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			const toastItem = container.querySelector('.toastItem.error');
+			expect(toastItem).toBeInTheDocument();
+		});
+
+		it('applies correct CSS class for info type', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Info',
+					type: 'info' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			const toastItem = container.querySelector('.toastItem.info');
+			expect(toastItem).toBeInTheDocument();
+		});
+
+		it('applies correct CSS class for warn type', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Warning',
+					type: 'warn' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			const toastItem = container.querySelector('.toastItem.warn');
+			expect(toastItem).toBeInTheDocument();
+		});
+
+		it('applies toastItem--dismissing class when toast is dismissing', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Test',
+					type: 'success' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			const toastItem = container.querySelector('.toastItem');
+			expect(toastItem).not.toHaveClass('toastItem--dismissing');
+		});
+	});
+
+	describe('Accessibility', () => {
+		it('has role="status" on container', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Test message',
+					type: 'info' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			render(<Toaster />);
+
+			const container = screen.getByRole('status');
+			expect(container).toBeInTheDocument();
+		});
+
+		it('has aria-live="polite" on container', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Test message',
+					type: 'info' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			render(<Toaster />);
+
+			const container = screen.getByRole('status');
+			expect(container).toHaveAttribute('aria-live', 'polite');
+		});
+
+		it('icon has aria-hidden="true"', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Test message',
+					type: 'success' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			const svgs = container.querySelectorAll('svg');
+			svgs.forEach((svg) => {
+				expect(svg).toHaveAttribute('aria-hidden', 'true');
+			});
+		});
+	});
+
+	describe('Text Content', () => {
+		it('displays toast title text correctly', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Custom toast message',
+					type: 'success' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			render(<Toaster />);
+
+			expect(screen.getByText('Custom toast message')).toBeInTheDocument();
+		});
+
+		it('displays multiple toast titles correctly', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'First toast',
+					type: 'success' as const,
+				},
+				{
+					id: 'toast-2',
+					title: 'Second toast',
+					type: 'error' as const,
+				},
+				{
+					id: 'toast-3',
+					title: 'Third toast',
+					type: 'warn' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			render(<Toaster />);
+
+			expect(screen.getByText('First toast')).toBeInTheDocument();
+			expect(screen.getByText('Second toast')).toBeInTheDocument();
+			expect(screen.getByText('Third toast')).toBeInTheDocument();
+		});
+
+		it('renders text in toastItem__text span', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Test message',
+					type: 'info' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			const textSpan = container.querySelector('.toastItem__text');
+			expect(textSpan).toBeInTheDocument();
+			expect(textSpan).toHaveTextContent('Test message');
+		});
+	});
+
+	describe('DOM Structure', () => {
+		it('renders container with toastContainer class', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Test',
+					type: 'success' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			const toastContainer = container.querySelector('.toastContainer');
+			expect(toastContainer).toBeInTheDocument();
+		});
+
+		it('renders toastItem elements with correct class', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Test 1',
+					type: 'success' as const,
+				},
+				{
+					id: 'toast-2',
+					title: 'Test 2',
+					type: 'error' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			const toastItems = container.querySelectorAll('.toastItem');
+			expect(toastItems).toHaveLength(2);
+		});
+
+		it('renders icon span within each toast item', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Test',
+					type: 'success' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			const toastItem = container.querySelector('.toastItem');
+			const iconSpan = toastItem?.querySelector('.toastItem__icon');
+			expect(iconSpan).toBeInTheDocument();
+		});
+
+		it('renders text span within each toast item', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Test',
+					type: 'success' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			const toastItem = container.querySelector('.toastItem');
+			const textSpan = toastItem?.querySelector('.toastItem__text');
+			expect(textSpan).toBeInTheDocument();
+		});
+	});
+
+	describe('Type Variations', () => {
+		it('handles all toast types: success, error, info, warn', () => {
+			const mockToasts = [
+				{
+					id: 'toast-success',
+					title: 'Success message',
+					type: 'success' as const,
+				},
+				{
+					id: 'toast-error',
+					title: 'Error message',
+					type: 'error' as const,
+				},
+				{
+					id: 'toast-info',
+					title: 'Info message',
+					type: 'info' as const,
+				},
+				{
+					id: 'toast-warn',
+					title: 'Warning message',
+					type: 'warn' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			const { container } = render(<Toaster />);
+
+			expect(container.querySelector('.toastItem.success')).toBeInTheDocument();
+			expect(container.querySelector('.toastItem.error')).toBeInTheDocument();
+			expect(container.querySelector('.toastItem.info')).toBeInTheDocument();
+			expect(container.querySelector('.toastItem.warn')).toBeInTheDocument();
+		});
+	});
+
+	describe('Redux Integration', () => {
+		it('uses useAppSelector to get toasts', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Test',
+					type: 'success' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			render(<Toaster />);
+
+			expect(vi.mocked(storeHooks.useAppSelector)).toHaveBeenCalled();
+		});
+
+		it('uses useAppDispatch hook', () => {
+			const mockToasts = [
+				{
+					id: 'toast-1',
+					title: 'Test',
+					type: 'success' as const,
+				},
+			];
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+
+			render(<Toaster />);
+
+			// Component initializes dispatch reference during render
+			// Verify component doesn't error with dispatch available
+			expect(vi.mocked(storeHooks.useAppDispatch)).toBeDefined();
+		});
+	});
+});

--- a/donaction-frontend/src/layouts/components/toaster/Toaster.test.tsx
+++ b/donaction-frontend/src/layouts/components/toaster/Toaster.test.tsx
@@ -1,473 +1,186 @@
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock SCSS
 vi.mock('./index.scss', () => ({}));
 
-// Mock Redux hooks before importing component
+// Stable dispatch mock (persists across renders)
+const mockDispatch = vi.fn();
+
 vi.mock('@/core/store/hooks', () => ({
-	useAppDispatch: () => vi.fn(),
+	useAppDispatch: () => mockDispatch,
 	useAppSelector: vi.fn(),
+}));
+
+vi.mock('@/core/store/modules/rootSlice', () => ({
+	popToast: (id: string) => ({ type: 'root/popToast', payload: id }),
+	selectToasts: (state: { root: { toasts: unknown[] } }) => state.root.toasts,
 }));
 
 import Toaster from './index';
 import * as storeHooks from '@/core/store/hooks';
 
+const makeToast = (
+	overrides: Partial<{ id: string; title: string; type: 'success' | 'error' | 'info' | 'warn' }> = {}
+) => ({
+	id: 'toast-1',
+	title: 'Test message',
+	type: 'success' as const,
+	...overrides,
+});
+
 describe('Toaster', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
 	});
 
 	describe('Rendering', () => {
 		it('renders nothing when no toasts', () => {
 			vi.mocked(storeHooks.useAppSelector).mockReturnValue([]);
-
 			const { container } = render(<Toaster />);
-
 			expect(container.firstChild).toBeNull();
 		});
 
-		it('renders toast with text', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Success message',
-					type: 'success' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+		it('renders toast with correct text and icon', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
+			const { container } = render(<Toaster />);
 
-			render(<Toaster />);
-
-			expect(screen.getByText('Success message')).toBeInTheDocument();
+			expect(screen.getByText('Test message')).toBeInTheDocument();
+			expect(container.querySelector('.toastItem__icon svg')).toBeInTheDocument();
 		});
 
-		it('renders multiple toasts', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'First message',
-					type: 'success' as const,
-				},
-				{
-					id: 'toast-2',
-					title: 'Second message',
-					type: 'error' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
+		it('renders multiple toasts stacked', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([
+				makeToast({ id: 'a', title: 'First' }),
+				makeToast({ id: 'b', title: 'Second', type: 'error' }),
+			]);
 			render(<Toaster />);
 
-			expect(screen.getByText('First message')).toBeInTheDocument();
-			expect(screen.getByText('Second message')).toBeInTheDocument();
+			expect(screen.getByText('First')).toBeInTheDocument();
+			expect(screen.getByText('Second')).toBeInTheDocument();
 		});
 	});
 
-	describe('Icons', () => {
-		it('renders correct icon for success type', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Success',
-					type: 'success' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
+	describe('BEM type modifiers', () => {
+		it.each([
+			['success', '.toastItem--success'],
+			['error', '.toastItem--error'],
+			['info', '.toastItem--info'],
+			['warn', '.toastItem--warn'],
+		])('applies %s modifier class', (type, selector) => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([
+				makeToast({ type: type as 'success' | 'error' | 'info' | 'warn' }),
+			]);
 			const { container } = render(<Toaster />);
-
-			const iconSpan = container.querySelector('.toastItem__icon');
-			expect(iconSpan).toBeInTheDocument();
-			expect(iconSpan?.querySelector('svg')).toBeInTheDocument();
+			expect(container.querySelector(selector)).toBeInTheDocument();
 		});
 
-		it('renders correct icon for error type', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Error',
-					type: 'error' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
+		it('renders all four types simultaneously', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([
+				makeToast({ id: '1', type: 'success' }),
+				makeToast({ id: '2', type: 'error' }),
+				makeToast({ id: '3', type: 'info' }),
+				makeToast({ id: '4', type: 'warn' }),
+			]);
 			const { container } = render(<Toaster />);
-
-			const iconSpan = container.querySelector('.toastItem__icon');
-			expect(iconSpan).toBeInTheDocument();
-			expect(iconSpan?.querySelector('svg')).toBeInTheDocument();
-		});
-
-		it('renders correct icon for info type', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Info',
-					type: 'info' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
-			const { container } = render(<Toaster />);
-
-			const iconSpan = container.querySelector('.toastItem__icon');
-			expect(iconSpan).toBeInTheDocument();
-			expect(iconSpan?.querySelector('svg')).toBeInTheDocument();
-		});
-
-		it('renders correct icon for warn type', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Warning',
-					type: 'warn' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
-			const { container } = render(<Toaster />);
-
-			const iconSpan = container.querySelector('.toastItem__icon');
-			expect(iconSpan).toBeInTheDocument();
-			expect(iconSpan?.querySelector('svg')).toBeInTheDocument();
+			expect(container.querySelectorAll('.toastItem')).toHaveLength(4);
 		});
 	});
 
-	describe('CSS Classes', () => {
-		it('applies correct CSS class for success type', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Success',
-					type: 'success' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
+	describe('Auto-dismiss timing', () => {
+		it('adds dismissing class after TOAST_DURATION (3700ms)', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
 			const { container } = render(<Toaster />);
 
-			const toastItem = container.querySelector('.toastItem.success');
-			expect(toastItem).toBeInTheDocument();
+			expect(container.querySelector('.toastItem--dismissing')).toBeNull();
+
+			act(() => {
+				vi.advanceTimersByTime(3700);
+			});
+
+			expect(container.querySelector('.toastItem--dismissing')).toBeInTheDocument();
 		});
 
-		it('applies correct CSS class for error type', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Error',
-					type: 'error' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+		it('dispatches popToast after TOAST_DURATION + DISMISS_ANIMATION_DURATION', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast({ id: 'xyz' })]);
+			render(<Toaster />);
 
-			const { container } = render(<Toaster />);
+			act(() => {
+				vi.advanceTimersByTime(3700 + 400);
+			});
 
-			const toastItem = container.querySelector('.toastItem.error');
-			expect(toastItem).toBeInTheDocument();
+			expect(mockDispatch).toHaveBeenCalledWith({
+				type: 'root/popToast',
+				payload: 'xyz',
+			});
 		});
 
-		it('applies correct CSS class for info type', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Info',
-					type: 'info' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
+		it('does not dispatch popToast before full duration', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
+			render(<Toaster />);
 
-			const { container } = render(<Toaster />);
+			act(() => {
+				vi.advanceTimersByTime(3700);
+			});
 
-			const toastItem = container.querySelector('.toastItem.info');
-			expect(toastItem).toBeInTheDocument();
-		});
-
-		it('applies correct CSS class for warn type', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Warning',
-					type: 'warn' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
-			const { container } = render(<Toaster />);
-
-			const toastItem = container.querySelector('.toastItem.warn');
-			expect(toastItem).toBeInTheDocument();
-		});
-
-		it('applies toastItem--dismissing class when toast is dismissing', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Test',
-					type: 'success' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
-			const { container } = render(<Toaster />);
-
-			const toastItem = container.querySelector('.toastItem');
-			expect(toastItem).not.toHaveClass('toastItem--dismissing');
+			expect(mockDispatch).not.toHaveBeenCalled();
 		});
 	});
 
 	describe('Accessibility', () => {
-		it('has role="status" on container', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Test message',
-					type: 'info' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
-			render(<Toaster />);
-
-			const container = screen.getByRole('status');
-			expect(container).toBeInTheDocument();
-		});
-
-		it('has aria-live="polite" on container', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Test message',
-					type: 'info' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
+		it('has role="status" and aria-live="polite" on container', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
 			render(<Toaster />);
 
 			const container = screen.getByRole('status');
 			expect(container).toHaveAttribute('aria-live', 'polite');
 		});
 
-		it('icon has aria-hidden="true"', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Test message',
-					type: 'success' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
+		it('icons have aria-hidden="true"', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
 			const { container } = render(<Toaster />);
 
-			const svgs = container.querySelectorAll('svg');
-			svgs.forEach((svg) => {
+			container.querySelectorAll('svg').forEach((svg) => {
 				expect(svg).toHaveAttribute('aria-hidden', 'true');
 			});
 		});
 	});
 
-	describe('Text Content', () => {
-		it('displays toast title text correctly', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Custom toast message',
-					type: 'success' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
-			render(<Toaster />);
-
-			expect(screen.getByText('Custom toast message')).toBeInTheDocument();
-		});
-
-		it('displays multiple toast titles correctly', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'First toast',
-					type: 'success' as const,
-				},
-				{
-					id: 'toast-2',
-					title: 'Second toast',
-					type: 'error' as const,
-				},
-				{
-					id: 'toast-3',
-					title: 'Third toast',
-					type: 'warn' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
-			render(<Toaster />);
-
-			expect(screen.getByText('First toast')).toBeInTheDocument();
-			expect(screen.getByText('Second toast')).toBeInTheDocument();
-			expect(screen.getByText('Third toast')).toBeInTheDocument();
-		});
-
-		it('renders text in toastItem__text span', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Test message',
-					type: 'info' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
+	describe('DOM structure', () => {
+		it('renders toastContainer > toastItem > icon + text', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
 			const { container } = render(<Toaster />);
 
-			const textSpan = container.querySelector('.toastItem__text');
-			expect(textSpan).toBeInTheDocument();
-			expect(textSpan).toHaveTextContent('Test message');
+			const wrapper = container.querySelector('.toastContainer');
+			expect(wrapper).toBeInTheDocument();
+
+			const item = wrapper?.querySelector('.toastItem');
+			expect(item?.querySelector('.toastItem__icon')).toBeInTheDocument();
+			expect(item?.querySelector('.toastItem__text')).toHaveTextContent('Test message');
 		});
 	});
 
-	describe('DOM Structure', () => {
-		it('renders container with toastContainer class', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Test',
-					type: 'success' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
-			const { container } = render(<Toaster />);
-
-			const toastContainer = container.querySelector('.toastContainer');
-			expect(toastContainer).toBeInTheDocument();
-		});
-
-		it('renders toastItem elements with correct class', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Test 1',
-					type: 'success' as const,
-				},
-				{
-					id: 'toast-2',
-					title: 'Test 2',
-					type: 'error' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
-			const { container } = render(<Toaster />);
-
-			const toastItems = container.querySelectorAll('.toastItem');
-			expect(toastItems).toHaveLength(2);
-		});
-
-		it('renders icon span within each toast item', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Test',
-					type: 'success' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
-			const { container } = render(<Toaster />);
-
-			const toastItem = container.querySelector('.toastItem');
-			const iconSpan = toastItem?.querySelector('.toastItem__icon');
-			expect(iconSpan).toBeInTheDocument();
-		});
-
-		it('renders text span within each toast item', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Test',
-					type: 'success' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
-			const { container } = render(<Toaster />);
-
-			const toastItem = container.querySelector('.toastItem');
-			const textSpan = toastItem?.querySelector('.toastItem__text');
-			expect(textSpan).toBeInTheDocument();
-		});
-	});
-
-	describe('Type Variations', () => {
-		it('handles all toast types: success, error, info, warn', () => {
-			const mockToasts = [
-				{
-					id: 'toast-success',
-					title: 'Success message',
-					type: 'success' as const,
-				},
-				{
-					id: 'toast-error',
-					title: 'Error message',
-					type: 'error' as const,
-				},
-				{
-					id: 'toast-info',
-					title: 'Info message',
-					type: 'info' as const,
-				},
-				{
-					id: 'toast-warn',
-					title: 'Warning message',
-					type: 'warn' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
-			const { container } = render(<Toaster />);
-
-			expect(container.querySelector('.toastItem.success')).toBeInTheDocument();
-			expect(container.querySelector('.toastItem.error')).toBeInTheDocument();
-			expect(container.querySelector('.toastItem.info')).toBeInTheDocument();
-			expect(container.querySelector('.toastItem.warn')).toBeInTheDocument();
-		});
-	});
-
-	describe('Redux Integration', () => {
-		it('uses useAppSelector to get toasts', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Test',
-					type: 'success' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
+	describe('Redux integration', () => {
+		it('calls useAppSelector with selectToasts', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([]);
 			render(<Toaster />);
-
 			expect(vi.mocked(storeHooks.useAppSelector)).toHaveBeenCalled();
 		});
 
-		it('uses useAppDispatch hook', () => {
-			const mockToasts = [
-				{
-					id: 'toast-1',
-					title: 'Test',
-					type: 'success' as const,
-				},
-			];
-			vi.mocked(storeHooks.useAppSelector).mockReturnValue(mockToasts);
-
+		it('uses stable dispatch reference for popToast', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
 			render(<Toaster />);
 
-			// Component initializes dispatch reference during render
-			// Verify component doesn't error with dispatch available
-			expect(vi.mocked(storeHooks.useAppDispatch)).toBeDefined();
+			act(() => {
+				vi.advanceTimersByTime(4100);
+			});
+
+			expect(mockDispatch).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/donaction-frontend/src/layouts/components/toaster/icons/ErrorIcon.tsx
+++ b/donaction-frontend/src/layouts/components/toaster/icons/ErrorIcon.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface ErrorIconProps {
+  className?: string;
+}
+
+const ErrorIcon: React.FC<ErrorIconProps> = ({ className }) => (
+  <svg
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    aria-hidden="true"
+  >
+    <circle cx="10" cy="10" r="9" stroke="currentColor" strokeWidth="1.5" />
+    <path
+      d="M7 7l6 6M13 7l-6 6"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default ErrorIcon;

--- a/donaction-frontend/src/layouts/components/toaster/icons/InfoIcon.tsx
+++ b/donaction-frontend/src/layouts/components/toaster/icons/InfoIcon.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface InfoIconProps {
+  className?: string;
+}
+
+const InfoIcon: React.FC<InfoIconProps> = ({ className }) => (
+  <svg
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    aria-hidden="true"
+  >
+    <circle cx="10" cy="10" r="9" stroke="currentColor" strokeWidth="1.5" />
+    <path
+      d="M10 6v0.01M10 9v3"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default InfoIcon;

--- a/donaction-frontend/src/layouts/components/toaster/icons/SuccessIcon.tsx
+++ b/donaction-frontend/src/layouts/components/toaster/icons/SuccessIcon.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+interface SuccessIconProps {
+  className?: string;
+}
+
+const SuccessIcon: React.FC<SuccessIconProps> = ({ className }) => (
+  <svg
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    aria-hidden="true"
+  >
+    <circle cx="10" cy="10" r="9" stroke="currentColor" strokeWidth="1.5" />
+    <path
+      d="M6.5 10l2.5 2.5 4-5"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default SuccessIcon;

--- a/donaction-frontend/src/layouts/components/toaster/icons/WarnIcon.tsx
+++ b/donaction-frontend/src/layouts/components/toaster/icons/WarnIcon.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+interface WarnIconProps {
+  className?: string;
+}
+
+const WarnIcon: React.FC<WarnIconProps> = ({ className }) => (
+  <svg
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+    aria-hidden="true"
+  >
+    <path
+      d="M10 2L2 16h16L10 2z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M10 9v2M10 13v0.01"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default WarnIcon;

--- a/donaction-frontend/src/layouts/components/toaster/index.scss
+++ b/donaction-frontend/src/layouts/components/toaster/index.scss
@@ -48,8 +48,8 @@
   // Entry animation
   animation: toastSlideIn 0.35s cubic-bezier(0.21, 1.02, 0.73, 1) forwards;
 
-  // Type-specific accents
-  &.success {
+  // Type-specific accents (BEM modifiers)
+  &--success {
     border-left-color: #73cfa8;
 
     .toastItem__icon {
@@ -57,7 +57,7 @@
     }
   }
 
-  &.error {
+  &--error {
     border-left-color: #fb9289;
 
     .toastItem__icon {
@@ -65,7 +65,7 @@
     }
   }
 
-  &.warn {
+  &--warn {
     border-left-color: #fde179;
 
     .toastItem__icon {
@@ -73,7 +73,7 @@
     }
   }
 
-  &.info {
+  &--info {
     border-left-color: #73b1ff;
 
     .toastItem__icon {

--- a/donaction-frontend/src/layouts/components/toaster/index.scss
+++ b/donaction-frontend/src/layouts/components/toaster/index.scss
@@ -1,49 +1,149 @@
-
-.toastItem {
+// Toast Container
+.toastContainer {
   position: fixed;
-  z-index: 999999999999;
-  max-width: min(400px, 80vw);
-  right: 2rem;
-  padding: 13px 28px;
-  border-radius: 6px;
-  font-size: 15px;
-  font-weight: 600;
-  opacity: 0;
-  animation: opacityChange 4s ease-in-out;
-  transition: bottom ease-in-out .2s;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 999999;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 0.75rem;
+  pointer-events: none;
 
-  color: #FFF;
+  @media (max-width: 575px) {
+    right: 0;
+    left: 0;
+    bottom: 1rem;
+    align-items: center;
+  }
+}
 
-  // TODO: bgColors to be changed
-  &.info {
-    background: #000;
+// Toast Item
+.toastItem {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 14px 20px;
+  border-radius: 12px;
+  max-width: min(420px, calc(100vw - 3rem));
+  font-size: 14px;
+  font-weight: 500;
+  color: #374151;
+  border-left: 3px solid transparent;
+
+  // Glassmorphism
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.08),
+    0 2px 8px rgba(0, 0, 0, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+
+  // Fallback for browsers without backdrop-filter
+  @supports not (backdrop-filter: blur(16px)) {
+    background: rgba(255, 255, 255, 0.97);
   }
-  &.warning {
-    background: darkorange;
-  }
+
+  // Entry animation
+  animation: toastSlideIn 0.35s cubic-bezier(0.21, 1.02, 0.73, 1) forwards;
+
+  // Type-specific accents
   &.success {
-    background: green;
-  }
-  &.error {
-    background: red;
+    border-left-color: #73cfa8;
+
+    .toastItem__icon {
+      color: #059669;
+    }
   }
 
-  @keyframes opacityChange {
-    0% {
+  &.error {
+    border-left-color: #fb9289;
+
+    .toastItem__icon {
+      color: #dc2626;
+    }
+  }
+
+  &.warn {
+    border-left-color: #fde179;
+
+    .toastItem__icon {
+      color: #d97706;
+    }
+  }
+
+  &.info {
+    border-left-color: #73b1ff;
+
+    .toastItem__icon {
+      color: #2563eb;
+    }
+  }
+
+  // Dismiss animation
+  &--dismissing {
+    animation: toastFadeOut 0.4s ease forwards;
+  }
+
+  // Icon
+  &__icon {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+
+    svg {
+      width: 20px;
+      height: 20px;
+    }
+  }
+
+  // Text
+  &__text {
+    flex: 1;
+    line-height: 1.4;
+  }
+
+  @media (max-width: 575px) {
+    max-width: calc(100vw - 2rem);
+  }
+}
+
+// Animations
+@keyframes toastSlideIn {
+  0% {
+    opacity: 0;
+    transform: translateY(100%) scale(0.95);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes toastFadeOut {
+  0% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(8px) scale(0.96);
+  }
+}
+
+// Reduced motion
+@media (prefers-reduced-motion: reduce) {
+  .toastItem {
+    animation: none;
+    opacity: 1;
+    transform: none;
+
+    &--dismissing {
+      animation: none;
       opacity: 0;
-      transform: translateX(100%);
-    }
-    10% {
-      opacity: 1;
-      transform: translateX(0);
-    }
-    90% {
-      opacity: 1;
-      transform: translateX(0);
-    }
-    100% {
-      opacity: 0;
-      transform: translateX(100%);
     }
   }
 }

--- a/donaction-frontend/src/layouts/components/toaster/index.tsx
+++ b/donaction-frontend/src/layouts/components/toaster/index.tsx
@@ -26,13 +26,12 @@ const Toaster = () => {
 	const timersRef = useRef<Map<string, NodeJS.Timeout>>(new Map());
 
 	useEffect(() => {
+		// Schedule timers for new toasts
 		toasts.forEach((toast) => {
 			if (!timersRef.current.has(toast.id)) {
-				// Schedule dismiss animation
 				const dismissTimer = setTimeout(() => {
 					setDismissing((prev) => new Set(prev).add(toast.id));
 
-					// Schedule removal after animation
 					const removeTimer = setTimeout(() => {
 						dispatch(popToast(toast.id));
 						setDismissing((prev) => {
@@ -41,6 +40,7 @@ const Toaster = () => {
 							return next;
 						});
 						timersRef.current.delete(toast.id);
+						timersRef.current.delete(toast.id + '-remove');
 					}, DISMISS_ANIMATION_DURATION);
 
 					timersRef.current.set(toast.id + '-remove', removeTimer);
@@ -49,9 +49,30 @@ const Toaster = () => {
 				timersRef.current.set(toast.id, dismissTimer);
 			}
 		});
+
+		// Clean up timers for externally removed toasts
+		const activeIds = new Set(toasts.map((t) => t.id));
+		timersRef.current.forEach((timer, key) => {
+			const baseId = key.replace('-remove', '');
+			if (!activeIds.has(baseId)) {
+				clearTimeout(timer);
+				timersRef.current.delete(key);
+			}
+		});
+		setDismissing((prev) => {
+			const next = new Set(prev);
+			let changed = false;
+			next.forEach((id) => {
+				if (!activeIds.has(id)) {
+					next.delete(id);
+					changed = true;
+				}
+			});
+			return changed ? next : prev;
+		});
 	}, [toasts, dispatch]);
 
-	// Cleanup timers on unmount
+	// Cleanup all timers on unmount
 	useEffect(() => {
 		return () => {
 			timersRef.current.forEach((timer) => clearTimeout(timer));
@@ -69,7 +90,7 @@ const Toaster = () => {
 
 				return (
 					<div
-						className={`toastItem ${toast.type}${isDismissing ? ' toastItem--dismissing' : ''}`}
+						className={`toastItem toastItem--${toast.type}${isDismissing ? ' toastItem--dismissing' : ''}`}
 						key={toast.id}
 					>
 						{Icon && (

--- a/donaction-frontend/src/layouts/components/toaster/index.tsx
+++ b/donaction-frontend/src/layouts/components/toaster/index.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '@/core/store/hooks';
-import { popToast, selectToasts } from '@/core/store/modules/rootSlice';
+import { popToast, selectToasts, type IToast } from '@/core/store/modules/rootSlice';
 import SuccessIcon from './icons/SuccessIcon';
 import ErrorIcon from './icons/ErrorIcon';
 import InfoIcon from './icons/InfoIcon';
@@ -12,12 +12,19 @@ import './index.scss';
 const TOAST_DURATION = 3700; // visible time before dismiss starts
 const DISMISS_ANIMATION_DURATION = 400; // exit animation length
 
-const ICON_MAP = {
+const ICON_MAP: Record<IToast['type'], React.FC<{ className?: string }>> = {
 	success: SuccessIcon,
 	error: ErrorIcon,
 	info: InfoIcon,
 	warn: WarnIcon,
-} as const;
+};
+
+const ARIA_LABELS: Record<IToast['type'], string> = {
+	success: 'Success notification',
+	error: 'Error notification',
+	info: 'Information notification',
+	warn: 'Warning notification',
+};
 
 const Toaster = () => {
 	const dispatch = useAppDispatch();
@@ -50,25 +57,29 @@ const Toaster = () => {
 			}
 		});
 
-		// Clean up timers for externally removed toasts
+		// Clean up timers and dismissing state for externally removed toasts
 		const activeIds = new Set(toasts.map((t) => t.id));
+		const keysToDelete: string[] = [];
 		timersRef.current.forEach((timer, key) => {
 			const baseId = key.replace('-remove', '');
 			if (!activeIds.has(baseId)) {
 				clearTimeout(timer);
-				timersRef.current.delete(key);
+				keysToDelete.push(key);
 			}
 		});
+		keysToDelete.forEach((key) => timersRef.current.delete(key));
+
 		setDismissing((prev) => {
-			const next = new Set(prev);
 			let changed = false;
-			next.forEach((id) => {
-				if (!activeIds.has(id)) {
-					next.delete(id);
-					changed = true;
-				}
+			prev.forEach((id) => {
+				if (!activeIds.has(id)) changed = true;
 			});
-			return changed ? next : prev;
+			if (!changed) return prev;
+			const next = new Set<string>();
+			prev.forEach((id) => {
+				if (activeIds.has(id)) next.add(id);
+			});
+			return next;
 		});
 	}, [toasts, dispatch]);
 
@@ -92,6 +103,7 @@ const Toaster = () => {
 					<div
 						className={`toastItem toastItem--${toast.type}${isDismissing ? ' toastItem--dismissing' : ''}`}
 						key={toast.id}
+						aria-label={ARIA_LABELS[toast.type]}
 					>
 						{Icon && (
 							<span className="toastItem__icon">

--- a/donaction-frontend/src/layouts/components/toaster/index.tsx
+++ b/donaction-frontend/src/layouts/components/toaster/index.tsx
@@ -1,56 +1,87 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '@/core/store/hooks';
-import { popToast, pushToast, selectToasts } from '@/core/store/modules/rootSlice';
+import { popToast, selectToasts } from '@/core/store/modules/rootSlice';
+import SuccessIcon from './icons/SuccessIcon';
+import ErrorIcon from './icons/ErrorIcon';
+import InfoIcon from './icons/InfoIcon';
+import WarnIcon from './icons/WarnIcon';
 import './index.scss';
+
+const TOAST_DURATION = 3700; // visible time before dismiss starts
+const DISMISS_ANIMATION_DURATION = 400; // exit animation length
+
+const ICON_MAP = {
+	success: SuccessIcon,
+	error: ErrorIcon,
+	info: InfoIcon,
+	warn: WarnIcon,
+} as const;
 
 const Toaster = () => {
 	const dispatch = useAppDispatch();
-	const toastsSelector = useAppSelector(selectToasts);
-	const [toasts, setToasts] = useState<typeof toastsSelector>([]);
-
-	// TODO: This is for testing
-	useEffect(() => {
-		// setTimeout(() => {
-		// 	dispatch(pushToast({ title: `Toast 1: info`, type: 'info' }));
-		// }, 1000);
-		// setTimeout(() => {
-		// 	dispatch(pushToast({ title: `Toast 2: error`, type: 'error' }));
-		// }, 2000);
-		// setTimeout(() => {
-		// 	dispatch(pushToast({ title: `Toast 3: success`, type: 'success' }));
-		// }, 3000);
-		// setTimeout(() => {
-		// 	dispatch(pushToast({ title: `Toast 4: warning`, type: 'warning' }));
-		// }, 4000);
-	}, []);
-	// /\ \\
+	const toasts = useAppSelector(selectToasts);
+	const [dismissing, setDismissing] = useState<Set<string>>(new Set());
+	const timersRef = useRef<Map<string, NodeJS.Timeout>>(new Map());
 
 	useEffect(() => {
-		toastsSelector.forEach((_) => {
-			if (!toasts.find((toast) => toast.id === _.id)) {
-				toasts.push(_);
-				setTimeout(() => {
-					dispatch(popToast(_.id));
-					toasts.filter((__) => __.id !== _.id);
-				}, 4100);
+		toasts.forEach((toast) => {
+			if (!timersRef.current.has(toast.id)) {
+				// Schedule dismiss animation
+				const dismissTimer = setTimeout(() => {
+					setDismissing((prev) => new Set(prev).add(toast.id));
+
+					// Schedule removal after animation
+					const removeTimer = setTimeout(() => {
+						dispatch(popToast(toast.id));
+						setDismissing((prev) => {
+							const next = new Set(prev);
+							next.delete(toast.id);
+							return next;
+						});
+						timersRef.current.delete(toast.id);
+					}, DISMISS_ANIMATION_DURATION);
+
+					timersRef.current.set(toast.id + '-remove', removeTimer);
+				}, TOAST_DURATION);
+
+				timersRef.current.set(toast.id, dismissTimer);
 			}
 		});
-	}, [toastsSelector]);
+	}, [toasts, dispatch]);
+
+	// Cleanup timers on unmount
+	useEffect(() => {
+		return () => {
+			timersRef.current.forEach((timer) => clearTimeout(timer));
+			timersRef.current.clear();
+		};
+	}, []);
+
+	if (toasts.length === 0) return null;
 
 	return (
-		<>
-			{toastsSelector.map((toast, _index) => (
-				<div
-					className={`toastItem ${toast.type}`}
-					style={{ bottom: 2 + 4 * _index + `rem` }}
-					key={toast.id}
-				>
-					{toast.title}
-				</div>
-			))}
-		</>
+		<div className="toastContainer" role="status" aria-live="polite">
+			{toasts.map((toast) => {
+				const Icon = ICON_MAP[toast.type];
+				const isDismissing = dismissing.has(toast.id);
+
+				return (
+					<div
+						className={`toastItem ${toast.type}${isDismissing ? ' toastItem--dismissing' : ''}`}
+						key={toast.id}
+					>
+						{Icon && (
+							<span className="toastItem__icon">
+								<Icon />
+							</span>
+						)}
+						<span className="toastItem__text">{toast.title}</span>
+					</div>
+				);
+			})}
+		</div>
 	);
 };
 


### PR DESCRIPTION
## Summary

Redesign the Toaster component with modern glassmorphism styling matching the newHP design system.

- **Glassmorphism**: `backdrop-blur(16px)`, semi-transparent white background, subtle shadow, frosted border
- **Type accents**: Colored left border per toast type using design tokens (success=#73cfa8, error=#fb9289, warn=#fde179, info=#73b1ff)
- **Icons**: 4 inline SVG icon components (SuccessIcon, ErrorIcon, InfoIcon, WarnIcon) matching newHP stroke style
- **Entry animation**: Sonner-style slide-in from bottom (350ms, spring easing)
- **Exit animation**: Progressive fade-out with scale-down (400ms), CSS class triggers before Redux removal
- **Layout**: Flex `column-reverse` with gap replaces manual `bottom` offset stacking
- **Responsive**: Centered on mobile (≤575px)
- **Accessibility**: `role="status"`, `aria-live="polite"`, `aria-hidden` icons, `prefers-reduced-motion` support
- **BEM naming**: Type modifiers use `toastItem--success` convention
- **Bug fixes**: Removed broken local state tracking, proper timer cleanup for externally removed toasts
- **Tests**: 16 focused unit tests (rendering, BEM classes, auto-dismiss timing, accessibility, DOM structure, Redux integration)

**Zero-touch migration**: Redux `pushToast`/`popToast` API unchanged — all 15+ dispatch sites work identically.

## Test plan

- [ ] Trigger success toast (e.g., newsletter signup)
- [ ] Trigger error toast (e.g., invalid login)
- [ ] Verify glassmorphism blur effect against page content
- [ ] Verify slide-in animation from bottom
- [ ] Verify fade-out before disappearance
- [ ] Test multiple toasts stacking
- [ ] Test mobile viewport (375px) — centered layout
- [ ] Test with `prefers-reduced-motion: reduce`
- [ ] Run `npx vitest run src/layouts/components/toaster/` — 16 tests pass

Closes #153