### PR TITLE
feat(saas): redesign toast in widget with glassmorphism (#157)

### DIFF
--- a/donaction-saas/src/components/sponsorshipForm/__tests__/toaster.test.ts
+++ b/donaction-saas/src/components/sponsorshipForm/__tests__/toaster.test.ts
@@ -290,8 +290,8 @@ describe('Style Injection', () => {
     const style = mockShadowRoot.querySelector('#don-toast-styles') as HTMLStyleElement;
     const content = style.textContent || '';
 
-    expect(content).toContain('backdrop-filter: blur(16px)');
-    expect(content).toContain('-webkit-backdrop-filter: blur(16px)');
+    expect(content).toContain('backdrop-filter: blur(20px) saturate(180%)');
+    expect(content).toContain('-webkit-backdrop-filter: blur(20px) saturate(180%)');
   });
 });
 

--- a/donaction-saas/src/components/sponsorshipForm/__tests__/toaster.test.ts
+++ b/donaction-saas/src/components/sponsorshipForm/__tests__/toaster.test.ts
@@ -578,6 +578,24 @@ describe('Swipe-to-Dismiss (Mobile)', () => {
     // Toast should NOT be dismissing
     expect(toast.classList.contains('don-toast--dismissing')).toBe(false);
   });
+
+  it('cleans up touch listeners on toast removal', () => {
+    setViewportWidth(375);
+    dispatchToast('Test message', 'success');
+
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+    const removeListenerSpy = vi.spyOn(toast, 'removeEventListener');
+
+    // Dismiss and wait for removal
+    vi.advanceTimersByTime(__testing__.TOAST_CONFIG.DURATION_MOBILE);
+    vi.advanceTimersByTime(__testing__.TOAST_CONFIG.DISMISS_ANIMATION_DURATION);
+
+    const removedEvents = removeListenerSpy.mock.calls.map((call) => call[0]);
+    expect(removedEvents).toContain('touchstart');
+    expect(removedEvents).toContain('touchmove');
+    expect(removedEvents).toContain('touchend');
+    expect(removedEvents).toContain('touchcancel');
+  });
 });
 
 // ============================================================================

--- a/donaction-saas/src/components/sponsorshipForm/__tests__/toaster.test.ts
+++ b/donaction-saas/src/components/sponsorshipForm/__tests__/toaster.test.ts
@@ -1,193 +1,941 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { dispatchToast } from '../logic/toaster';
+import {
+  dispatchToast,
+  clearAllToasts,
+  __testing__,
+} from '../logic/toaster';
 
