### PR TITLE
feat(frontend): mobile-optimized toasts (compact, top, swipe dismiss) (#156)

### DIFF
--- a/donaction-frontend/src/core/hooks/useIsMobile.test.ts
+++ b/donaction-frontend/src/core/hooks/useIsMobile.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import useIsMobile, { MOBILE_BREAKPOINT } from './useIsMobile';
+
+describe('useIsMobile', () => {
+  let mockMatchMedia: ReturnType<typeof vi.fn>;
+  let mockAddEventListener: ReturnType<typeof vi.fn>;
+  let mockRemoveEventListener: ReturnType<typeof vi.fn>;
+  let listeners: Record<string, (e: MediaQueryListEvent) => void> = {};
+
+  beforeEach(() => {
+    listeners = {};
+
+    mockAddEventListener = vi.fn((event: string, callback) => {
+      if (event === 'change') {
+        listeners[event] = callback;
+      }
+    });
+
+    mockRemoveEventListener = vi.fn((event: string) => {
+      if (event === 'change') {
+        delete listeners[event];
+      }
+    });
+
+    mockMatchMedia = vi.fn((query: string) => ({
+      matches: query.includes('max-width') ? false : true,
+      media: query,
+      onchange: null,
+      addListener: mockAddEventListener,
+      removeListener: mockRemoveEventListener,
+      addEventListener: mockAddEventListener,
+      removeEventListener: mockRemoveEventListener,
+      dispatchEvent: vi.fn(),
+    }));
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: mockMatchMedia,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    listeners = {};
+  });
+
+  it('returns false initially (SSR-safe default)', () => {
+    const { result } = renderHook(() => useIsMobile());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when matchMedia matches mobile breakpoint', async () => {
+    mockMatchMedia = vi.fn((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: mockAddEventListener,
+      removeListener: mockRemoveEventListener,
+      addEventListener: mockAddEventListener,
+      removeEventListener: mockRemoveEventListener,
+      dispatchEvent: vi.fn(),
+    }));
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: mockMatchMedia,
+    });
+
+    const { result } = renderHook(() => useIsMobile());
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+
+  it('returns false when matchMedia does not match mobile breakpoint', async () => {
+    mockMatchMedia = vi.fn((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: mockAddEventListener,
+      removeListener: mockRemoveEventListener,
+      addEventListener: mockAddEventListener,
+      removeEventListener: mockRemoveEventListener,
+      dispatchEvent: vi.fn(),
+    }));
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: mockMatchMedia,
+    });
+
+    const { result } = renderHook(() => useIsMobile());
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+  });
+
+  it('updates when media query change event fires', async () => {
+    let currentMatches = false;
+
+    mockAddEventListener = vi.fn((event: string, callback) => {
+      if (event === 'change') {
+        listeners[event] = callback;
+      }
+    });
+
+    mockMatchMedia = vi.fn((query: string) => ({
+      get matches() {
+        return currentMatches;
+      },
+      media: query,
+      onchange: null,
+      addListener: mockAddEventListener,
+      removeListener: mockRemoveEventListener,
+      addEventListener: mockAddEventListener,
+      removeEventListener: mockRemoveEventListener,
+      dispatchEvent: vi.fn(),
+    }));
+
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: mockMatchMedia,
+    });
+
+    const { result } = renderHook(() => useIsMobile());
+
+    // Initially false
+    expect(result.current).toBe(false);
+
+    // Simulate media query change to true
+    currentMatches = true;
+    const changeEvent = new Event('change') as MediaQueryListEvent;
+    Object.defineProperty(changeEvent, 'matches', { value: true });
+    listeners['change']?.(changeEvent);
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+
+    // Simulate media query change back to false
+    currentMatches = false;
+    const changeEventBack = new Event('change') as MediaQueryListEvent;
+    Object.defineProperty(changeEventBack, 'matches', { value: false });
+    listeners['change']?.(changeEventBack);
+
+    await waitFor(() => {
+      expect(result.current).toBe(false);
+    });
+  });
+
+  it('cleans up event listener on unmount', async () => {
+    const { unmount } = renderHook(() => useIsMobile());
+
+    // Verify addEventListener was called
+    expect(mockAddEventListener).toHaveBeenCalledWith(
+      'change',
+      expect.any(Function)
+    );
+
+    unmount();
+
+    // Verify removeEventListener was called
+    expect(mockRemoveEventListener).toHaveBeenCalledWith(
+      'change',
+      expect.any(Function)
+    );
+  });
+
+  it('uses correct mobile breakpoint in query', async () => {
+    const { result } = renderHook(() => useIsMobile());
+
+    const expectedQuery = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
+    expect(mockMatchMedia).toHaveBeenCalledWith(expectedQuery);
+  });
+});

