### PR TITLE
feat(frontend): toast stacking system (max 3, depth effect) (#155)

### DIFF
--- a/donaction-frontend/src/core/store/modules/rootSlice.test.ts
+++ b/donaction-frontend/src/core/store/modules/rootSlice.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import reducer, { pushToast, popToast, MAX_VISIBLE_TOASTS } from './rootSlice';
+
+const makeInitialState = (toasts: Array<{ id: string; title: string; type: 'success' }> = []) => ({
+	isRootLoading: false,
+	currentLanguage: 'fr',
+	popAuth: '',
+	toasts,
+	isDonationCguShown: false,
+});
+
+describe('rootSlice — toast stacking', () => {
+	it('exports MAX_VISIBLE_TOASTS as 3', () => {
+		expect(MAX_VISIBLE_TOASTS).toBe(3);
+	});
+
+	it('pushes a toast when under capacity', () => {
+		const state = makeInitialState();
+		const next = reducer(state, pushToast({ id: 'a', title: 'Hello', type: 'success' }));
+		expect(next.toasts).toHaveLength(1);
+		expect(next.toasts[0].title).toBe('Hello');
+	});
+
+	it('allows up to MAX_VISIBLE_TOASTS', () => {
+		let state = makeInitialState();
+		state = reducer(state, pushToast({ id: 'a', title: 'First', type: 'success' }));
+		state = reducer(state, pushToast({ id: 'b', title: 'Second', type: 'success' }));
+		state = reducer(state, pushToast({ id: 'c', title: 'Third', type: 'success' }));
+		expect(state.toasts).toHaveLength(3);
+	});
+
+	it('evicts oldest toast when pushing beyond MAX_VISIBLE_TOASTS', () => {
+		let state = makeInitialState();
+		state = reducer(state, pushToast({ id: 'a', title: 'First', type: 'success' }));
+		state = reducer(state, pushToast({ id: 'b', title: 'Second', type: 'success' }));
+		state = reducer(state, pushToast({ id: 'c', title: 'Third', type: 'success' }));
+		state = reducer(state, pushToast({ id: 'd', title: 'Fourth', type: 'success' }));
+
+		expect(state.toasts).toHaveLength(3);
+		expect(state.toasts.map((t) => t.id)).toEqual(['b', 'c', 'd']);
+		expect(state.toasts.map((t) => t.title)).toEqual(['Second', 'Third', 'Fourth']);
+	});
+
+	it('evicts multiple if somehow state exceeds capacity', () => {
+		// Simulate a state with 4 toasts already (edge case)
+		const state = makeInitialState([
+			{ id: 'a', title: 'A', type: 'success' },
+			{ id: 'b', title: 'B', type: 'success' },
+			{ id: 'c', title: 'C', type: 'success' },
+			{ id: 'd', title: 'D', type: 'success' },
+		]);
+		const next = reducer(state, pushToast({ id: 'e', title: 'E', type: 'success' }));
+
+		expect(next.toasts).toHaveLength(3);
+		expect(next.toasts[next.toasts.length - 1].id).toBe('e');
+	});
+
+	it('popToast removes a specific toast by id', () => {
+		let state = makeInitialState();
+		state = reducer(state, pushToast({ id: 'a', title: 'A', type: 'success' }));
+		state = reducer(state, pushToast({ id: 'b', title: 'B', type: 'success' }));
+		state = reducer(state, popToast('a'));
+
+		expect(state.toasts).toHaveLength(1);
+		expect(state.toasts[0].id).toBe('b');
+	});
+});

--- a/donaction-frontend/src/core/store/modules/rootSlice.ts
+++ b/donaction-frontend/src/core/store/modules/rootSlice.ts
@@ -1,6 +1,8 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RootState } from '../index';
 