-describe('dispatchToast', () => {
-  let mockShadowRoot: {
-    appendChild: ReturnType<typeof vi.fn>;
-    removeChild: ReturnType<typeof vi.fn>;
+// ============================================================================
+// Test Setup & Utilities
+// ============================================================================
+
+let mockShadowRoot: ShadowRoot;
+let mockHost: HTMLDivElement;
+
+/**
+ * Create a real shadow DOM for testing
+ */
+function createMockShadowRoot(): ShadowRoot {
+  const host = document.createElement('div');
+  host.id = 'mock-form-host';
+  document.body.appendChild(host);
+  return host.attachShadow({ mode: 'open' });
+}
+
+/**
+ * Setup mock for document.querySelector to return element with shadowRoot
+ */
+function mockShadowRootLookup(): void {
+  const mockElement = {
+    shadowRoot: mockShadowRoot,
   };
-  let createdElement: HTMLSpanElement | null;
+  vi.spyOn(document, 'querySelector').mockReturnValue(
+    mockElement as unknown as Element
+  );
+}
 
-  beforeEach(() => {
-    vi.useFakeTimers();
-    mockShadowRoot = {
-      appendChild: vi.fn(),
-      removeChild: vi.fn(),
-    };
+/**
+ * Set viewport width for mobile detection
+ */
+function setViewportWidth(width: number): void {
+  Object.defineProperty(window, 'innerWidth', {
+    value: width,
+    writable: true,
+    configurable: true,
+  });
+}
 
-    vi.spyOn(document, 'querySelector').mockReturnValue({
-      shadowRoot: mockShadowRoot,
-    } as unknown as Element);
+// ============================================================================
+// Test Hooks
+// ============================================================================
 
-    createdElement = null;
-    const originalCreateElement = document.createElement;
-    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
-      const el = originalCreateElement.call(document, tagName);
-      if (tagName === 'span') {
-        createdElement = el;
-      }
-      return el;
-    });
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockShadowRoot = createMockShadowRoot();
+  mockHost = document.querySelector('#mock-form-host') as HTMLDivElement;
+  mockShadowRootLookup();
+  setViewportWidth(1024); // Default desktop
+  __testing__.resetState();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  if (mockHost && mockHost.parentElement) {
+    mockHost.remove();
+  }
+  __testing__.resetState();
+});
+
+// ============================================================================
+// 1. Toast Container Management
+// ============================================================================
+
+describe('Toast Container Management', () => {
+  it('creates container on first toast', () => {
+    dispatchToast('Test message', 'success');
+
+    const container = __testing__.getToastContainer();
+    expect(container).not.toBeNull();
+    expect(container?.classList.contains('don-toastContainer')).toBe(true);
   });
 
-  afterEach(() => {
+  it('reuses existing container for subsequent toasts', () => {
+    dispatchToast('First toast', 'success');
+    const firstContainer = __testing__.getToastContainer();
+
+    dispatchToast('Second toast', 'error');
+    const secondContainer = __testing__.getToastContainer();
+
+    expect(firstContainer).toBe(secondContainer);
+    expect(mockShadowRoot.querySelectorAll('.don-toastContainer').length).toBe(1);
+  });
+
+  it('container has correct accessibility attributes', () => {
+    dispatchToast('Test message', 'info');
+
+    const container = __testing__.getToastContainer();
+    expect(container?.getAttribute('role')).toBe('status');
+    expect(container?.getAttribute('aria-live')).toBe('polite');
+    expect(container?.getAttribute('aria-atomic')).toBe('false');
+  });
+
+  it('removes container after last toast dismissed and removed', () => {
+    dispatchToast('Test message', 'success');
+    vi.runAllTimers();
+
+    expect(__testing__.getToastContainer()).toBeNull();
+  });
+
+  it('does not remove container while toasts remain', () => {
+    dispatchToast('First toast', 'success');
+    dispatchToast('Second toast', 'error');
+
+    const activeToasts = __testing__.getActiveToasts();
+    expect(activeToasts.length).toBe(2);
+
+    // Dismiss first toast only
+    const closeButton = mockShadowRoot.querySelector('[data-toast-id="0"] .don-toast__close') as HTMLButtonElement;
+    closeButton.click();
+    vi.advanceTimersByTime(__testing__.TOAST_CONFIG.DISMISS_ANIMATION_DURATION);
+
+    // Container should still exist because second toast remains
+    const container = __testing__.getToastContainer();
+    expect(container).not.toBeNull();
+    expect(__testing__.getActiveToasts().length).toBe(1);
+  });
+});
+
+// ============================================================================
+// 2. Toast Element Structure
+// ============================================================================
+
+describe('Toast Element Structure', () => {
+  it('creates div with correct classes for type', () => {
+    dispatchToast('Test message', 'success');
+
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+    expect(toast).not.toBeNull();
+    expect(toast.classList.contains('don-toast')).toBe(true);
+    expect(toast.classList.contains('don-toast--success')).toBe(true);
+  });
+
+  it('sets data-toast-id attribute', () => {
+    dispatchToast('Test message', 'error');
+
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+    expect(toast.getAttribute('data-toast-id')).toBe('0');
+  });
+
+  it('sets aria-label based on toast type', () => {
+    dispatchToast('Test message', 'warn');
+
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+    expect(toast.getAttribute('aria-label')).toBe('Warning notification');
+  });
+
+  it('creates icon div with SVG', () => {
+    dispatchToast('Test message', 'success');
+
+    const icon = mockShadowRoot.querySelector('.don-toast__icon') as HTMLDivElement;
+    expect(icon).not.toBeNull();
+    expect(icon.querySelector('svg')).not.toBeNull();
+    expect(icon.innerHTML).toContain('<svg');
+  });
+
+  it('creates text div with message content', () => {
+    const message = 'This is a test message';
+    dispatchToast(message, 'info');
+
+    const textElement = mockShadowRoot.querySelector('.don-toast__text') as HTMLDivElement;
+    expect(textElement).not.toBeNull();
+    expect(textElement.textContent).toBe(message);
+  });
+
+  it('creates close button with correct attributes', () => {
+    dispatchToast('Test message', 'success');
+
+    const closeButton = mockShadowRoot.querySelector('.don-toast__close') as HTMLButtonElement;
+    expect(closeButton).not.toBeNull();
+    expect(closeButton.type).toBe('button');
+    expect(closeButton.getAttribute('aria-label')).toBe('Dismiss notification');
+    expect(closeButton.innerHTML).toContain('<svg');
+  });
+
+  it('verifies toast DOM hierarchy', () => {
+    dispatchToast('Test message', 'error');
+
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+    const children = Array.from(toast.children) as HTMLElement[];
+
+    expect(children[0].classList.contains('don-toast__icon')).toBe(true);
+    expect(children[1].classList.contains('don-toast__text')).toBe(true);
+    expect(children[2].classList.contains('don-toast__close')).toBe(true);
+  });
+});
+
+// ============================================================================
+// 3. Type Mapping (Backward Compatibility)
+// ============================================================================
+
+describe('Type Mapping (Legacy Compatibility)', () => {
+  it('maps DANGER to error', () => {
+    dispatchToast('Test message', 'DANGER' as any);
+
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+    expect(toast.classList.contains('don-toast--error')).toBe(true);
+  });
+
+  it('maps WARNING to warn', () => {
+    dispatchToast('Test message', 'WARNING' as any);
+
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+    expect(toast.classList.contains('don-toast--warn')).toBe(true);
+  });
+
+  it('maps SUCCESS to success', () => {
+    dispatchToast('Test message', 'SUCCESS' as any);
+
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+    expect(toast.classList.contains('don-toast--success')).toBe(true);
+  });
+
+  it('accepts lowercase types directly', () => {
+    const types: Array<'success' | 'error' | 'warn' | 'info'> = [
+      'success',
+      'error',
+      'warn',
+      'info',
+    ];
+
+    types.forEach((type) => {
+      __testing__.resetState();
+      // Clear the shadow root between iterations
+      const allElements = mockShadowRoot.querySelectorAll('*');
+      allElements.forEach(el => el.remove());
+
+      dispatchToast('Test', type);
+
+      const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+      expect(toast.classList.contains(`don-toast--${type}`)).toBe(true);
+    });
+  });
+});
+
+// ============================================================================
+// 4. Style Injection
+// ============================================================================
+
+describe('Style Injection', () => {
+  it('injects style element on first toast', () => {
+    dispatchToast('Test message', 'success');
+
+    const style = mockShadowRoot.querySelector('#don-toast-styles');
+    expect(style).not.toBeNull();
+    expect(style?.tagName).toBe('STYLE');
+  });
+
+  it('does not duplicate style element on subsequent toasts', () => {
+    dispatchToast('First toast', 'success');
+    dispatchToast('Second toast', 'error');
+
+    const styles = mockShadowRoot.querySelectorAll('#don-toast-styles');
+    expect(styles.length).toBe(1);
+  });
+
+  it('style contains CSS content', () => {
+    dispatchToast('Test message', 'success');
+
+    const style = mockShadowRoot.querySelector('#don-toast-styles') as HTMLStyleElement;
+    const content = style.textContent || '';
+
+    expect(content.length).toBeGreaterThan(0);
+    expect(content).toContain('.don-toastContainer');
+    expect(content).toContain('.don-toast');
+  });
+
+  it('style contains animation keyframes', () => {
+    dispatchToast('Test message', 'success');
+
+    const style = mockShadowRoot.querySelector('#don-toast-styles') as HTMLStyleElement;
+    const content = style.textContent || '';
+
+    expect(content).toContain('@keyframes donToastSlideIn');
+    expect(content).toContain('@keyframes donToastFadeOut');
+  });
+
+  it('style contains glassmorphism properties', () => {
+    dispatchToast('Test message', 'success');
+
+    const style = mockShadowRoot.querySelector('#don-toast-styles') as HTMLStyleElement;
+    const content = style.textContent || '';
+
+    expect(content).toContain('backdrop-filter: blur(16px)');
+    expect(content).toContain('-webkit-backdrop-filter: blur(16px)');
+  });
+});
+
+// ============================================================================
+// 5. Close Button Interaction
+// ============================================================================
+
+describe('Close Button Interaction', () => {
+  it('adds dismissing class when close button clicked', () => {
+    dispatchToast('Test message', 'success');
+
+    const closeButton = mockShadowRoot.querySelector('.don-toast__close') as HTMLButtonElement;
+    closeButton.click();
+
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+    expect(toast.classList.contains('don-toast--dismissing')).toBe(true);
+  });
+
+  it('removes toast from DOM after dismiss animation duration', () => {
+    dispatchToast('Test message', 'success');
+    expect(mockShadowRoot.querySelectorAll('.don-toast').length).toBe(1);
+
+    const closeButton = mockShadowRoot.querySelector('.don-toast__close') as HTMLButtonElement;
+    closeButton.click();
+
+    vi.advanceTimersByTime(__testing__.TOAST_CONFIG.DISMISS_ANIMATION_DURATION);
+    expect(mockShadowRoot.querySelectorAll('.don-toast').length).toBe(0);
+  });
+
+  it('removes toast from active toasts array after dismiss', () => {
+    dispatchToast('Test message', 'success');
+    expect(__testing__.getActiveToasts().length).toBe(1);
+
+    const closeButton = mockShadowRoot.querySelector('.don-toast__close') as HTMLButtonElement;
+    closeButton.click();
+
+    vi.runAllTimers();
+    expect(__testing__.getActiveToasts().length).toBe(0);
+  });
+
+  it('clears auto-dismiss timer when manually dismissed', () => {
+    dispatchToast('Test message', 'success');
+
+    const closeButton = mockShadowRoot.querySelector('.don-toast__close') as HTMLButtonElement;
+    closeButton.click();
+
+    // Toast should have dismissing class immediately after manual click
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+    expect(toast.classList.contains('don-toast--dismissing')).toBe(true);
+
+    // Verify the toast is removed after dismiss animation duration
+    vi.advanceTimersByTime(__testing__.TOAST_CONFIG.DISMISS_ANIMATION_DURATION);
+    expect(__testing__.getActiveToasts().length).toBe(0);
+  });
+});
+
+// ============================================================================
+// 6. Auto-Dismiss Timing
+// ============================================================================
+
+describe('Auto-Dismiss Timing', () => {
+  it('dismisses desktop toast after 5000ms', () => {
+    setViewportWidth(1024);
+    dispatchToast('Test message', 'success');
+
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+    expect(toast.classList.contains('don-toast--dismissing')).toBe(false);
+
+    vi.advanceTimersByTime(__testing__.TOAST_CONFIG.DURATION_DESKTOP);
+    expect(toast.classList.contains('don-toast--dismissing')).toBe(true);
+  });
+
+  it('dismisses mobile toast after 4000ms', () => {
+    setViewportWidth(375);
+    dispatchToast('Test message', 'success');
+
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+
+    vi.advanceTimersByTime(__testing__.TOAST_CONFIG.DURATION_MOBILE);
+    expect(toast.classList.contains('don-toast--dismissing')).toBe(true);
+  });
+
+  it('removes toast from DOM after dismiss animation', () => {
+    setViewportWidth(1024);
+    dispatchToast('Test message', 'success');
+
+    vi.advanceTimersByTime(
+      __testing__.TOAST_CONFIG.DURATION_DESKTOP +
+      __testing__.TOAST_CONFIG.DISMISS_ANIMATION_DURATION
+    );
+
+    expect(mockShadowRoot.querySelectorAll('.don-toast').length).toBe(0);
+  });
+
+  it('respects different timing for mobile vs desktop', () => {
+    const timeDiff =
+      __testing__.TOAST_CONFIG.DURATION_DESKTOP -
+      __testing__.TOAST_CONFIG.DURATION_MOBILE;
+
+    expect(timeDiff).toBe(1000);
+  });
+});
+
+// ============================================================================
+// 7. Stacking and Depth
+// ============================================================================
+
+describe('Stacking and Depth', () => {
+  it('limits to max 3 visible toasts', () => {
+    for (let i = 0; i < 5; i++) {
+      dispatchToast(`Toast ${i}`, 'success');
+    }
+
+    const activeToasts = __testing__.getActiveToasts();
+    expect(activeToasts.length).toBe(3);
+  });
+
+  it('newest toast has data-depth=0 and no depth class', () => {
+    dispatchToast('First toast', 'success');
+    dispatchToast('Second toast', 'error');
+
+    const toasts = mockShadowRoot.querySelectorAll('.don-toast');
+    const newest = toasts[0] as HTMLDivElement;
+
+    expect(newest.getAttribute('data-depth')).toBe('0');
+    expect(newest.classList.contains('don-toast--depth-1')).toBe(false);
+    expect(newest.classList.contains('don-toast--depth-2')).toBe(false);
+  });
+
+  it('second toast has data-depth=1 and depth-1 class', () => {
+    dispatchToast('First toast', 'success');
+    dispatchToast('Second toast', 'error');
+
+    const toasts = mockShadowRoot.querySelectorAll('.don-toast');
+    const second = toasts[1] as HTMLDivElement;
+
+    expect(second.getAttribute('data-depth')).toBe('1');
+    expect(second.classList.contains('don-toast--depth-1')).toBe(true);
+  });
+
+  it('third toast has data-depth=2 and depth-2 class', () => {
+    dispatchToast('First toast', 'success');
+    dispatchToast('Second toast', 'error');
+    dispatchToast('Third toast', 'warn');
+
+    const toasts = mockShadowRoot.querySelectorAll('.don-toast');
+    const third = toasts[2] as HTMLDivElement;
+
+    expect(third.getAttribute('data-depth')).toBe('2');
+    expect(third.classList.contains('don-toast--depth-2')).toBe(true);
+  });
+
+  it('evicts oldest toast when 4th added', () => {
+    dispatchToast('Toast 1', 'success');
+    dispatchToast('Toast 2', 'error');
+    dispatchToast('Toast 3', 'warn');
+
+    expect(__testing__.getActiveToasts().length).toBe(3);
+    const toast1Id = mockShadowRoot.querySelector('[data-toast-id="0"]');
+
+    dispatchToast('Toast 4', 'info');
+
+    expect(__testing__.getActiveToasts().length).toBe(3);
+    expect(mockShadowRoot.querySelector('[data-toast-id="0"]')).toBeNull();
+  });
+
+  it('updates depths when toast removed', () => {
+    dispatchToast('Toast 1', 'success');
+    dispatchToast('Toast 2', 'error');
+    dispatchToast('Toast 3', 'warn');
+
+    const closeButton = mockShadowRoot.querySelector('[data-toast-id="2"] .don-toast__close') as HTMLButtonElement;
+    closeButton.click();
+    vi.advanceTimersByTime(__testing__.TOAST_CONFIG.DISMISS_ANIMATION_DURATION);
+
+    const toasts = mockShadowRoot.querySelectorAll('.don-toast');
+    expect(toasts[1].getAttribute('data-depth')).toBe('1');
+    expect(toasts[1].classList.contains('don-toast--depth-1')).toBe(true);
+  });
+
+  it('newest toast always at index 0 (column-reverse)', () => {
+    dispatchToast('Toast 1', 'success');
+    dispatchToast('Toast 2', 'error');
+
+    const toasts = mockShadowRoot.querySelectorAll('.don-toast');
+
+    // In the DOM, with flex column-reverse, the visual order is reversed
+    // Toast IDs are 0, 1. The newest (ID 1) should be visually first
+    // but the DOM order depends on flex direction
+    // Verify by checking data-depth: newest=0, second=1
+    expect((toasts[0] as HTMLDivElement).getAttribute('data-depth')).toBe('0');
+    expect((toasts[1] as HTMLDivElement).getAttribute('data-depth')).toBe('1');
+  });
+});
+
+// ============================================================================
+// 8. Swipe-to-Dismiss (Mobile)
+// ============================================================================
+
+describe('Swipe-to-Dismiss (Mobile)', () => {
+  it('attaches touch listeners on mobile', () => {
+    setViewportWidth(375);
+
+    const addEventListenerSpy = vi.spyOn(HTMLDivElement.prototype, 'addEventListener');
+    dispatchToast('Test message', 'success');
+
+    // Check that addEventListener was called with touch events
+    const touchstartCalls = addEventListenerSpy.mock.calls.filter(
+      (call) => call[0] === 'touchstart'
+    );
+    const touchmoveCalls = addEventListenerSpy.mock.calls.filter(
+      (call) => call[0] === 'touchmove'
+    );
+    const touchendCalls = addEventListenerSpy.mock.calls.filter(
+      (call) => call[0] === 'touchend'
+    );
+    const touchcancelCalls = addEventListenerSpy.mock.calls.filter(
+      (call) => call[0] === 'touchcancel'
+    );
+
+    expect(touchstartCalls.length).toBeGreaterThan(0);
+    expect(touchmoveCalls.length).toBeGreaterThan(0);
+    expect(touchendCalls.length).toBeGreaterThan(0);
+    expect(touchcancelCalls.length).toBeGreaterThan(0);
+
     vi.restoreAllMocks();
-    vi.useRealTimers();
   });
 
-  describe('element creation', () => {
-    it('creates a span element with correct text', () => {
-      dispatchToast('Test message', 'SUCCESS');
-      expect(createdElement?.innerText).toBe('Test message');
-    });
+  it('does NOT attach touch listeners on desktop', () => {
+    setViewportWidth(1024);
+    dispatchToast('Test message', 'success');
 
-    it('sets correct padding style', () => {
-      dispatchToast('Test', 'SUCCESS');
-      expect(createdElement?.style.padding).toBe('8px 12px');
-    });
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
 
-    it('sets correct maxWidth style', () => {
-      dispatchToast('Test', 'SUCCESS');
-      expect(createdElement?.style.maxWidth).toBe('350px');
-    });
-
-    it('sets position to fixed', () => {
-      dispatchToast('Test', 'SUCCESS');
-      expect(createdElement?.style.position).toBe('fixed');
-    });
-
-    it('sets zIndex to 9999', () => {
-      dispatchToast('Test', 'SUCCESS');
-      expect(createdElement?.style.zIndex).toBe('9999');
-    });
-
-    it('sets top to 50px', () => {
-      dispatchToast('Test', 'SUCCESS');
-      expect(createdElement?.style.top).toBe('50px');
-    });
-
-    it('sets initial right to -100%', () => {
-      dispatchToast('Test', 'SUCCESS');
-      expect(createdElement?.style.right).toBe('-100%');
-    });
-
-    it('sets text color to white', () => {
-      dispatchToast('Test', 'SUCCESS');
-      expect(createdElement?.style.color).toBe('white');
-    });
-
-    it('sets correct fontFamily', () => {
-      dispatchToast('Test', 'SUCCESS');
-      expect(createdElement?.style.fontFamily).toBe('"Maven-Pro-Regular", sans-serif');
-    });
-
-    it('sets borderTopLeftRadius to 6px', () => {
-      dispatchToast('Test', 'SUCCESS');
-      expect(createdElement?.style.borderTopLeftRadius).toBe('6px');
-    });
-
-    it('sets borderBottomLeftRadius to 6px', () => {
-      dispatchToast('Test', 'SUCCESS');
-      expect(createdElement?.style.borderBottomLeftRadius).toBe('6px');
-    });
-
-    it('sets transition property', () => {
-      dispatchToast('Test', 'SUCCESS');
-      expect(createdElement?.style.transition).toBe('right .5s ease-in-out');
-    });
+    // Check that touch events are not attached
+    // (This is tricky to test without implementing listener tracking)
+    // We verify by checking viewport width detection works
+    expect(window.innerWidth).toBe(1024);
   });
 
-  describe('background colors', () => {
-    it('sets background color to red for DANGER', () => {
-      dispatchToast('Danger message', 'DANGER');
-      expect(createdElement?.style.backgroundColor).toBe('red');
-    });
+  it('swipe up beyond threshold dismisses toast', () => {
+    setViewportWidth(375);
+    dispatchToast('Test message', 'success');
 
-    it('sets background color to yellow for WARNING', () => {
-      dispatchToast('Warning message', 'WARNING');
-      expect(createdElement?.style.backgroundColor).toBe('yellow');
-    });
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
 
-    it('sets background color to green for SUCCESS', () => {
-      dispatchToast('Success message', 'SUCCESS');
-      expect(createdElement?.style.backgroundColor).toBe('green');
-    });
+    // Simulate swipe up
+    const touchStartEvent = new TouchEvent('touchstart', {
+      touches: [{ clientY: 100 } as Touch],
+    } as TouchEventInit);
+    toast.dispatchEvent(touchStartEvent);
+
+    const touchMoveEvent = new TouchEvent('touchmove', {
+      touches: [{ clientY: 30 } as Touch],
+    } as TouchEventInit);
+    toast.dispatchEvent(touchMoveEvent);
+
+    const touchEndEvent = new TouchEvent('touchend', {});
+    toast.dispatchEvent(touchEndEvent);
+
+    expect(toast.classList.contains('don-toast--dismissing')).toBe(true);
   });
 
-  describe('shadowRoot interactions', () => {
-    it('appends element to shadowRoot', () => {
-      dispatchToast('Test', 'SUCCESS');
-      expect(mockShadowRoot.appendChild).toHaveBeenCalledWith(createdElement);
-    });
+  it('snap back if swipe below threshold', () => {
+    setViewportWidth(375);
+    dispatchToast('Test message', 'success');
 
-    it('appends element immediately', () => {
-      dispatchToast('Test', 'SUCCESS');
-      expect(mockShadowRoot.appendChild).toHaveBeenCalledTimes(1);
-    });
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+
+    // Simulate small swipe up (below threshold)
+    const touchStartEvent = new TouchEvent('touchstart', {
+      touches: [{ clientY: 100 } as Touch],
+    } as TouchEventInit);
+    toast.dispatchEvent(touchStartEvent);
+
+    const touchMoveEvent = new TouchEvent('touchmove', {
+      touches: [{ clientY: 80 } as Touch],
+    } as TouchEventInit);
+    toast.dispatchEvent(touchMoveEvent);
+
+    const touchEndEvent = new TouchEvent('touchend', {});
+    toast.dispatchEvent(touchEndEvent);
+
+    // Toast should NOT be dismissing
+    expect(toast.classList.contains('don-toast--dismissing')).toBe(false);
+  });
+});
+
+// ============================================================================
+// 9. Edge Cases
+// ============================================================================
+
+describe('Edge Cases', () => {
+  it('handles null shadowRoot gracefully', () => {
+    vi.spyOn(document, 'querySelector').mockReturnValue(null as any);
+
+    expect(() => {
+      dispatchToast('Test message', 'success');
+    }).not.toThrow();
+
+    expect(__testing__.getActiveToasts().length).toBe(0);
   });
 
-  describe('animation timing', () => {
-    it('sets right to 0 after 100ms', () => {
-      dispatchToast('Test', 'SUCCESS');
-      vi.advanceTimersByTime(100);
-      expect(createdElement?.style.right).toBe('0px');
-    });
+  it('handles element with no shadowRoot', () => {
+    vi.spyOn(document, 'querySelector').mockReturnValue({} as any);
 
-    it('sets right to -100% after 4000ms', () => {
-      dispatchToast('Test', 'SUCCESS');
-      vi.advanceTimersByTime(4000);
-      expect(createdElement?.style.right).toBe('-100%');
-    });
+    expect(() => {
+      dispatchToast('Test message', 'success');
+    }).not.toThrow();
 
-    it('removes element from shadowRoot after 5000ms', () => {
-      dispatchToast('Test', 'SUCCESS');
-      vi.advanceTimersByTime(5000);
-      expect(mockShadowRoot.removeChild).toHaveBeenCalledWith(createdElement);
-    });
-
-    it('maintains correct sequence of style changes', () => {
-      dispatchToast('Test', 'SUCCESS');
-
-      expect(createdElement?.style.right).toBe('-100%');
-
-      vi.advanceTimersByTime(100);
-      expect(createdElement?.style.right).toBe('0px');
-      expect(mockShadowRoot.removeChild).not.toHaveBeenCalled();
-
-      vi.advanceTimersByTime(3900);
-      expect(createdElement?.style.right).toBe('-100%');
-      expect(mockShadowRoot.removeChild).not.toHaveBeenCalled();
-
-      vi.advanceTimersByTime(1000);
-      expect(mockShadowRoot.removeChild).toHaveBeenCalled();
-    });
+    expect(__testing__.getActiveToasts().length).toBe(0);
   });
 
-  describe('edge cases', () => {
-    it('handles null shadowRoot gracefully', () => {
-      vi.spyOn(document, 'querySelector').mockReturnValue({
-        shadowRoot: null,
-      } as unknown as Element);
+  it('handles multiple rapid toasts', () => {
+    for (let i = 0; i < 10; i++) {
+      dispatchToast(`Toast ${i}`, 'success');
+    }
 
-      expect(() => {
-        dispatchToast('Test', 'SUCCESS');
-      }).not.toThrow();
-    });
+    expect(__testing__.getActiveToasts().length).toBe(3);
+    expect(mockShadowRoot.querySelectorAll('.don-toast').length).toBe(3);
+  });
 
-    it('handles null query selector result gracefully', () => {
-      vi.spyOn(document, 'querySelector').mockReturnValue(null);
+  it('handles dispatchToast with empty string', () => {
+    dispatchToast('', 'success');
 
-      expect(() => {
-        dispatchToast('Test', 'SUCCESS');
-      }).not.toThrow();
-    });
+    const textElement = mockShadowRoot.querySelector('.don-toast__text') as HTMLDivElement;
+    expect(textElement.textContent).toBe('');
+  });
 
-    it('handles multiple toasts in sequence', () => {
-      dispatchToast('Toast 1', 'SUCCESS');
-      dispatchToast('Toast 2', 'WARNING');
-      dispatchToast('Toast 3', 'DANGER');
+  it('handles dispatchToast with very long text', () => {
+    const longText = 'A'.repeat(500);
+    dispatchToast(longText, 'success');
 
-      expect(mockShadowRoot.appendChild).toHaveBeenCalledTimes(3);
-    });
+    const textElement = mockShadowRoot.querySelector('.don-toast__text') as HTMLDivElement;
+    expect(textElement.textContent).toBe(longText);
+  });
+
+  it('handles special characters in message', () => {
+    const specialMessage = 'Test <>&"\'`;';
+    dispatchToast(specialMessage, 'success');
+
+    const textElement = mockShadowRoot.querySelector('.don-toast__text') as HTMLDivElement;
+    expect(textElement.textContent).toBe(specialMessage);
+  });
+});
+
+// ============================================================================
+// 10. clearAllToasts
+// ============================================================================
+
+describe('clearAllToasts', () => {
+  it('dismisses all active toasts', () => {
+    dispatchToast('Toast 1', 'success');
+    dispatchToast('Toast 2', 'error');
+    dispatchToast('Toast 3', 'warn');
+
+    const toasts = mockShadowRoot.querySelectorAll('.don-toast');
+    expect(toasts.length).toBe(3);
+
+    clearAllToasts();
+
+    const dismissingToasts = mockShadowRoot.querySelectorAll('.don-toast--dismissing');
+    expect(dismissingToasts.length).toBe(3);
+  });
+
+  it('removes all toasts from DOM after animation duration', () => {
+    dispatchToast('Toast 1', 'success');
+    dispatchToast('Toast 2', 'error');
+    dispatchToast('Toast 3', 'warn');
+
+    clearAllToasts();
+
+    vi.advanceTimersByTime(__testing__.TOAST_CONFIG.DISMISS_ANIMATION_DURATION);
+
+    expect(mockShadowRoot.querySelectorAll('.don-toast').length).toBe(0);
+    expect(__testing__.getActiveToasts().length).toBe(0);
+  });
+
+  it('removes container after all toasts cleared', () => {
+    dispatchToast('Toast 1', 'success');
+    dispatchToast('Toast 2', 'error');
+
+    clearAllToasts();
+
+    vi.runAllTimers();
+
+    expect(__testing__.getToastContainer()).toBeNull();
+  });
+
+  it('handles clearAllToasts when no toasts present', () => {
+    expect(() => {
+      clearAllToasts();
+    }).not.toThrow();
+
+    expect(__testing__.getActiveToasts().length).toBe(0);
+  });
+
+  it('handles clearAllToasts called while toasts already dismissing', () => {
+    dispatchToast('Toast 1', 'success');
+    dispatchToast('Toast 2', 'error');
+
+    const firstCloseButton = mockShadowRoot.querySelector('[data-toast-id="1"] .don-toast__close') as HTMLButtonElement;
+    firstCloseButton.click();
+
+    clearAllToasts();
+
+    vi.runAllTimers();
+
+    expect(__testing__.getActiveToasts().length).toBe(0);
+  });
+});
+
+// ============================================================================
+// 11. Testing Utilities (resetState, getActiveToasts, getToastContainer)
+// ============================================================================
+
+describe('Testing Utilities', () => {
+  it('getActiveToasts returns copy of active toasts', () => {
+    dispatchToast('Toast 1', 'success');
+    dispatchToast('Toast 2', 'error');
+
+    const toasts = __testing__.getActiveToasts();
+    expect(toasts.length).toBe(2);
+    expect(toasts[0].text).toBe('Toast 2');
+    expect(toasts[1].text).toBe('Toast 1');
+  });
+
+  it('getActiveToasts returns empty array when no toasts', () => {
+    const toasts = __testing__.getActiveToasts();
+    expect(Array.isArray(toasts)).toBe(true);
+    expect(toasts.length).toBe(0);
+  });
+
+  it('getToastContainer returns null when no container', () => {
+    const container = __testing__.getToastContainer();
+    expect(container).toBeNull();
+  });
+
+  it('getToastContainer returns container after first toast', () => {
+    dispatchToast('Test message', 'success');
+
+    const container = __testing__.getToastContainer();
+    expect(container).not.toBeNull();
+    expect(container?.classList.contains('don-toastContainer')).toBe(true);
+  });
+
+  it('resetState clears all toasts', () => {
+    dispatchToast('Toast 1', 'success');
+    dispatchToast('Toast 2', 'error');
+
+    __testing__.resetState();
+
+    expect(__testing__.getActiveToasts().length).toBe(0);
+  });
+
+  it('resetState removes container', () => {
+    dispatchToast('Test message', 'success');
+
+    __testing__.resetState();
+
+    expect(__testing__.getToastContainer()).toBeNull();
+  });
+
+  it('resetState clears timers', () => {
+    dispatchToast('Test message', 'success');
+
+    __testing__.resetState();
+
+    // Timers should not fire
+    vi.runAllTimers();
+
+    expect(__testing__.getActiveToasts().length).toBe(0);
+  });
+});
+
+// ============================================================================
+// 12. Constants & Configuration
+// ============================================================================
+
+describe('Constants & Configuration', () => {
+  it('exposes TOAST_CONFIG', () => {
+    const config = __testing__.TOAST_CONFIG;
+    expect(config.MAX_VISIBLE).toBe(3);
+    expect(config.DURATION_DESKTOP).toBe(5000);
+    expect(config.DURATION_MOBILE).toBe(4000);
+    expect(config.DISMISS_ANIMATION_DURATION).toBe(400);
+    expect(config.SWIPE_THRESHOLD).toBe(50);
+    expect(config.MOBILE_BREAKPOINT).toBe(768);
+  });
+
+  it('exposes TOAST_CSS', () => {
+    const css = __testing__.TOAST_CSS;
+    expect(typeof css).toBe('string');
+    expect(css.length).toBeGreaterThan(0);
+  });
+
+  it('exposes TOAST_ICONS', () => {
+    const icons = __testing__.TOAST_ICONS;
+    expect(icons.success).toContain('<svg');
+    expect(icons.error).toContain('<svg');
+    expect(icons.warn).toContain('<svg');
+    expect(icons.info).toContain('<svg');
+  });
+
+  it('exposes CLOSE_ICON', () => {
+    const icon = __testing__.CLOSE_ICON;
+    expect(typeof icon).toBe('string');
+    expect(icon).toContain('<svg');
+  });
+
+  it('exposes ARIA_LABELS', () => {
+    const labels = __testing__.ARIA_LABELS;
+    expect(labels.success).toBe('Success notification');
+    expect(labels.error).toBe('Error notification');
+    expect(labels.warn).toBe('Warning notification');
+    expect(labels.info).toBe('Information notification');
+  });
+
+  it('exposes LEGACY_TYPE_MAP', () => {
+    const map = __testing__.LEGACY_TYPE_MAP;
+    expect(map.DANGER).toBe('error');
+    expect(map.WARNING).toBe('warn');
+    expect(map.SUCCESS).toBe('success');
+  });
+});
+
+// ============================================================================
+// 13. Icon Correctness
+// ============================================================================
+
+describe('Icon Correctness', () => {
+  it('uses correct icon for success toast', () => {
+    dispatchToast('Test message', 'success');
+
+    const iconContainer = mockShadowRoot.querySelector('.don-toast--success .don-toast__icon') as HTMLDivElement;
+    expect(iconContainer.innerHTML).toContain('<svg');
+    expect(iconContainer.innerHTML).toContain('viewBox="0 0 20 20"');
+  });
+
+  it('uses correct icon for error toast', () => {
+    dispatchToast('Test message', 'error');
+
+    const iconContainer = mockShadowRoot.querySelector('.don-toast--error .don-toast__icon') as HTMLDivElement;
+    expect(iconContainer.innerHTML).toContain('<svg');
+    expect(iconContainer.innerHTML).toContain('viewBox="0 0 20 20"');
+  });
+
+  it('uses correct icon for warn toast', () => {
+    dispatchToast('Test message', 'warn');
+
+    const iconContainer = mockShadowRoot.querySelector('.don-toast--warn .don-toast__icon') as HTMLDivElement;
+    expect(iconContainer.innerHTML).toContain('<svg');
+    expect(iconContainer.innerHTML).toContain('viewBox="0 0 20 20"');
+  });
+
+  it('uses correct icon for info toast', () => {
+    dispatchToast('Test message', 'info');
+
+    const iconContainer = mockShadowRoot.querySelector('.don-toast--info .don-toast__icon') as HTMLDivElement;
+    expect(iconContainer.innerHTML).toContain('<svg');
+    expect(iconContainer.innerHTML).toContain('viewBox="0 0 20 20"');
+  });
+
+  it('uses correct close icon for all toasts', () => {
+    dispatchToast('Test message', 'success');
+
+    const closeButton = mockShadowRoot.querySelector('.don-toast__close') as HTMLButtonElement;
+    expect(closeButton.innerHTML).toContain('<svg');
+    expect(closeButton.innerHTML).toContain('viewBox="0 0 20 20"');
+  });
+});
+
+// ============================================================================
+// 14. Order & Newest First
+// ============================================================================
+
+describe('Order & Newest First', () => {
+  it('newest toast appears first in activeToasts array', () => {
+    dispatchToast('Toast 1', 'success');
+    dispatchToast('Toast 2', 'error');
+    dispatchToast('Toast 3', 'warn');
+
+    const activeToasts = __testing__.getActiveToasts();
+    expect(activeToasts[0].text).toBe('Toast 3');
+    expect(activeToasts[1].text).toBe('Toast 2');
+    expect(activeToasts[2].text).toBe('Toast 1');
+  });
+
+  it('newest toast in activeToasts array is at index 0', () => {
+    dispatchToast('Toast 1', 'success');
+    dispatchToast('Toast 2', 'error');
+    dispatchToast('Toast 3', 'warn');
+
+    const activeToasts = __testing__.getActiveToasts();
+    expect(activeToasts[0].text).toBe('Toast 3');
+    expect(activeToasts[1].text).toBe('Toast 2');
+    expect(activeToasts[2].text).toBe('Toast 1');
+  });
+});
+
+// ============================================================================
+// 15. Timer Management
+// ============================================================================
+
+describe('Timer Management', () => {
+  it('schedules auto-dismiss timer on dispatch', () => {
+    dispatchToast('Test message', 'success');
+
+    const activeToasts = __testing__.getActiveToasts();
+    expect(activeToasts[0].autoDismissTimer).not.toBeNull();
+  });
+
+  it('clears auto-dismiss timer on manual dismiss', () => {
+    dispatchToast('Test message', 'success');
+
+    const activeToasts = __testing__.getActiveToasts();
+    const originalTimer = activeToasts[0].autoDismissTimer;
+
+    const closeButton = mockShadowRoot.querySelector('.don-toast__close') as HTMLButtonElement;
+    closeButton.click();
+
+    // After dismiss, timer should be cleared
+    // (We can't directly check this, but behavior should be correct)
+    expect(closeButton).not.toBeNull();
+  });
+
+  it('schedules remove timer on dismiss', () => {
+    dispatchToast('Test message', 'success');
+
+    const closeButton = mockShadowRoot.querySelector('.don-toast__close') as HTMLButtonElement;
+    closeButton.click();
+
+    const activeToasts = __testing__.getActiveToasts();
+    expect(activeToasts[0].removeTimer).not.toBeNull();
+  });
+
+  it('removes toast after remove timer fires', () => {
+    dispatchToast('Test message', 'success');
+
+    const closeButton = mockShadowRoot.querySelector('.don-toast__close') as HTMLButtonElement;
+    closeButton.click();
+
+    vi.advanceTimersByTime(__testing__.TOAST_CONFIG.DISMISS_ANIMATION_DURATION);
+
+    expect(__testing__.getActiveToasts().length).toBe(0);
   });
 });

--- a/donaction-saas/src/components/sponsorshipForm/__tests__/toaster.test.ts
+++ b/donaction-saas/src/components/sponsorshipForm/__tests__/toaster.test.ts
@@ -200,21 +200,21 @@ describe('Toast Element Structure', () => {
 
 describe('Type Mapping (Legacy Compatibility)', () => {
   it('maps DANGER to error', () => {
-    dispatchToast('Test message', 'DANGER' as any);
+    dispatchToast('Test message', 'DANGER');
 
     const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
     expect(toast.classList.contains('don-toast--error')).toBe(true);
   });
 
   it('maps WARNING to warn', () => {
-    dispatchToast('Test message', 'WARNING' as any);
+    dispatchToast('Test message', 'WARNING');
 
     const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
     expect(toast.classList.contains('don-toast--warn')).toBe(true);
   });
 
   it('maps SUCCESS to success', () => {
-    dispatchToast('Test message', 'SUCCESS' as any);
+    dispatchToast('Test message', 'SUCCESS');
 
     const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
     expect(toast.classList.contains('don-toast--success')).toBe(true);
@@ -450,7 +450,7 @@ describe('Stacking and Depth', () => {
     dispatchToast('Toast 3', 'warn');
 
     expect(__testing__.getActiveToasts().length).toBe(3);
-    const toast1Id = mockShadowRoot.querySelector('[data-toast-id="0"]');
+    expect(mockShadowRoot.querySelector('[data-toast-id="0"]')).not.toBeNull();
 
     dispatchToast('Toast 4', 'info');
 
@@ -522,14 +522,16 @@ describe('Swipe-to-Dismiss (Mobile)', () => {
 
   it('does NOT attach touch listeners on desktop', () => {
     setViewportWidth(1024);
+
+    const addEventListenerSpy = vi.spyOn(HTMLDivElement.prototype, 'addEventListener');
     dispatchToast('Test message', 'success');
 
-    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+    const touchCalls = addEventListenerSpy.mock.calls.filter(
+      (call) => typeof call[0] === 'string' && call[0].startsWith('touch')
+    );
+    expect(touchCalls.length).toBe(0);
 
-    // Check that touch events are not attached
-    // (This is tricky to test without implementing listener tracking)
-    // We verify by checking viewport width detection works
-    expect(window.innerWidth).toBe(1024);
+    vi.restoreAllMocks();
   });
 
   it('swipe up beyond threshold dismisses toast', () => {
@@ -539,15 +541,13 @@ describe('Swipe-to-Dismiss (Mobile)', () => {
     const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
 
     // Simulate swipe up
-    const touchStartEvent = new TouchEvent('touchstart', {
-      touches: [{ clientY: 100 } as Touch],
-    } as TouchEventInit);
-    toast.dispatchEvent(touchStartEvent);
+    toast.dispatchEvent(new TouchEvent('touchstart', {
+      touches: [{ clientY: 100 } as unknown as Touch],
+    }));
 
-    const touchMoveEvent = new TouchEvent('touchmove', {
-      touches: [{ clientY: 30 } as Touch],
-    } as TouchEventInit);
-    toast.dispatchEvent(touchMoveEvent);
+    toast.dispatchEvent(new TouchEvent('touchmove', {
+      touches: [{ clientY: 30 } as unknown as Touch],
+    }));
 
     const touchEndEvent = new TouchEvent('touchend', {});
     toast.dispatchEvent(touchEndEvent);
@@ -562,15 +562,13 @@ describe('Swipe-to-Dismiss (Mobile)', () => {
     const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
 
     // Simulate small swipe up (below threshold)
-    const touchStartEvent = new TouchEvent('touchstart', {
-      touches: [{ clientY: 100 } as Touch],
-    } as TouchEventInit);
-    toast.dispatchEvent(touchStartEvent);
+    toast.dispatchEvent(new TouchEvent('touchstart', {
+      touches: [{ clientY: 100 } as unknown as Touch],
+    }));
 
-    const touchMoveEvent = new TouchEvent('touchmove', {
-      touches: [{ clientY: 80 } as Touch],
-    } as TouchEventInit);
-    toast.dispatchEvent(touchMoveEvent);
+    toast.dispatchEvent(new TouchEvent('touchmove', {
+      touches: [{ clientY: 80 } as unknown as Touch],
+    }));
 
     const touchEndEvent = new TouchEvent('touchend', {});
     toast.dispatchEvent(touchEndEvent);
@@ -604,7 +602,7 @@ describe('Swipe-to-Dismiss (Mobile)', () => {
 
 describe('Edge Cases', () => {
   it('handles null shadowRoot gracefully', () => {
-    vi.spyOn(document, 'querySelector').mockReturnValue(null as any);
+    vi.spyOn(document, 'querySelector').mockReturnValue(null);
 
     expect(() => {
       dispatchToast('Test message', 'success');
@@ -614,7 +612,7 @@ describe('Edge Cases', () => {
   });
 
   it('handles element with no shadowRoot', () => {
-    vi.spyOn(document, 'querySelector').mockReturnValue({} as any);
+    vi.spyOn(document, 'querySelector').mockReturnValue({} as unknown as Element);
 
     expect(() => {
       dispatchToast('Test message', 'success');
@@ -926,14 +924,14 @@ describe('Timer Management', () => {
     dispatchToast('Test message', 'success');
 
     const activeToasts = __testing__.getActiveToasts();
-    const originalTimer = activeToasts[0].autoDismissTimer;
+    expect(activeToasts[0].autoDismissTimer).not.toBeNull();
 
     const closeButton = mockShadowRoot.querySelector('.don-toast__close') as HTMLButtonElement;
     closeButton.click();
 
-    // After dismiss, timer should be cleared
-    // (We can't directly check this, but behavior should be correct)
-    expect(closeButton).not.toBeNull();
+    // After dismiss, the toast should have dismissing class
+    const toast = mockShadowRoot.querySelector('.don-toast') as HTMLDivElement;
+    expect(toast.classList.contains('don-toast--dismissing')).toBe(true);
   });
 
   it('schedules remove timer on dismiss', () => {

--- a/donaction-saas/src/components/sponsorshipForm/index.svelte
+++ b/donaction-saas/src/components/sponsorshipForm/index.svelte
@@ -29,6 +29,7 @@
   import error from '../../assets/animations/error.json';
   import { initPlausible } from '../../utils/initPlausible';
   import { getProjectsList } from './logic/api';
+  import { clearAllToasts } from './logic/toaster';
 
   const { klubrUuid, projectUuid }: { klubrUuid?: string; projectUuid?: string } = $props();
 
@@ -94,6 +95,7 @@
 
   onDestroy(() => {
     console.log('HERE: ON DESTROY');
+    clearAllToasts();
     document.body.style.overflow = '';
     document.documentElement.style.overflow = '';
     Object.keys(DEFAULT_VALUES).forEach((_) => {

--- a/donaction-saas/src/components/sponsorshipForm/logic/toaster.ts
+++ b/donaction-saas/src/components/sponsorshipForm/logic/toaster.ts
@@ -1,27 +1,648 @@
-export function dispatchToast(text: string, type: 'DANGER' | 'WARNING' | 'SUCCESS') {
-  const el = document.createElement('span');
-  el.innerText = text;
-  el.style.padding = '8px 12px';
-  el.style.maxWidth = '350px';
-  el.style.position = 'fixed';
-  el.style.zIndex = '9999';
-  el.style.top = '50px';
-  el.style.right = '-100%';
-  el.style.backgroundColor = type === 'DANGER' ? 'red' : type === 'WARNING' ? 'yellow' : 'green';
-  el.style.color = 'white';
-  el.style.fontFamily = '"Maven-Pro-Regular", sans-serif';
-  el.style.borderTopLeftRadius = '6px';
-  el.style.borderBottomLeftRadius = '6px';
-  el.style.transition = 'right .5s ease-in-out';
-  document.querySelector('klubr-sponsorship-form')?.shadowRoot?.appendChild(el);
+// ============================================================================
+// Glassmorphism Toast System for Shadow DOM Web Components
+// ============================================================================
+// Converts imperative 27-line toast into a modern, stacked system with
+// swipe-dismiss, depth effects, and responsive design. Fully self-contained.
 
-  setTimeout(() => {
-    el.style.right = '0';
-  }, 100);
-  setTimeout(() => {
-    el.style.right = '-100%';
-  }, 4000);
-  setTimeout(() => {
-    document.querySelector('klubr-sponsorship-form')?.shadowRoot?.removeChild(el);
-  }, 5000);
+// --- Types ---
+type ToastType = 'success' | 'error' | 'warn' | 'info';
+type LegacyToastType = 'DANGER' | 'WARNING' | 'SUCCESS';
+
+interface ToastInstance {
+  id: string;
+  element: HTMLDivElement;
+  type: ToastType;
+  text: string;
+  autoDismissTimer: NodeJS.Timeout | null;
+  removeTimer: NodeJS.Timeout | null;
 }
+
+// --- Constants ---
+const TOAST_CONFIG = {
+  MAX_VISIBLE: 3,
+  DURATION_DESKTOP: 5000,
+  DURATION_MOBILE: 4000,
+  DISMISS_ANIMATION_DURATION: 400,
+  ENTRY_ANIMATION_DURATION: 350,
+  SWIPE_THRESHOLD: 50,
+  MOBILE_BREAKPOINT: 768,
+} as const;
+
+const LEGACY_TYPE_MAP: Record<LegacyToastType, ToastType> = {
+  DANGER: 'error',
+  WARNING: 'warn',
+  SUCCESS: 'success',
+};
+
+const ARIA_LABELS: Record<ToastType, string> = {
+  success: 'Success notification',
+  error: 'Error notification',
+  warn: 'Warning notification',
+  info: 'Information notification',
+};
+
+// --- SVG Icons (raw SVG strings, no dependencies) ---
+const TOAST_ICONS: Record<ToastType, string> = {
+  success: `<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="10" r="9" stroke="currentColor" stroke-width="1.5"/>
+    <path d="M6.5 10l2.5 2.5 4-5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>`,
+  error: `<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="10" r="9" stroke="currentColor" stroke-width="1.5"/>
+    <path d="M7 7l6 6M13 7l-6 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+  </svg>`,
+  warn: `<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <path d="M10 2L2 16h16L10 2z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+    <path d="M10 9v2M10 13v0.01" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+  </svg>`,
+  info: `<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="10" cy="10" r="9" stroke="currentColor" stroke-width="1.5"/>
+    <path d="M10 6v0.01M10 9v3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+  </svg>`,
+};
+
+const CLOSE_ICON = `<svg viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+  <path d="M6 6l8 8M14 6l-8 8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+</svg>`;
+
+// --- CSS Styles (injected into shadow DOM) ---
+const TOAST_CSS = `
+/* Toast Container */
+.don-toastContainer {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  z-index: 999999;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: 0.75rem;
+  pointer-events: none;
+}
+
+/* Mobile: top-positioned, full-width */
+@media (max-width: 768px) {
+  .don-toastContainer {
+    top: 0.75rem;
+    bottom: auto;
+    right: 0;
+    left: 0;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+  }
+}
+
+/* Individual Toast Item */
+.don-toast {
+  pointer-events: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 14px 20px;
+  border-radius: 12px;
+  max-width: min(420px, calc(100vw - 3rem));
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 14px;
+  line-height: 1.4;
+  font-weight: 500;
+  color: #374151;
+  border-left: 3px solid transparent;
+  transition: transform 0.3s cubic-bezier(0.21, 1.02, 0.73, 1),
+              opacity 0.3s ease;
+
+  /* Glassmorphism */
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08), 0 2px 8px rgba(0, 0, 0, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.5);
+
+  /* Entry animation */
+  animation: donToastSlideIn 0.35s cubic-bezier(0.21, 1.02, 0.73, 1) forwards;
+}
+
+/* Fallback for browsers without backdrop-filter */
+@supports not (backdrop-filter: blur(16px)) {
+  .don-toast {
+    background: rgba(255, 255, 255, 0.97);
+  }
+}
+
+/* Type-specific accents */
+.don-toast--success { border-left-color: #73cfa8; }
+.don-toast--success .don-toast__icon { color: #059669; }
+
+.don-toast--error { border-left-color: #fb9289; }
+.don-toast--error .don-toast__icon { color: #dc2626; }
+
+.don-toast--warn { border-left-color: #fde179; }
+.don-toast--warn .don-toast__icon { color: #d97706; }
+
+.don-toast--info { border-left-color: #73b1ff; }
+.don-toast--info .don-toast__icon { color: #2563eb; }
+
+/* Icon Container */
+.don-toast__icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.don-toast__icon svg {
+  width: 20px;
+  height: 20px;
+}
+
+/* Text Content */
+.don-toast__text {
+  flex: 1;
+  line-height: 1.4;
+}
+
+/* Close Button */
+.don-toast__close {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  margin-left: 4px;
+  background: none;
+  border: none;
+  border-radius: 6px;
+  color: #9ca3af;
+  cursor: pointer;
+  transition: color 0.15s ease, background-color 0.15s ease;
+}
+
+.don-toast__close:hover {
+  color: #374151;
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.don-toast__close:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 1px;
+}
+
+.don-toast__close svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* Depth effect -- toasts further back appear slightly receded */
+.don-toast--depth-1 {
+  transform: scale(0.96);
+  opacity: 0.85;
+}
+
+.don-toast--depth-2 {
+  transform: scale(0.92);
+  opacity: 0.7;
+}
+
+/* Dismiss animation */
+.don-toast--dismissing {
+  animation: donToastFadeOut 0.4s ease forwards;
+}
+
+/* Mobile: Compact Sizing */
+@media (max-width: 768px) {
+  .don-toast {
+    padding: 10px 14px;
+    font-size: 13px;
+    gap: 0.5rem;
+    max-width: calc(100vw - 1.5rem);
+    border-radius: 10px;
+    touch-action: pan-x;
+    user-select: none;
+  }
+
+  .don-toast__icon svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  .don-toast__close {
+    width: 20px;
+    height: 20px;
+  }
+
+  .don-toast__close svg {
+    width: 12px;
+    height: 12px;
+  }
+}
+
+/* Animations -- desktop */
+@keyframes donToastSlideIn {
+  0% { opacity: 0; transform: translateY(100%) scale(0.95); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@keyframes donToastFadeOut {
+  0% { opacity: 1; transform: translateY(0) scale(1); }
+  100% { opacity: 0; transform: translateY(8px) scale(0.96); }
+}
+
+/* Animations -- mobile (from top) */
+@keyframes donToastSlideInFromTop {
+  0% { opacity: 0; transform: translateY(-100%) scale(0.95); }
+  100% { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+@keyframes donToastSwipeOut {
+  0% { opacity: 1; transform: translateY(0) scale(1); }
+  100% { opacity: 0; transform: translateY(-100%) scale(0.96); }
+}
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  .don-toast {
+    animation: none;
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+
+  .don-toast--dismissing {
+    animation: none;
+    opacity: 0;
+  }
+
+  .don-toast--depth-1 {
+    opacity: 0.85;
+    transform: none;
+  }
+
+  .don-toast--depth-2 {
+    opacity: 0.7;
+    transform: none;
+  }
+
+  .don-toast__close {
+    transition: none;
+  }
+}
+
+/* Mobile: Entry from top, swipe-out upward */
+@media (max-width: 768px) {
+  .don-toast {
+    animation-name: donToastSlideInFromTop;
+  }
+
+  .don-toast--dismissing {
+    animation-name: donToastSwipeOut;
+  }
+}
+`;
+
+// --- State Management ---
+const activeToasts: ToastInstance[] = [];
+let toastContainer: HTMLDivElement | null = null;
+let toastIdCounter = 0;
+
+// --- Helper Functions ---
+
+/**
+ * Get the shadow root of the sponsorship form web component
+ */
+function getShadowRoot(): ShadowRoot | null {
+  const element = document.querySelector('klubr-sponsorship-form');
+  return element?.shadowRoot || null;
+}
+
+/**
+ * Check if device is mobile based on viewport width
+ */
+function isMobile(): boolean {
+  return typeof window !== 'undefined' && window.innerWidth <= TOAST_CONFIG.MOBILE_BREAKPOINT;
+}
+
+/**
+ * Inject CSS styles into shadow root (once)
+ */
+function ensureStyles(shadowRoot: ShadowRoot): void {
+  if (shadowRoot.querySelector('#don-toast-styles')) {
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.id = 'don-toast-styles';
+  style.textContent = TOAST_CSS;
+  shadowRoot.appendChild(style);
+}
+
+/**
+ * Create or retrieve the toast container in shadow DOM
+ */
+function ensureToastContainer(shadowRoot: ShadowRoot): HTMLDivElement {
+  if (toastContainer && toastContainer.parentNode) {
+    return toastContainer;
+  }
+
+  toastContainer = document.createElement('div');
+  toastContainer.className = 'don-toastContainer';
+  toastContainer.setAttribute('role', 'status');
+  toastContainer.setAttribute('aria-live', 'polite');
+  toastContainer.setAttribute('aria-atomic', 'false');
+
+  shadowRoot.appendChild(toastContainer);
+  return toastContainer;
+}
+
+/**
+ * Create a toast element with icon, text, and close button
+ */
+function createToastElement(id: string, text: string, type: ToastType): HTMLDivElement {
+  const toast = document.createElement('div');
+  toast.className = `don-toast don-toast--${type}`;
+  toast.setAttribute('data-toast-id', id);
+  toast.setAttribute('aria-label', ARIA_LABELS[type]);
+
+  // Icon container
+  const iconContainer = document.createElement('div');
+  iconContainer.className = 'don-toast__icon';
+  iconContainer.innerHTML = TOAST_ICONS[type];
+
+  // Text content
+  const textElement = document.createElement('div');
+  textElement.className = 'don-toast__text';
+  textElement.textContent = text;
+
+  // Close button
+  const closeButton = document.createElement('button');
+  closeButton.className = 'don-toast__close';
+  closeButton.type = 'button';
+  closeButton.innerHTML = CLOSE_ICON;
+  closeButton.setAttribute('aria-label', 'Dismiss notification');
+  closeButton.addEventListener('click', () => dismissToast(id));
+
+  // Assemble toast
+  toast.appendChild(iconContainer);
+  toast.appendChild(textElement);
+  toast.appendChild(closeButton);
+
+  return toast;
+}
+
+/**
+ * Update depth classes (newest at depth-0, older at depth-1/2)
+ */
+function updateDepths(): void {
+  const count = activeToasts.length;
+  activeToasts.forEach((toast, index) => {
+    const element = toast.element;
+    const depth = count - 1 - index;
+
+    // Remove all depth classes
+    element.classList.remove('don-toast--depth-1', 'don-toast--depth-2');
+
+    // Apply depth class for non-zero depths
+    if (depth === 1) {
+      element.classList.add('don-toast--depth-1');
+    } else if (depth >= 2) {
+      element.classList.add('don-toast--depth-2');
+    }
+
+    element.setAttribute('data-depth', String(depth));
+  });
+}
+
+/**
+ * Attach swipe-to-dismiss handlers for mobile (adapted from frontend useSwipeDismiss)
+ */
+function attachSwipeHandlers(element: HTMLDivElement, toastId: string): void {
+  if (!isMobile()) {
+    return; // Only for mobile
+  }
+
+  let startY = 0;
+  let currentOffset = 0;
+
+  const onTouchStart = (e: TouchEvent): void => {
+    startY = e.touches[0].clientY;
+    currentOffset = 0;
+  };
+
+  const onTouchMove = (e: TouchEvent): void => {
+    const deltaY = e.touches[0].clientY - startY;
+    // Only allow upward swipe (negative delta)
+    const offset = Math.min(0, deltaY);
+    currentOffset = offset;
+
+    // Direct DOM manipulation for smooth 60fps visual feedback
+    element.style.transform = `translateY(${offset}px)`;
+    element.style.opacity = `${Math.max(0.3, 1 - Math.abs(offset) / 150)}`;
+  };
+
+  const onTouchEnd = (): void => {
+    if (Math.abs(currentOffset) >= TOAST_CONFIG.SWIPE_THRESHOLD) {
+      dismissToast(toastId);
+    } else {
+      // Snap back with transition
+      element.style.transition = 'transform 0.2s ease, opacity 0.2s ease';
+      element.style.transform = '';
+      element.style.opacity = '';
+      const cleanup = () => {
+        element.style.transition = '';
+        element.removeEventListener('transitionend', cleanup);
+      };
+      element.addEventListener('transitionend', cleanup);
+    }
+    currentOffset = 0;
+  };
+
+  const onTouchCancel = (): void => {
+    element.style.transform = '';
+    element.style.opacity = '';
+    currentOffset = 0;
+  };
+
+  element.addEventListener('touchstart', onTouchStart, { passive: true });
+  element.addEventListener('touchmove', onTouchMove, { passive: true });
+  element.addEventListener('touchend', onTouchEnd);
+  element.addEventListener('touchcancel', onTouchCancel);
+}
+
+/**
+ * Remove a toast completely (after dismiss animation)
+ */
+function removeToast(id: string): void {
+  const index = activeToasts.findIndex((t) => t.id === id);
+  if (index === -1) {
+    return;
+  }
+
+  const toast = activeToasts[index];
+
+  // Clear all timers
+  if (toast.autoDismissTimer) {
+    clearTimeout(toast.autoDismissTimer);
+  }
+  if (toast.removeTimer) {
+    clearTimeout(toast.removeTimer);
+  }
+
+  // Remove element from DOM
+  if (toast.element.parentElement) {
+    toast.element.remove();
+  }
+
+  // Remove from state
+  activeToasts.splice(index, 1);
+
+  // Update depths
+  updateDepths();
+
+  // Remove container if empty
+  if (activeToasts.length === 0 && toastContainer) {
+    if (toastContainer.parentElement) {
+      toastContainer.remove();
+    }
+    toastContainer = null;
+  }
+}
+
+/**
+ * Dismiss a toast (start animation, then remove)
+ */
+function dismissToast(id: string): void {
+  const toast = activeToasts.find((t) => t.id === id);
+  if (!toast) {
+    return;
+  }
+
+  // Clear auto-dismiss timer if still pending
+  if (toast.autoDismissTimer) {
+    clearTimeout(toast.autoDismissTimer);
+    toast.autoDismissTimer = null;
+  }
+
+  // Add dismissing animation
+  toast.element.classList.add('don-toast--dismissing');
+
+  // Schedule removal after animation
+  toast.removeTimer = setTimeout(() => {
+    removeToast(id);
+  }, TOAST_CONFIG.DISMISS_ANIMATION_DURATION);
+}
+
+/**
+ * Core API: Dispatch a toast notification
+ */
+export function dispatchToast(text: string, type: LegacyToastType | ToastType): void {
+  const shadowRoot = getShadowRoot();
+  if (!shadowRoot) {
+    return;
+  }
+
+  // Ensure styles are injected
+  ensureStyles(shadowRoot);
+
+  // Resolve type
+  const resolvedType = (LEGACY_TYPE_MAP[type as LegacyToastType] || type) as ToastType;
+
+  // Ensure container exists
+  const container = ensureToastContainer(shadowRoot);
+
+  // If at max capacity, evict oldest
+  if (activeToasts.length >= TOAST_CONFIG.MAX_VISIBLE) {
+    const oldestId = activeToasts[activeToasts.length - 1].id;
+    removeToast(oldestId);
+  }
+
+  // Create toast element
+  const toastId = String(toastIdCounter++);
+  const element = createToastElement(toastId, text, resolvedType);
+
+  // Add to state
+  const toastInstance: ToastInstance = {
+    id: toastId,
+    element,
+    type: resolvedType,
+    text,
+    autoDismissTimer: null,
+    removeTimer: null,
+  };
+  activeToasts.unshift(toastInstance); // Newest first
+
+  // Append to DOM (triggers animation via CSS)
+  container.appendChild(element);
+
+  // Update depths
+  updateDepths();
+
+  // Attach swipe handlers for mobile
+  attachSwipeHandlers(element, toastId);
+
+  // Schedule auto-dismiss
+  const duration = isMobile() ? TOAST_CONFIG.DURATION_MOBILE : TOAST_CONFIG.DURATION_DESKTOP;
+  toastInstance.autoDismissTimer = setTimeout(() => {
+    dismissToast(toastId);
+  }, duration);
+}
+
+/**
+ * Clear all visible toasts
+ */
+export function clearAllToasts(): void {
+  // Copy array to avoid mutation during iteration
+  const toastsToClear = [...activeToasts];
+  toastsToClear.forEach((toast) => {
+    dismissToast(toast.id);
+  });
+}
+
+/**
+ * Testing utilities (for unit tests)
+ */
+export const __testing__ = {
+  TOAST_CONFIG,
+  TOAST_CSS,
+  TOAST_ICONS,
+  CLOSE_ICON,
+  ARIA_LABELS,
+  LEGACY_TYPE_MAP,
+
+  /**
+   * Get current active toasts
+   */
+  getActiveToasts: (): ToastInstance[] => {
+    return [...activeToasts];
+  },
+
+  /**
+   * Get current toast container reference
+   */
+  getToastContainer: (): HTMLDivElement | null => {
+    return toastContainer;
+  },
+
+  /**
+   * Reset all internal state (for test cleanup)
+   */
+  resetState: (): void => {
+    // Clear all toasts
+    activeToasts.forEach((toast) => {
+      if (toast.autoDismissTimer) {
+        clearTimeout(toast.autoDismissTimer);
+      }
+      if (toast.removeTimer) {
+        clearTimeout(toast.removeTimer);
+      }
+    });
+    activeToasts.length = 0;
+
+    // Remove container
+    if (toastContainer && toastContainer.parentElement) {
+      toastContainer.remove();
+    }
+    toastContainer = null;
+
+    // Reset counter
+    toastIdCounter = 0;
+  },
+};

--- a/donaction-saas/src/components/sponsorshipForm/logic/toaster.ts
+++ b/donaction-saas/src/components/sponsorshipForm/logic/toaster.ts
@@ -13,8 +13,9 @@ interface ToastInstance {
   element: HTMLDivElement;
   type: ToastType;
   text: string;
-  autoDismissTimer: NodeJS.Timeout | null;
-  removeTimer: NodeJS.Timeout | null;
+  autoDismissTimer: ReturnType<typeof setTimeout> | null;
+  removeTimer: ReturnType<typeof setTimeout> | null;
+  cleanupListeners?: () => void;
 }
 
 // --- Constants ---
@@ -366,6 +367,7 @@ function createToastElement(id: string, text: string, type: ToastType): HTMLDivE
   toast.setAttribute('aria-label', ARIA_LABELS[type]);
 
   // Icon container
+  // Safe: TOAST_ICONS are static SVG constants, not user input
   const iconContainer = document.createElement('div');
   iconContainer.className = 'don-toast__icon';
   iconContainer.innerHTML = TOAST_ICONS[type];
@@ -379,6 +381,7 @@ function createToastElement(id: string, text: string, type: ToastType): HTMLDivE
   const closeButton = document.createElement('button');
   closeButton.className = 'don-toast__close';
   closeButton.type = 'button';
+  // Safe: CLOSE_ICON is a static SVG string, not user input
   closeButton.innerHTML = CLOSE_ICON;
   closeButton.setAttribute('aria-label', 'Dismiss notification');
   closeButton.addEventListener('click', () => dismissToast(id));
@@ -417,9 +420,9 @@ function updateDepths(): void {
 /**
  * Attach swipe-to-dismiss handlers for mobile (adapted from frontend useSwipeDismiss)
  */
-function attachSwipeHandlers(element: HTMLDivElement, toastId: string): void {
+function attachSwipeHandlers(element: HTMLDivElement, toastId: string): (() => void) | undefined {
   if (!isMobile()) {
-    return; // Only for mobile
+    return undefined;
   }
 
   let startY = 0;
@@ -468,6 +471,13 @@ function attachSwipeHandlers(element: HTMLDivElement, toastId: string): void {
   element.addEventListener('touchmove', onTouchMove, { passive: true });
   element.addEventListener('touchend', onTouchEnd);
   element.addEventListener('touchcancel', onTouchCancel);
+
+  return () => {
+    element.removeEventListener('touchstart', onTouchStart);
+    element.removeEventListener('touchmove', onTouchMove);
+    element.removeEventListener('touchend', onTouchEnd);
+    element.removeEventListener('touchcancel', onTouchCancel);
+  };
 }
 
 /**
@@ -489,6 +499,11 @@ function removeToast(id: string): void {
     clearTimeout(toast.removeTimer);
   }
 
+  // Clean up event listeners
+  if (toast.cleanupListeners) {
+    toast.cleanupListeners();
+  }
+
   // Remove element from DOM
   if (toast.element.parentElement) {
     toast.element.remove();
@@ -500,9 +515,10 @@ function removeToast(id: string): void {
   // Update depths
   updateDepths();
 
-  // Remove container if empty
-  if (activeToasts.length === 0 && toastContainer) {
-    if (toastContainer.parentElement) {
+  // Remove container and reset counter if empty
+  if (activeToasts.length === 0) {
+    toastIdCounter = 0;
+    if (toastContainer?.parentElement) {
       toastContainer.remove();
     }
     toastContainer = null;
@@ -579,7 +595,7 @@ export function dispatchToast(text: string, type: LegacyToastType | ToastType): 
   updateDepths();
 
   // Attach swipe handlers for mobile
-  attachSwipeHandlers(element, toastId);
+  toastInstance.cleanupListeners = attachSwipeHandlers(element, toastId);
 
   // Schedule auto-dismiss
   const duration = isMobile() ? TOAST_CONFIG.DURATION_MOBILE : TOAST_CONFIG.DURATION_DESKTOP;

--- a/donaction-saas/src/components/sponsorshipForm/logic/toaster.ts
+++ b/donaction-saas/src/components/sponsorshipForm/logic/toaster.ts
@@ -111,20 +111,23 @@ const TOAST_CSS = `
               opacity 0.3s ease;
 
   /* Glassmorphism */
-  background: rgba(255, 255, 255, 0.85);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08), 0 2px 8px rgba(0, 0, 0, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.55);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.12),
+    0 2px 8px rgba(0, 0, 0, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.35);
 
   /* Entry animation */
   animation: donToastSlideIn 0.35s cubic-bezier(0.21, 1.02, 0.73, 1) forwards;
 }
 
 /* Fallback for browsers without backdrop-filter */
-@supports not (backdrop-filter: blur(16px)) {
+@supports not (backdrop-filter: blur(20px)) {
   .don-toast {
-    background: rgba(255, 255, 255, 0.97);
+    background: rgba(255, 255, 255, 0.95);
   }
 }
 

--- a/donaction-saas/src/components/sponsorshipForm/logic/toaster.ts
+++ b/donaction-saas/src/components/sponsorshipForm/logic/toaster.ts
@@ -26,6 +26,9 @@ const TOAST_CONFIG = {
   DISMISS_ANIMATION_DURATION: 400,
   ENTRY_ANIMATION_DURATION: 350,
   SWIPE_THRESHOLD: 50,
+  SWIPE_MIN_OPACITY: 0.3,
+  SWIPE_FADE_DISTANCE: 150,
+  SWIPE_SNAPBACK_DURATION: 200,
   MOBILE_BREAKPOINT: 768,
 } as const;
 
@@ -319,6 +322,24 @@ function getShadowRoot(): ShadowRoot | null {
 }
 
 /**
+ * Normalize legacy or modern toast type to internal ToastType
+ */
+function normalizeType(type: LegacyToastType | ToastType): ToastType {
+  if (type in LEGACY_TYPE_MAP) {
+    return LEGACY_TYPE_MAP[type as LegacyToastType];
+  }
+  return type as ToastType;
+}
+
+/**
+ * Parse an SVG string into a DOM element (CSP-safe, no innerHTML)
+ */
+function parseSVG(svgString: string): Element {
+  const doc = new DOMParser().parseFromString(svgString, 'image/svg+xml');
+  return doc.documentElement;
+}
+
+/**
  * Check if device is mobile based on viewport width
  */
 function isMobile(): boolean {
@@ -367,10 +388,9 @@ function createToastElement(id: string, text: string, type: ToastType): HTMLDivE
   toast.setAttribute('aria-label', ARIA_LABELS[type]);
 
   // Icon container
-  // Safe: TOAST_ICONS are static SVG constants, not user input
   const iconContainer = document.createElement('div');
   iconContainer.className = 'don-toast__icon';
-  iconContainer.innerHTML = TOAST_ICONS[type];
+  iconContainer.appendChild(parseSVG(TOAST_ICONS[type]));
 
   // Text content
   const textElement = document.createElement('div');
@@ -381,8 +401,7 @@ function createToastElement(id: string, text: string, type: ToastType): HTMLDivE
   const closeButton = document.createElement('button');
   closeButton.className = 'don-toast__close';
   closeButton.type = 'button';
-  // Safe: CLOSE_ICON is a static SVG string, not user input
-  closeButton.innerHTML = CLOSE_ICON;
+  closeButton.appendChild(parseSVG(CLOSE_ICON));
   closeButton.setAttribute('aria-label', 'Dismiss notification');
   closeButton.addEventListener('click', () => dismissToast(id));
 
@@ -441,7 +460,7 @@ function attachSwipeHandlers(element: HTMLDivElement, toastId: string): (() => v
 
     // Direct DOM manipulation for smooth 60fps visual feedback
     element.style.transform = `translateY(${offset}px)`;
-    element.style.opacity = `${Math.max(0.3, 1 - Math.abs(offset) / 150)}`;
+    element.style.opacity = `${Math.max(TOAST_CONFIG.SWIPE_MIN_OPACITY, 1 - Math.abs(offset) / TOAST_CONFIG.SWIPE_FADE_DISTANCE)}`;
   };
 
   const onTouchEnd = (): void => {
@@ -449,13 +468,17 @@ function attachSwipeHandlers(element: HTMLDivElement, toastId: string): (() => v
       dismissToast(toastId);
     } else {
       // Snap back with transition
-      element.style.transition = 'transform 0.2s ease, opacity 0.2s ease';
+      const ms = TOAST_CONFIG.SWIPE_SNAPBACK_DURATION;
+      element.style.transition = `transform ${ms}ms ease, opacity ${ms}ms ease`;
       element.style.transform = '';
       element.style.opacity = '';
-      const cleanup = () => {
+      // Timeout fallback if transitionend never fires (e.g. element removed early)
+      const fallbackTimer = setTimeout(cleanup, ms + 50);
+      function cleanup() {
+        clearTimeout(fallbackTimer);
         element.style.transition = '';
         element.removeEventListener('transitionend', cleanup);
-      };
+      }
       element.addEventListener('transitionend', cleanup);
     }
     currentOffset = 0;
@@ -562,7 +585,7 @@ export function dispatchToast(text: string, type: LegacyToastType | ToastType): 
   ensureStyles(shadowRoot);
 
   // Resolve type
-  const resolvedType = (LEGACY_TYPE_MAP[type as LegacyToastType] || type) as ToastType;
+  const resolvedType = normalizeType(type);
 
   // Ensure container exists
   const container = ensureToastContainer(shadowRoot);


### PR DESCRIPTION
## Summary

- Replace 27-line imperative toast (`<span>` + inline styles) with modern glassmorphism toast system matching frontend design
- Fully self-contained within Shadow DOM — CSS injected via `<style>` tag, SVG icons as inline strings, no external dependencies
- Backward compatible: existing callers (`step4.svelte`, `useSponsorshipForm.svelte.ts`, `Share.svelte`) work unchanged

## Changes

### `toaster.ts` (complete rewrite, 650 lines)
- Glassmorphism: frosted glass background, `backdrop-filter: blur(16px)`, soft shadows, white border
- 3px colored left border per type: success (#73cfa8), error (#fb9289), warn (#fde179), info (#73b1ff)
- SVG icons matching frontend (success checkmark, error X, warn triangle, info circle)
- Close button with hover state and focus-visible outline
- Max 3 toast stacking with depth effect (`scale(0.96)` / `scale(0.92)` + opacity)
- Mobile: top-center compact layout, swipe-to-dismiss (upward, 50px threshold)
- Desktop: bottom-right with slide-up entry animation
- `prefers-reduced-motion` support — no animations, static opacity only
- `@supports not (backdrop-filter)` fallback for older browsers
- `clearAllToasts()` export for widget cleanup

### `toaster.test.ts` (complete rewrite, 75 tests)
- Container management, element structure, type mapping, style injection
- Close button interaction, auto-dismiss timing, stacking/depth
- Swipe-to-dismiss (mobile), edge cases, clearAllToasts, testing utilities

### `index.svelte`
- Import and call `clearAllToasts()` in `onDestroy` for proper cleanup

## Test plan

- [x] All 513 SaaS tests pass (`npx vitest run`)
- [x] Production build succeeds (`npm run build`)
- [x] Legacy types (DANGER/WARNING/SUCCESS) still work
- [ ] Visual verification in dev server with toast triggers

Closes #157