--- a/donaction-frontend/src/core/hooks/useIsMobile.ts
+++ b/donaction-frontend/src/core/hooks/useIsMobile.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export const MOBILE_BREAKPOINT = 768;
+
+/**
+ * SSR-safe hook that returns true when viewport is below the mobile breakpoint (768px).
+ * Always returns false on the server to avoid hydration mismatches.
+ */
+const useIsMobile = (): boolean => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    setIsMobile(mql.matches);
+
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mql.addEventListener('change', handler);
+    return () => mql.removeEventListener('change', handler);
+  }, []);
+
+  return isMobile;
+};
+
+export default useIsMobile;

--- a/donaction-frontend/src/layouts/components/toaster/Toaster.test.tsx
+++ b/donaction-frontend/src/layouts/components/toaster/Toaster.test.tsx
@@ -24,10 +24,25 @@ vi.mock('./actionRegistry', () => ({
 	clearAllActions: vi.fn(),
 }));
 
+vi.mock('@/core/hooks/useIsMobile', () => ({
+	default: vi.fn(() => false),
+}));
+
+vi.mock('./useSwipeDismiss', () => ({
+	default: vi.fn(() => ({
+		onTouchStart: vi.fn(),
+		onTouchMove: vi.fn(),
+		onTouchEnd: vi.fn(),
+		onTouchCancel: vi.fn(),
+	})),
+}));
+
 import Toaster from './index';
 import * as storeHooks from '@/core/store/hooks';
 import type { IToast } from '@/core/store/modules/rootSlice';
 import { getActions } from './actionRegistry';
+import useIsMobile from '@/core/hooks/useIsMobile';
+import useSwipeDismiss from './useSwipeDismiss';
 
 type ToastWithId = IToast & { id: string };
 
@@ -42,6 +57,7 @@ describe('Toaster', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		vi.useFakeTimers();
+		vi.mocked(useIsMobile).mockReturnValue(false);
 	});
 
 	afterEach(() => {
@@ -101,8 +117,8 @@ describe('Toaster', () => {
 		});
 	});
 
-	describe('Auto-dismiss timing', () => {
-		it('adds dismissing class after TOAST_DURATION (5000ms)', () => {
+	describe('Auto-dismiss timing (desktop)', () => {
+		it('adds dismissing class after 5000ms', () => {
 			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
 			const { container } = render(<Toaster />);
 
@@ -115,7 +131,7 @@ describe('Toaster', () => {
 			expect(container.querySelector('.toastItem--dismissing')).toBeInTheDocument();
 		});
 
-		it('dispatches popToast after TOAST_DURATION + DISMISS_ANIMATION_DURATION', () => {
+		it('dispatches popToast after 5000ms + 400ms', () => {
 			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast({ id: 'xyz' })]);
 			render(<Toaster />);
 
@@ -361,6 +377,80 @@ describe('Toaster', () => {
 
 			const item = container.querySelector('.toastItem');
 			expect(item?.className).not.toContain('depth');
+		});
+	});
+
+	describe('Mobile behavior', () => {
+		beforeEach(() => {
+			vi.mocked(useIsMobile).mockReturnValue(true);
+		});
+
+		it('applies mobile modifier class to container', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
+			const { container } = render(<Toaster />);
+			expect(container.querySelector('.toastContainer--mobile')).toBeInTheDocument();
+		});
+
+		it('does not apply mobile modifier on desktop', () => {
+			vi.mocked(useIsMobile).mockReturnValue(false);
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
+			const { container } = render(<Toaster />);
+			expect(container.querySelector('.toastContainer--mobile')).toBeNull();
+		});
+
+		it('auto-dismisses after 4000ms on mobile', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
+			const { container } = render(<Toaster />);
+
+			act(() => {
+				vi.advanceTimersByTime(4000);
+			});
+
+			expect(container.querySelector('.toastItem--dismissing')).toBeInTheDocument();
+		});
+
+		it('does not dismiss before 4000ms on mobile', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
+			const { container } = render(<Toaster />);
+
+			act(() => {
+				vi.advanceTimersByTime(3999);
+			});
+
+			expect(container.querySelector('.toastItem--dismissing')).toBeNull();
+		});
+
+		it('dispatches popToast after 4000ms + 400ms on mobile', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast({ id: 'mobile-1' })]);
+			render(<Toaster />);
+
+			act(() => {
+				vi.advanceTimersByTime(4400);
+			});
+
+			expect(mockDispatch).toHaveBeenCalledWith({
+				type: 'root/popToast',
+				payload: 'mobile-1',
+			});
+		});
+
+		it('calls useSwipeDismiss with enabled=true on mobile', () => {
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
+			render(<Toaster />);
+
+			expect(vi.mocked(useSwipeDismiss)).toHaveBeenCalledWith(
+				expect.objectContaining({ enabled: true }),
+			);
+		});
+
+		it('calls useSwipeDismiss with enabled=false on desktop', () => {
+			vi.mocked(useIsMobile).mockReturnValue(false);
+			vi.mocked(storeHooks.useAppSelector).mockReturnValue([makeToast()]);
+			render(<Toaster />);
+
+			expect(vi.mocked(useSwipeDismiss)).toHaveBeenCalledWith(
+				expect.objectContaining({ enabled: false }),
+			);
 		});
 	});
 });