+export const MAX_VISIBLE_TOASTS = 3;
+
 export interface IToast {
 	title: string;
 	type: 'info' | 'warn' | 'error' | 'success';
@@ -50,6 +52,12 @@ export const rootSlice = createSlice({
 				action.payload.id ??
 				crypto?.randomUUID?.() ??
 				`${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+
+			// Evict oldest toasts when at capacity
+			while (state.toasts.length >= MAX_VISIBLE_TOASTS) {
+				state.toasts.shift();
+			}
+
 			state.toasts.push({ title, type, hasActions, id });
 		},
 		popToast: (state, action: PayloadAction<string>) => {

--- a/donaction-frontend/src/layouts/components/toaster/Toaster.test.tsx
+++ b/donaction-frontend/src/layouts/components/toaster/Toaster.test.tsx
@@ -15,6 +15,7 @@ vi.mock('@/core/store/hooks', () => ({
 vi.mock('@/core/store/modules/rootSlice', () => ({
 	popToast: (id: string) => ({ type: 'root/popToast', payload: id }),
 	selectToasts: (state: { root: { toasts: unknown[] } }) => state.root.toasts,
+	MAX_VISIBLE_TOASTS: 3,
 }));
 
 vi.mock('./actionRegistry', () => ({
@@ -312,6 +313,54 @@ describe('Toaster', () => {
 			});
 
 			expect(mockDispatch).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('Stacking & depth effect', () => {
+		it('assigns depth-0 to a single toast (newest)', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
+			const { container } = render(<Toaster />);
+
+			const item = container.querySelector('.toastItem');
+			expect(item).toHaveAttribute('data-depth', '0');
+			expect(item?.classList.contains('toastItem--depth-0')).toBe(false);
+		});
+
+		it('assigns increasing depth to older toasts', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([
+				makeToast({ id: 'oldest', title: 'Oldest' }),
+				makeToast({ id: 'middle', title: 'Middle' }),
+				makeToast({ id: 'newest', title: 'Newest' }),
+			]);
+			const { container } = render(<Toaster />);
+
+			const items = container.querySelectorAll('.toastItem');
+			// Array order: oldest first, newest last
+			expect(items[0]).toHaveAttribute('data-depth', '2'); // oldest
+			expect(items[1]).toHaveAttribute('data-depth', '1'); // middle
+			expect(items[2]).toHaveAttribute('data-depth', '0'); // newest
+		});
+
+		it('applies depth modifier classes for non-zero depths', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([
+				makeToast({ id: 'oldest', title: 'Oldest' }),
+				makeToast({ id: 'middle', title: 'Middle' }),
+				makeToast({ id: 'newest', title: 'Newest' }),
+			]);
+			const { container } = render(<Toaster />);
+
+			const items = container.querySelectorAll('.toastItem');
+			expect(items[0].classList.contains('toastItem--depth-2')).toBe(true);
+			expect(items[1].classList.contains('toastItem--depth-1')).toBe(true);
+			expect(items[2].classList.contains('toastItem--depth-0')).toBe(false);
+		});
+
+		it('does not apply depth class to single toast', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
+			const { container } = render(<Toaster />);
+
+			const item = container.querySelector('.toastItem');
+			expect(item?.className).not.toContain('depth');
 		});
 	});
 });

--- a/donaction-frontend/src/layouts/components/toaster/index.scss
+++ b/donaction-frontend/src/layouts/components/toaster/index.scss
@@ -31,6 +31,10 @@
   color: #374151;
   border-left: 3px solid transparent;
 
+  // Smooth repositioning when toasts shift in the stack
+  transition: transform 0.3s cubic-bezier(0.21, 1.02, 0.73, 1),
+              opacity 0.3s ease;
+
   // Glassmorphism
   background: rgba(255, 255, 255, 0.85);
   backdrop-filter: blur(16px);
@@ -47,6 +51,17 @@
 
   // Entry animation
   animation: toastSlideIn 0.35s cubic-bezier(0.21, 1.02, 0.73, 1) forwards;
+
+  // Depth effect — toasts further back appear slightly receded
+  &--depth-1 {
+    transform: scale(0.96);
+    opacity: 0.85;
+  }
+
+  &--depth-2 {
+    transform: scale(0.92);
+    opacity: 0.7;
+  }
 
   // Type-specific accents (BEM modifiers)
   &--success {
@@ -205,10 +220,22 @@
     animation: none;
     opacity: 1;
     transform: none;
+    transition: none;
 
     &--dismissing {
       animation: none;
       opacity: 0;
+    }
+
+    // Depth still shown statically (opacity only, no transform)
+    &--depth-1 {
+      opacity: 0.85;
+      transform: none;
+    }
+
+    &--depth-2 {
+      opacity: 0.7;
+      transform: none;
     }
 
     &__close,

--- a/donaction-frontend/src/layouts/components/toaster/index.tsx
+++ b/donaction-frontend/src/layouts/components/toaster/index.tsx
@@ -137,16 +137,19 @@ const Toaster = () => {
 
 	return (
 		<div className="toastContainer" role="status" aria-live="polite">
-			{toasts.map((toast) => {
+			{toasts.map((toast, index) => {
 				const Icon = ICON_MAP[toast.type];
 				const isDismissing = dismissing.has(toast.id);
 				const actions = actionsMap.get(toast.id) ?? [];
+				// Depth: newest toast (last in array) = 0, oldest = highest
+				const depth = toasts.length - 1 - index;
 
 				return (
 					<div
-						className={`toastItem toastItem--${toast.type}${isDismissing ? ' toastItem--dismissing' : ''}`}
+						className={`toastItem toastItem--${toast.type}${isDismissing ? ' toastItem--dismissing' : ''}${depth > 0 ? ` toastItem--depth-${depth}` : ''}`}
 						key={toast.id}
 						aria-label={ARIA_LABELS[toast.type]}
+						data-depth={depth}
 					>
 						{Icon && (
 							<span className="toastItem__icon">


### PR DESCRIPTION
## Summary
- Limit visible toasts to **3 max** — oldest auto-evicted when a 4th arrives
- Add **depth effect** (scale + opacity) so stacked toasts appear receded
- Smooth **repositioning transitions** when the stack changes
- Respects `prefers-reduced-motion` (static opacity only, no transform)

## Changes
| File | What |
|------|------|
| `rootSlice.ts` | `MAX_VISIBLE_TOASTS = 3`, eviction in `pushToast` reducer |
| `toaster/index.tsx` | `data-depth` attribute + `--depth-N` BEM modifier |
| `toaster/index.scss` | Depth scale/opacity, reposition transition, reduced-motion |
| `rootSlice.test.ts` | New: reducer eviction tests (6 tests) |
| `Toaster.test.tsx` | New: stacking & depth effect tests (4 tests) |

## Test plan
- [x] All 276 tests pass (19 files, 0 regressions)
- [ ] Visual check: trigger 4+ toasts rapidly, verify oldest evicted
- [ ] Visual check: stacked toasts show depth effect (scale/opacity)
- [ ] Visual check: smooth transition when toast is dismissed mid-stack

Closes #155