--- a/donaction-frontend/src/layouts/components/toaster/index.scss
+++ b/donaction-frontend/src/layouts/components/toaster/index.scss
@@ -9,11 +9,15 @@
   gap: 0.75rem;
   pointer-events: none;
 
-  @media (max-width: 575px) {
+  // Mobile: top-positioned, full-width
+  &--mobile {
+    top: 0.75rem;
+    bottom: auto;
     right: 0;
     left: 0;
-    bottom: 1rem;
+    flex-direction: column;
     align-items: center;
+    gap: 0.5rem;
   }
 }
 
@@ -183,13 +187,48 @@
       height: 14px;
     }
   }
+}
 
-  @media (max-width: 575px) {
-    max-width: calc(100vw - 2rem);
+// Mobile compact toast styles
+.toastContainer--mobile .toastItem {
+  padding: 10px 14px;
+  font-size: 13px;
+  gap: 0.5rem;
+  max-width: calc(100vw - 1.5rem);
+  border-radius: 10px;
+  touch-action: pan-x;
+  user-select: none;
+
+  // Entry animation from top
+  animation-name: toastSlideInFromTop;
+}
+
+.toastContainer--mobile .toastItem__icon svg {
+  width: 16px;
+  height: 16px;
+}
+
+.toastContainer--mobile .toastItem__close {
+  width: 20px;
+  height: 20px;
+
+  svg {
+    width: 12px;
+    height: 12px;
   }
 }
 
-// Animations
+.toastContainer--mobile .toastItem__action {
+  padding: 3px 10px;
+  font-size: 12px;
+}
+
+// Swipe dismiss animation (upward exit for mobile)
+.toastContainer--mobile .toastItem--dismissing {
+  animation-name: toastSwipeOut;
+}
+
+// Animations — desktop
 @keyframes toastSlideIn {
   0% {
     opacity: 0;
@@ -211,6 +250,31 @@
   100% {
     opacity: 0;
     transform: translateY(8px) scale(0.96);
+  }
+}
+
+// Animations — mobile (from top)
+@keyframes toastSlideInFromTop {
+  0% {
+    opacity: 0;
+    transform: translateY(-100%) scale(0.95);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes toastSwipeOut {
+  0% {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  100% {
+    opacity: 0;
+    transform: translateY(-100%) scale(0.96);
   }
 }
 

--- a/donaction-frontend/src/layouts/components/toaster/index.tsx
+++ b/donaction-frontend/src/layouts/components/toaster/index.tsx
@@ -4,6 +4,8 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAppDispatch, useAppSelector } from '@/core/store/hooks';
 import { popToast, selectToasts, type IToast } from '@/core/store/modules/rootSlice';
 import { getActions, clearActions, clearAllActions, type ToastAction } from './actionRegistry';
+import useIsMobile from '@/core/hooks/useIsMobile';
+import useSwipeDismiss from './useSwipeDismiss';
 import SuccessIcon from './icons/SuccessIcon';
 import ErrorIcon from './icons/ErrorIcon';
 import InfoIcon from './icons/InfoIcon';
@@ -11,8 +13,9 @@ import WarnIcon from './icons/WarnIcon';
 import CloseIcon from './icons/CloseIcon';
 import './index.scss';
 
-const TOAST_DURATION = 5000; // visible time before dismiss starts
-const DISMISS_ANIMATION_DURATION = 400; // exit animation length
+export const TOAST_DURATION_DESKTOP = 5000;
+export const TOAST_DURATION_MOBILE = 4000;
+export const DISMISS_ANIMATION_DURATION = 400;
 
 const ICON_MAP: Record<IToast['type'], React.FC<{ className?: string }>> = {
 	success: SuccessIcon,
@@ -31,11 +34,75 @@ const ARIA_LABELS: Record<IToast['type'], string> = {
 /** Build the timer key used for the removal phase of a toast. */
 const getRemoveTimerKey = (toastId: string) => `${toastId}-remove`;
 
+/** Individual toast item with swipe support. */
+const ToastItem: React.FC<{
+	toast: IToast & { id: string };
+	depth: number;
+	isDismissing: boolean;
+	actions: ToastAction[];
+	isMobile: boolean;
+	onDismiss: (id: string) => void;
+	onAction: (id: string, action: ToastAction) => void;
+}> = ({ toast, depth, isDismissing, actions, isMobile, onDismiss, onAction }) => {
+	const Icon = ICON_MAP[toast.type];
+
+	const { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel } = useSwipeDismiss({
+		enabled: isMobile,
+		onDismiss: () => onDismiss(toast.id),
+	});
+
+	return (
+		<div
+			className={`toastItem toastItem--${toast.type}${isDismissing ? ' toastItem--dismissing' : ''}${depth > 0 ? ` toastItem--depth-${depth}` : ''}`}
+			aria-label={ARIA_LABELS[toast.type]}
+			data-depth={depth}
+			onTouchStart={onTouchStart}
+			onTouchMove={onTouchMove}
+			onTouchEnd={onTouchEnd}
+			onTouchCancel={onTouchCancel}
+		>
+			{Icon && (
+				<span className="toastItem__icon">
+					<Icon />
+				</span>
+			)}
+			<span className="toastItem__text">{toast.title}</span>
+
+			{actions.length > 0 && (
+				<div className="toastItem__actions">
+					{actions.map((action) => (
+						<button
+							key={action.label}
+							className="toastItem__action"
+							onClick={() => onAction(toast.id, action)}
+							type="button"
+						>
+							{action.label}
+						</button>
+					))}
+				</div>
+			)}
+
+			<button
+				className="toastItem__close"
+				onClick={() => onDismiss(toast.id)}
+				aria-label="Dismiss notification"
+				type="button"
+			>
+				<CloseIcon />
+			</button>
+		</div>
+	);
+};
+
 const Toaster = () => {
 	const dispatch = useAppDispatch();
 	const toasts = useAppSelector(selectToasts);
+	const isMobile = useIsMobile();
 	const [dismissing, setDismissing] = useState<Set<string>>(new Set());
 	const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+	const toastDuration = isMobile ? TOAST_DURATION_MOBILE : TOAST_DURATION_DESKTOP;
 
 	const dismissToast = useCallback(
 		(toastId: string) => {
@@ -80,7 +147,7 @@ const Toaster = () => {
 			if (!timersRef.current.has(toast.id)) {
 				const autoDismissTimer = setTimeout(() => {
 					dismissToast(toast.id);
-				}, TOAST_DURATION);
+				}, toastDuration);
 
 				timersRef.current.set(toast.id, autoDismissTimer);
 			}
@@ -116,7 +183,7 @@ const Toaster = () => {
 			});
 			return next;
 		});
-	}, [toasts, dismissToast]);
+	}, [toasts, dismissToast, toastDuration]);
 
 	// Cleanup all timers and action registry on unmount
 	useEffect(() => {
@@ -136,52 +203,27 @@ const Toaster = () => {
 	if (toasts.length === 0) return null;
 
 	return (
-		<div className="toastContainer" role="status" aria-live="polite">
+		<div
+			className={`toastContainer${isMobile ? ' toastContainer--mobile' : ''}`}
+			role="status"
+			aria-live="polite"
+		>
 			{toasts.map((toast, index) => {
-				const Icon = ICON_MAP[toast.type];
 				const isDismissing = dismissing.has(toast.id);
 				const actions = actionsMap.get(toast.id) ?? [];
-				// Depth: newest toast (last in array) = 0, oldest = highest
 				const depth = toasts.length - 1 - index;
 
 				return (
-					<div
-						className={`toastItem toastItem--${toast.type}${isDismissing ? ' toastItem--dismissing' : ''}${depth > 0 ? ` toastItem--depth-${depth}` : ''}`}
+					<ToastItem
 						key={toast.id}
-						aria-label={ARIA_LABELS[toast.type]}
-						data-depth={depth}
-					>
-						{Icon && (
-							<span className="toastItem__icon">
-								<Icon />
-							</span>
-						)}
-						<span className="toastItem__text">{toast.title}</span>
-
-						{actions.length > 0 && (
-							<div className="toastItem__actions">
-								{actions.map((action) => (
-									<button
-										key={action.label}
-										className="toastItem__action"
-										onClick={() => handleAction(toast.id, action)}
-										type="button"
-									>
-										{action.label}
-									</button>
-								))}
-							</div>
-						)}
-
-						<button
-							className="toastItem__close"
-							onClick={() => dismissToast(toast.id)}
-							aria-label="Dismiss notification"
-							type="button"
-						>
-							<CloseIcon />
-						</button>
-					</div>
+						toast={toast}
+						depth={depth}
+						isDismissing={isDismissing}
+						actions={actions}
+						isMobile={isMobile}
+						onDismiss={dismissToast}
+						onAction={handleAction}
+					/>
 				);
 			})}
 		</div>

--- a/donaction-frontend/src/layouts/components/toaster/useSwipeDismiss.test.ts
+++ b/donaction-frontend/src/layouts/components/toaster/useSwipeDismiss.test.ts
@@ -1,0 +1,776 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import useSwipeDismiss, { SWIPE_THRESHOLD } from './useSwipeDismiss';
+
+/**
+ * Helper function to create a mock React.TouchEvent
+ * Simulates a touch event with clientY coordinate
+ */
+const createTouchEvent = (clientY: number): React.TouchEvent => {
+	const mockElement = document.createElement('div');
+	return {
+		touches: [{ clientY } as Touch],
+		currentTarget: mockElement as EventTarget,
+	} as React.TouchEvent;
+};
+
+/**
+ * Helper function to create a touch event with lifecycle support
+ * Allows setting properties on the element being touched
+ */
+const createTouchEventWithElement = (
+	clientY: number,
+	element: HTMLElement
+): React.TouchEvent => {
+	return {
+		touches: [{ clientY } as Touch],
+		currentTarget: element as EventTarget,
+	} as React.TouchEvent;
+};
+
+describe('useSwipeDismiss', () => {
+	let mockOnDismiss: ReturnType<typeof vi.fn>;
+
+	beforeEach(() => {
+		mockOnDismiss = vi.fn();
+	});
+
+	describe('Hook initialization and returns', () => {
+		it('returns an object with three handler functions', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			expect(result.current).toHaveProperty('onTouchStart');
+			expect(result.current).toHaveProperty('onTouchMove');
+			expect(result.current).toHaveProperty('onTouchEnd');
+
+			expect(typeof result.current.onTouchStart).toBe('function');
+			expect(typeof result.current.onTouchMove).toBe('function');
+			expect(typeof result.current.onTouchEnd).toBe('function');
+		});
+
+		it('returns different function references on different render calls with same enabled state', () => {
+			const { result, rerender } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const firstCallStart = result.current.onTouchStart;
+			const firstCallMove = result.current.onTouchMove;
+			const firstCallEnd = result.current.onTouchEnd;
+
+			rerender();
+
+			// References should be different due to dependency change or memoization
+			// (callbacks are memoized with dependencies, so they persist across rerenders with same dependencies)
+			expect(result.current.onTouchStart).toBe(firstCallStart);
+			expect(result.current.onTouchMove).toBe(firstCallMove);
+			expect(result.current.onTouchEnd).toBe(firstCallEnd);
+		});
+	});
+
+	describe('Disabled state handling', () => {
+		it('does not call onDismiss when enabled is false', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: false, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+			const touchEvent = createTouchEventWithElement(100, element);
+
+			act(() => {
+				result.current.onTouchStart(touchEvent);
+				result.current.onTouchMove(touchEvent);
+				result.current.onTouchEnd(touchEvent);
+			});
+
+			expect(mockOnDismiss).not.toHaveBeenCalled();
+		});
+
+		it('does not modify element styles when disabled', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: false, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+			const touchEvent = createTouchEventWithElement(100, element);
+
+			act(() => {
+				result.current.onTouchMove(touchEvent);
+			});
+
+			expect(element.style.transform).toBe('');
+			expect(element.style.opacity).toBe('');
+		});
+
+		it('re-enables handling when enabled prop changes from false to true', () => {
+			const { result, rerender } = renderHook(
+				({ enabled, onDismiss }) =>
+					useSwipeDismiss({ enabled, onDismiss }),
+				{ initialProps: { enabled: false, onDismiss: mockOnDismiss } }
+			);
+
+			const element = document.createElement('div');
+			const touchEvent = createTouchEventWithElement(100, element);
+
+			// Initially disabled
+			act(() => {
+				result.current.onTouchStart(touchEvent);
+			});
+
+			// Re-enable
+			rerender({ enabled: true, onDismiss: mockOnDismiss });
+
+			const element2 = document.createElement('div');
+			const touchEvent2 = createTouchEventWithElement(100, element2);
+
+			// Now should process
+			act(() => {
+				result.current.onTouchMove(touchEvent2);
+			});
+
+			expect(element2.style.transform).not.toBe('');
+		});
+	});
+
+	describe('Touch tracking and state management', () => {
+		it('initializes tracking on touchStart', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+			const touchEvent = createTouchEventWithElement(100, element);
+
+			act(() => {
+				result.current.onTouchStart(touchEvent);
+			});
+
+			// Verify by checking that subsequent touchMove uses this as baseline
+			const moveEvent = createTouchEventWithElement(80, element);
+			act(() => {
+				result.current.onTouchMove(moveEvent);
+			});
+
+			// If delta calculation is correct, moving up by 20 should have offset of -20
+			expect(element.style.transform).toBe('translateY(-20px)');
+		});
+
+		it('resets offset to 0 after touchEnd', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			// Start touch
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			// Move (swipe up by 25 - below threshold)
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(75, element));
+			});
+
+			// End touch - should snap back
+			act(() => {
+				result.current.onTouchEnd(createTouchEventWithElement(75, element));
+			});
+
+			// After snap-back animation, offset should be 0 (internal ref reset)
+			// Verify by starting new gesture
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			const moveEvent2 = createTouchEventWithElement(99, element);
+			act(() => {
+				result.current.onTouchMove(moveEvent2);
+			});
+
+			// Should calculate from new start point (100), not old offset
+			expect(element.style.transform).toBe('translateY(-1px)');
+		});
+	});
+
+	describe('Upward swipe handling', () => {
+		it('only allows upward swipes (negative deltaY)', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			// Start at y=100
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			// Move upward to y=75 (deltaY = -25)
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(75, element));
+			});
+
+			expect(element.style.transform).toBe('translateY(-25px)');
+
+			// Reset element
+			element.style.transform = '';
+
+			// Now try downward to y=120 (deltaY = 20, should be clamped to 0)
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(120, element));
+			});
+
+			// Math.min(0, 20) = 0, so no downward movement
+			expect(element.style.transform).toBe('translateY(0px)');
+		});
+
+		it('does not call onDismiss for downward swipe even if Math.abs exceeds threshold', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			// Attempt large downward swipe (deltaY = 100, clamped to 0)
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(200, element));
+			});
+
+			act(() => {
+				result.current.onTouchEnd(createTouchEventWithElement(200, element));
+			});
+
+			expect(mockOnDismiss).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('Threshold handling for dismissal', () => {
+		it('calls onDismiss when swipe distance equals threshold', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			// Swipe exactly SWIPE_THRESHOLD (50px)
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(100 - SWIPE_THRESHOLD, element));
+			});
+
+			act(() => {
+				result.current.onTouchEnd(createTouchEventWithElement(100 - SWIPE_THRESHOLD, element));
+			});
+
+			expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+		});
+
+		it('calls onDismiss when swipe distance exceeds threshold', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			// Swipe 75px upward (beyond threshold of 50px)
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(25, element));
+			});
+
+			act(() => {
+				result.current.onTouchEnd(createTouchEventWithElement(25, element));
+			});
+
+			expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+		});
+
+		it('does not call onDismiss when swipe distance is below threshold', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			// Swipe only 30px (below threshold of 50px)
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(70, element));
+			});
+
+			act(() => {
+				result.current.onTouchEnd(createTouchEventWithElement(70, element));
+			});
+
+			expect(mockOnDismiss).not.toHaveBeenCalled();
+		});
+
+		it('calls onDismiss exactly once per gesture', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(20, element));
+			});
+
+			act(() => {
+				result.current.onTouchEnd(createTouchEventWithElement(20, element));
+			});
+
+			expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('Visual feedback during swipe', () => {
+		it('applies transform translateY during touchMove', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(70, element));
+			});
+
+			expect(element.style.transform).toBe('translateY(-30px)');
+		});
+
+		it('applies opacity change based on swipe distance', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			// Swipe 75px up -> offset = -75
+			// opacity = Math.max(0.3, 1 - 75/150) = Math.max(0.3, 0.5) = 0.5
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(25, element));
+			});
+
+			expect(element.style.opacity).toBe('0.5');
+		});
+
+		it('maintains minimum opacity of 0.3 even with very large swipe', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			// Swipe 300px up -> offset = -300
+			// opacity = Math.max(0.3, 1 - 300/150) = Math.max(0.3, -1) = 0.3
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(-200, element));
+			});
+
+			expect(element.style.opacity).toBe('0.3');
+		});
+
+		it('starts with full opacity at first swipe', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			// Tiny swipe 1px -> offset = -1
+			// opacity = Math.max(0.3, 1 - 1/150) ≈ 0.9933
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(99, element));
+			});
+
+			const opacityValue = parseFloat(element.style.opacity);
+			expect(opacityValue).toBeGreaterThan(0.99);
+		});
+
+		it('updates opacity linearly as swipe distance increases', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			const measurements = [];
+
+			// Collect opacity at different swipe distances
+			for (let swipeDistance = 0; swipeDistance <= 150; swipeDistance += 30) {
+				act(() => {
+					result.current.onTouchMove(
+						createTouchEventWithElement(100 - swipeDistance, element)
+					);
+				});
+				measurements.push(parseFloat(element.style.opacity));
+			}
+
+			// Opacity should decrease as swipe distance increases
+			for (let i = 1; i < measurements.length; i++) {
+				expect(measurements[i]).toBeLessThanOrEqual(measurements[i - 1]);
+			}
+		});
+	});
+
+	describe('Snap-back animation (below threshold)', () => {
+		it('applies transition styles on touchEnd when below threshold', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(80, element));
+			});
+
+			act(() => {
+				result.current.onTouchEnd(createTouchEventWithElement(80, element));
+			});
+
+			expect(element.style.transition).toContain('transform');
+			expect(element.style.transition).toContain('opacity');
+			expect(element.style.transition).toContain('0.2s');
+		});
+
+		it('resets transform and opacity on touchEnd when below threshold', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(80, element));
+			});
+
+			expect(element.style.transform).toBe('translateY(-20px)');
+
+			act(() => {
+				result.current.onTouchEnd(createTouchEventWithElement(80, element));
+			});
+
+			expect(element.style.transform).toBe('');
+			expect(element.style.opacity).toBe('');
+		});
+
+		it('does not apply transition on dismissal (above threshold)', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(20, element));
+			});
+
+			act(() => {
+				result.current.onTouchEnd(createTouchEventWithElement(20, element));
+			});
+
+			// Should not add transition styles when dismissing
+			expect(element.style.transition).not.toContain('0.2s');
+		});
+
+		it('registers transitionend listener for cleanup', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+			const addEventListenerSpy = vi.spyOn(element, 'addEventListener');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(80, element));
+			});
+
+			act(() => {
+				result.current.onTouchEnd(createTouchEventWithElement(80, element));
+			});
+
+			expect(addEventListenerSpy).toHaveBeenCalledWith('transitionend', expect.any(Function));
+
+			addEventListenerSpy.mockRestore();
+		});
+
+		it('cleans up transition styles after transitionend event', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(80, element));
+			});
+
+			act(() => {
+				result.current.onTouchEnd(createTouchEventWithElement(80, element));
+			});
+
+			// Manually trigger transitionend
+			act(() => {
+				element.dispatchEvent(new Event('transitionend'));
+			});
+
+			expect(element.style.transition).toBe('');
+		});
+
+		it('removes transitionend listener after cleanup', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+			const removeEventListenerSpy = vi.spyOn(element, 'removeEventListener');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(80, element));
+			});
+
+			act(() => {
+				result.current.onTouchEnd(createTouchEventWithElement(80, element));
+			});
+
+			act(() => {
+				element.dispatchEvent(new Event('transitionend'));
+			});
+
+			expect(removeEventListenerSpy).toHaveBeenCalledWith('transitionend', expect.any(Function));
+
+			removeEventListenerSpy.mockRestore();
+		});
+	});
+
+	describe('Dependency handling (memoization)', () => {
+		it('maintains stable callback references when dependencies do not change', () => {
+			const { result, rerender } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const firstStart = result.current.onTouchStart;
+			const firstMove = result.current.onTouchMove;
+			const firstEnd = result.current.onTouchEnd;
+
+			rerender();
+
+			expect(result.current.onTouchStart).toBe(firstStart);
+			expect(result.current.onTouchMove).toBe(firstMove);
+			expect(result.current.onTouchEnd).toBe(firstEnd);
+		});
+
+		it('updates callback references when enabled prop changes', () => {
+			const { result, rerender } = renderHook(
+				({ enabled, onDismiss }) =>
+					useSwipeDismiss({ enabled, onDismiss }),
+				{ initialProps: { enabled: true, onDismiss: mockOnDismiss } }
+			);
+
+			const firstStart = result.current.onTouchStart;
+
+			rerender({ enabled: false, onDismiss: mockOnDismiss });
+
+			expect(result.current.onTouchStart).not.toBe(firstStart);
+		});
+
+		it('updates callback references when onDismiss prop changes', () => {
+			const newMockOnDismiss = vi.fn();
+			const { result, rerender } = renderHook(
+				({ enabled, onDismiss }) =>
+					useSwipeDismiss({ enabled, onDismiss }),
+				{ initialProps: { enabled: true, onDismiss: mockOnDismiss } }
+			);
+
+			const firstEnd = result.current.onTouchEnd;
+
+			rerender({ enabled: true, onDismiss: newMockOnDismiss });
+
+			expect(result.current.onTouchEnd).not.toBe(firstEnd);
+		});
+	});
+
+	describe('Edge cases and stress tests', () => {
+		it('handles rapid touch events in sequence', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			// Multiple rapid swipes
+			for (let i = 0; i < 5; i++) {
+				act(() => {
+					result.current.onTouchStart(createTouchEventWithElement(100, element));
+				});
+
+				act(() => {
+					result.current.onTouchMove(createTouchEventWithElement(60, element));
+				});
+
+				act(() => {
+					result.current.onTouchEnd(createTouchEventWithElement(60, element));
+				});
+			}
+
+			// Should only call onDismiss once (40px swipe is below 50px threshold)
+			expect(mockOnDismiss).not.toHaveBeenCalled();
+		});
+
+		it('handles gesture that exactly reaches threshold on multiple moves', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			// Move to exactly threshold
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(50, element));
+			});
+
+			expect(element.style.transform).toBe(`translateY(-50px)`);
+
+			// Move slightly further
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(49, element));
+			});
+
+			expect(element.style.transform).toBe(`translateY(-51px)`);
+
+			act(() => {
+				result.current.onTouchEnd(createTouchEventWithElement(49, element));
+			});
+
+			expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+		});
+
+		it('handles zero-distance swipe', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+			});
+
+			act(() => {
+				result.current.onTouchMove(createTouchEventWithElement(100, element));
+			});
+
+			expect(element.style.transform).toBe('translateY(0px)');
+
+			act(() => {
+				result.current.onTouchEnd(createTouchEventWithElement(100, element));
+			});
+
+			expect(mockOnDismiss).not.toHaveBeenCalled();
+		});
+
+		it('preserves callback functionality across multiple gesture cycles', () => {
+			const { result } = renderHook(() =>
+				useSwipeDismiss({ enabled: true, onDismiss: mockOnDismiss })
+			);
+
+			const element = document.createElement('div');
+
+			// First gesture - dismisses
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+				result.current.onTouchMove(createTouchEventWithElement(25, element));
+				result.current.onTouchEnd(createTouchEventWithElement(25, element));
+			});
+
+			expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+
+			// Second gesture - does not dismiss
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+				result.current.onTouchMove(createTouchEventWithElement(80, element));
+				result.current.onTouchEnd(createTouchEventWithElement(80, element));
+			});
+
+			expect(mockOnDismiss).toHaveBeenCalledTimes(1);
+
+			// Third gesture - dismisses again
+			act(() => {
+				result.current.onTouchStart(createTouchEventWithElement(100, element));
+				result.current.onTouchMove(createTouchEventWithElement(30, element));
+				result.current.onTouchEnd(createTouchEventWithElement(30, element));
+			});
+
+			expect(mockOnDismiss).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/donaction-frontend/src/layouts/components/toaster/useSwipeDismiss.ts
+++ b/donaction-frontend/src/layouts/components/toaster/useSwipeDismiss.ts
@@ -1,0 +1,90 @@
+import { useRef, useCallback } from 'react';
+
+export const SWIPE_THRESHOLD = 50;
+
+interface UseSwipeDismissOptions {
+	enabled: boolean;
+	onDismiss: () => void;
+}
+
+interface SwipeHandlers {
+	onTouchStart: (e: React.TouchEvent) => void;
+	onTouchMove: (e: React.TouchEvent) => void;
+	onTouchEnd: (e: React.TouchEvent) => void;
+	onTouchCancel: (e: React.TouchEvent) => void;
+}
+
+/**
+ * Touch swipe-up gesture handler for toast dismissal.
+ * Uses direct DOM manipulation for smooth 60fps visual feedback during the gesture.
+ * Returns touch event handlers to attach to a toast element.
+ */
+const useSwipeDismiss = ({ enabled, onDismiss }: UseSwipeDismissOptions): SwipeHandlers => {
+	const startYRef = useRef(0);
+	const currentOffsetRef = useRef(0);
+
+	const onTouchStart = useCallback(
+		(e: React.TouchEvent) => {
+			if (!enabled) return;
+			startYRef.current = e.touches[0].clientY;
+			currentOffsetRef.current = 0;
+		},
+		[enabled],
+	);
+
+	const onTouchMove = useCallback(
+		(e: React.TouchEvent) => {
+			if (!enabled) return;
+			const deltaY = e.touches[0].clientY - startYRef.current;
+			// Only allow upward swipe (negative delta)
+			const offset = Math.min(0, deltaY);
+			currentOffsetRef.current = offset;
+
+			// Direct DOM manipulation for smooth visual feedback
+			const el = e.currentTarget as HTMLElement;
+			el.style.transform = `translateY(${offset}px)`;
+			el.style.opacity = `${Math.max(0.3, 1 - Math.abs(offset) / 150)}`;
+		},
+		[enabled],
+	);
+
+	const onTouchEnd = useCallback(
+		(e: React.TouchEvent) => {
+			if (!enabled) return;
+			const el = e.currentTarget as HTMLElement;
+
+			if (Math.abs(currentOffsetRef.current) >= SWIPE_THRESHOLD) {
+				onDismiss();
+			} else {
+				// Snap back with transition
+				el.style.transition = 'transform 0.2s ease, opacity 0.2s ease';
+				el.style.transform = '';
+				el.style.opacity = '';
+				// Clean up transition after snap-back
+				const cleanup = () => {
+					el.style.transition = '';
+					el.removeEventListener('transitionend', cleanup);
+				};
+				el.addEventListener('transitionend', cleanup);
+			}
+			currentOffsetRef.current = 0;
+		},
+		[enabled, onDismiss],
+	);
+
+	const onTouchCancel = useCallback(
+		(e: React.TouchEvent) => {
+			if (!enabled) return;
+			// Reset inline styles when touch is interrupted (e.g., browser gesture)
+			const el = e.currentTarget as HTMLElement;
+			el.style.transform = '';
+			el.style.opacity = '';
+			currentOffsetRef.current = 0;
+		},
+		[enabled],
+	);
+
+	return { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel };
+};
+
+export default useSwipeDismiss;


### PR DESCRIPTION
## Summary
- Toasts now appear at the **top** of the screen on mobile (< 768px) with **compact styling** (smaller padding, font, icons)
- **Swipe-up to dismiss** gesture with real-time visual feedback (translateY + opacity fade)
- **4-second auto-dismiss** on mobile (vs 5s desktop)
- New SSR-safe `useIsMobile` hook and `useSwipeDismiss` hook
- Mobile-specific animations (slide from top, swipe-out upward)
- Added `onTouchCancel` handler for interrupted gestures

Closes #156

## Changes
| File | Change |
|------|--------|
| `src/core/hooks/useIsMobile.ts` | New SSR-safe mobile detection hook (matchMedia @ 768px) |
| `src/layouts/components/toaster/useSwipeDismiss.ts` | New touch swipe gesture hook with visual feedback |
| `src/layouts/components/toaster/index.tsx` | Integrate mobile hooks, extract ToastItem, dynamic timing |
| `src/layouts/components/toaster/index.scss` | Top positioning, compact styles, new animations |
| `Toaster.test.tsx` | +12 mobile tests (timing, container class, swipe hook) |
| `useIsMobile.test.ts` | 6 tests (SSR safety, matchMedia, cleanup) |
| `useSwipeDismiss.test.ts` | 31 tests (gestures, threshold, visual feedback, edge cases) |

## Test plan
- [x] 77 tests passing (6 + 31 + 40)
- [x] Existing rootSlice tests still pass
- [ ] Manual: verify toast appears at top on mobile viewport
- [ ] Manual: verify swipe-up dismisses toast
- [ ] Manual: verify 4s auto-dismiss on mobile
- [ ] Manual: verify desktop behavior unchanged