### PR TITLE
feat(frontend): SEO meta tags, canonicals et rebranding Donaction

### DIFF
--- a/donaction-frontend/next.config.js
+++ b/donaction-frontend/next.config.js
@@ -33,9 +33,9 @@ const nextConfig = {
 				pathname: '/**',
 			},
 		],
+		deviceSizes: [640, 750, 828, 1080, 1200, 1920],
+		imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
 	},
-	deviceSizes: [480, 768],
-	imageSizes: [480, 1220],
 	experimental: {
 		// serverActions: true,
 		bodySizeLimit: '20mb',

--- a/donaction-frontend/src/app/(auth)/connexion/page.tsx
+++ b/donaction-frontend/src/app/(auth)/connexion/page.tsx
@@ -16,11 +16,11 @@ import { Metadata } from 'next';
 export const metadata: Metadata = {
 	title: 'On ne se connait pas encore! Créez votre compte.',
 	description:
-		'Connectez-vous ou créez votre compte Donaction pour soutenir vos clubs sportifs préférés.',
+		'Connectez-vous ou créez votre compte Donaction pour soutenir vos associations préférées.',
 	openGraph: {
 		title: 'On ne se connait pas encore! Créez votre compte.',
 		description:
-			'Connectez-vous ou créez votre compte Donaction pour soutenir vos clubs sportifs préférés.',
+			'Connectez-vous ou créez votre compte Donaction pour soutenir vos associations préférées.',
 		url: `${new URL(SITE_URL)}/connexion`,
 		siteName: 'Donaction',
 		images: [

--- a/donaction-frontend/src/app/(auth)/connexion/page.tsx
+++ b/donaction-frontend/src/app/(auth)/connexion/page.tsx
@@ -15,16 +15,20 @@ import { Metadata } from 'next';
 
 export const metadata: Metadata = {
 	title: 'On ne se connait pas encore! Créez votre compte.',
+	description:
+		'Connectez-vous ou créez votre compte Donaction pour soutenir vos clubs sportifs préférés.',
 	openGraph: {
 		title: 'On ne se connait pas encore! Créez votre compte.',
+		description:
+			'Connectez-vous ou créez votre compte Donaction pour soutenir vos clubs sportifs préférés.',
 		url: `${new URL(SITE_URL)}/connexion`,
 		siteName: 'Donaction',
 		images: [
 			{
-				url: `${SITE_URL}/images/images/auth/loginSignIn.svg`,
-				width: 800,
-				height: 385,
-				alt: 'Se Connecter',
+				url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+				width: 1200,
+				height: 628,
+				alt: 'Se Connecter - Donaction',
 			},
 		],
 		locale: 'fr_FR',

--- a/donaction-frontend/src/app/(auth)/connexion/page.tsx
+++ b/donaction-frontend/src/app/(auth)/connexion/page.tsx
@@ -9,7 +9,7 @@ import { cookies } from 'next/headers';
 import ConnexionForm from '@/partials/authentication/connexionForm';
 import { getAvatars } from '@/core/services/auth';
 import { WebPage, WithContext } from 'schema-dts';
-import { SITE_URL } from '@/core/services/endpoints';
+import { SITE_URL, OG_DEFAULT_IMAGE } from '@/core/services/endpoints';
 import React from 'react';
 import { Metadata } from 'next';
 
@@ -25,7 +25,7 @@ export const metadata: Metadata = {
 		siteName: 'Donaction',
 		images: [
 			{
-				url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+				url: OG_DEFAULT_IMAGE,
 				width: 1200,
 				height: 628,
 				alt: 'Se Connecter - Donaction',

--- a/donaction-frontend/src/app/(auth)/reset-password/page.tsx
+++ b/donaction-frontend/src/app/(auth)/reset-password/page.tsx
@@ -7,16 +7,19 @@ import React from 'react';
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
-	title: 'Réinitialiser votre mot de passe.',
+	title: 'Réinitialiser votre mot de passe',
+	description: 'Réinitialisez votre mot de passe Donaction pour retrouver l\'accès à votre compte.',
 	openGraph: {
-		title: 'Réinitialiser votre mot de passe.',
+		title: 'Réinitialiser votre mot de passe',
+		description: 'Réinitialisez votre mot de passe Donaction pour retrouver l\'accès à votre compte.',
 		url: `${new URL(SITE_URL)}/reset-password`,
 		siteName: 'Donaction',
 		images: [
 			{
-				url: `${SITE_URL}/images/images/auth/loginSignIn.svg`,
-				width: 800,
-				height: 385,
+				url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+				width: 1200,
+				height: 628,
+				alt: 'Réinitialiser votre mot de passe - Donaction',
 			},
 		],
 		locale: 'fr_FR',

--- a/donaction-frontend/src/app/(auth)/reset-password/page.tsx
+++ b/donaction-frontend/src/app/(auth)/reset-password/page.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 import loginSignIn from '../../../../public/images/auth/loginSignIn.svg';
 import ResetPasswordForm from '@/partials/authentication/resetPasswordForm';
 import { WebPage, WithContext } from 'schema-dts';
-import { SITE_URL } from '@/core/services/endpoints';
+import { SITE_URL, OG_DEFAULT_IMAGE } from '@/core/services/endpoints';
 import React from 'react';
 import { Metadata } from 'next';
 
@@ -16,7 +16,7 @@ export const metadata: Metadata = {
 		siteName: 'Donaction',
 		images: [
 			{
-				url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+				url: OG_DEFAULT_IMAGE,
 				width: 1200,
 				height: 628,
 				alt: 'Réinitialiser votre mot de passe - Donaction',

--- a/donaction-frontend/src/app/(main)/clubs/page.tsx
+++ b/donaction-frontend/src/app/(main)/clubs/page.tsx
@@ -15,20 +15,21 @@ import { WebPage, WithContext } from 'schema-dts';
 import { cookies } from 'next/headers';
 
 export const metadata: Metadata = {
-	title: 'Des clubs sportifs à soutenir',
+	title: 'Des associations à soutenir',
 	description:
-		'Découvrez tous les clubs sportifs inscrits sur Klubr et soutenez-les en faisant un don. Votre contribution aide les clubs à grandir et à offrir de meilleures activités à leurs membres.',
+		'Découvrez les associations sportives, humanitaires, sociales et culturelles inscrites sur Donaction. Soutenez-les en faisant un don pour les aider à grandir et à mener leurs projets.',
 	openGraph: {
-		title: `Des clubs sportifs à soutenir`,
-		description: `Découvrez tous les clubs sportifs inscrits sur Klubr et soutenez-les en faisant un don. Votre contribution aide les clubs à grandir et à offrir de meilleures activités à leurs membres.`,
+		title: 'Des associations à soutenir',
+		description:
+			'Découvrez les associations sportives, humanitaires, sociales et culturelles inscrites sur Donaction. Soutenez-les en faisant un don pour les aider à grandir et à mener leurs projets.',
 		url: `${new URL(SITE_URL)}/clubs`,
 		siteName: 'Donaction',
 		images: [
 			{
 				url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
-				width: 800,
-				height: 385,
-				alt: 'Des clubs sportifs à soutenir',
+				width: 1200,
+				height: 628,
+				alt: 'Des associations à soutenir - Donaction',
 			},
 		],
 		locale: 'fr_FR',
@@ -48,9 +49,9 @@ export default async function page() {
 		'@context': 'https://schema.org',
 		'@type': 'WebPage',
 		url: `${SITE_URL}/clubs`,
-		name: `Des clubs sportifs à soutenir`,
+		name: 'Des associations à soutenir',
 		description:
-			'Découvrez tous les clubs sportifs inscrits sur Klubr et soutenez-les en faisant un don. Votre contribution aide les clubs à grandir et à offrir de meilleures activités à leurs membres.',
+			'Découvrez les associations sportives, humanitaires, sociales et culturelles inscrites sur Donaction. Soutenez-les en faisant un don pour les aider à grandir et à mener leurs projets.',
 		publisher: {
 			'@type': 'Organization',
 			name: 'Nakaa',

--- a/donaction-frontend/src/app/(main)/clubs/page.tsx
+++ b/donaction-frontend/src/app/(main)/clubs/page.tsx
@@ -10,7 +10,7 @@ import PaginatedKlubsList from '@/partials/common/paginatedKlubsList';
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
 import GetServerCookie from '@/core/helpers/getServerCookie';
-import { SITE_URL } from '@/core/services/endpoints';
+import { SITE_URL, OG_DEFAULT_IMAGE } from '@/core/services/endpoints';
 import { WebPage, WithContext } from 'schema-dts';
 import { cookies } from 'next/headers';
 
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
 		siteName: 'Donaction',
 		images: [
 			{
-				url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+				url: OG_DEFAULT_IMAGE,
 				width: 1200,
 				height: 628,
 				alt: 'Des associations à soutenir - Donaction',
@@ -66,7 +66,7 @@ export default async function page() {
 		datePublished: '2024-10-16',
 		image: {
 			'@type': 'ImageObject',
-			url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+			url: OG_DEFAULT_IMAGE,
 			width: '800',
 			height: '385',
 		},

--- a/donaction-frontend/src/app/(main)/conditions-generales-d-utilisation/page.tsx
+++ b/donaction-frontend/src/app/(main)/conditions-generales-d-utilisation/page.tsx
@@ -3,7 +3,7 @@ import { getCGU } from '@/core/services/cms';
 import RichTextBlock from '@/components/RichTextBlock';
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import { SITE_URL } from '@/core/services/endpoints';
+import { SITE_URL, OG_DEFAULT_IMAGE } from '@/core/services/endpoints';
 import { WebPage, WithContext } from 'schema-dts';
 import { cookies } from 'next/headers';
 
@@ -22,7 +22,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			siteName: 'Donaction',
 			images: [
 				{
-					url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+					url: OG_DEFAULT_IMAGE,
 					width: 800,
 					height: 385,
 					alt: "Conditions Générales d'Utilisation",
@@ -60,7 +60,7 @@ export default async function Page() {
 		datePublished: '2024-10-16',
 		image: {
 			'@type': 'ImageObject',
-			url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+			url: OG_DEFAULT_IMAGE,
 			width: '800',
 			height: '385',
 		},

--- a/donaction-frontend/src/app/(main)/mecenat/page.tsx
+++ b/donaction-frontend/src/app/(main)/mecenat/page.tsx
@@ -19,10 +19,10 @@ export async function generateMetadata(): Promise<Metadata> {
 		notFound();
 	}
 	return {
-		title: `${res?.data?.attributes?.metaTitle || res?.data?.attributes?.titre || 'Politique de confidentialité'}`,
+		title: `${res?.data?.attributes?.metaTitle || res?.data?.attributes?.titre || 'Le mécénat simplifié'}`,
 		description: `${res?.data?.attributes?.metaDescription || ''}`,
 		openGraph: {
-			title: `${res?.data?.attributes?.metaTitle || res?.data?.attributes?.titre || 'Politique de confidentialité'}`,
+			title: `${res?.data?.attributes?.metaTitle || res?.data?.attributes?.titre || 'Le mécénat simplifié'}`,
 			description: `${res?.data?.attributes?.metaDescription || ''}`,
 			url: `${new URL(SITE_URL)}/mecenat`,
 			siteName: 'Donaction',
@@ -49,7 +49,7 @@ export default async function Page() {
 		'@context': 'https://schema.org',
 		'@type': 'WebPage',
 		url: `${SITE_URL}/mecenat`,
-		name: `${mecenatResult?.data?.attributes?.metaTitle || mecenatResult?.data?.attributes?.titre || 'Politique de confidentialité'}`,
+		name: `${mecenatResult?.data?.attributes?.metaTitle || mecenatResult?.data?.attributes?.titre || 'Le mécénat simplifié'}`,
 		description: `${mecenatResult?.data?.attributes?.metaDescription || ''}`,
 		publisher: {
 			'@type': 'Organization',

--- a/donaction-frontend/src/app/(main)/mecenat/page.tsx
+++ b/donaction-frontend/src/app/(main)/mecenat/page.tsx
@@ -8,7 +8,7 @@ import NeedHelp from '@/partials/mecenatPage/needHelp';
 import { Metadata } from 'next';
 import { getMecenat } from '@/core/services/cms';
 import { notFound } from 'next/navigation';
-import { SITE_URL } from '@/core/services/endpoints';
+import { SITE_URL, OG_MECENAT_IMAGE } from '@/core/services/endpoints';
 import { WebPage, WithContext } from 'schema-dts';
 import React from 'react';
 import { cookies } from 'next/headers';
@@ -28,7 +28,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			siteName: 'Donaction',
 			images: [
 				{
-					url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/mecenat-donaction.png',
+					url: OG_MECENAT_IMAGE,
 					width: 800,
 					height: 385,
 					alt: 'Le mécénat simplifié',
@@ -65,7 +65,7 @@ export default async function Page() {
 		datePublished: '2024-10-16',
 		image: {
 			'@type': 'ImageObject',
-			url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/mecenat-donaction.png',
+			url: OG_MECENAT_IMAGE,
 			width: '800',
 			height: '385',
 		},

--- a/donaction-frontend/src/app/(main)/mes-dons/[uuid]/details/page.tsx
+++ b/donaction-frontend/src/app/(main)/mes-dons/[uuid]/details/page.tsx
@@ -6,6 +6,12 @@ import { format } from 'date-fns';
 import frLocale from 'date-fns/locale/fr';
 import Link from 'next/link';
 import { cookies } from 'next/headers';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Détails du don',
+	robots: { index: false, follow: false },
+};
 
 export default async function Page({ params }: { params: { uuid: string } }) {
 	const result = await getDon(params.uuid, cookies().toString());

--- a/donaction-frontend/src/app/(main)/mes-dons/[uuid]/details/page.tsx
+++ b/donaction-frontend/src/app/(main)/mes-dons/[uuid]/details/page.tsx
@@ -10,6 +10,7 @@ import { Metadata } from 'next';
 
 export const metadata: Metadata = {
 	title: 'Détails du don',
+	description: 'Détails et reçu fiscal de votre don sur Donaction.',
 	robots: { index: false, follow: false },
 };
 

--- a/donaction-frontend/src/app/(main)/mes-dons/page.tsx
+++ b/donaction-frontend/src/app/(main)/mes-dons/page.tsx
@@ -5,6 +5,12 @@ import MyDonations from '@/partials/myDonations';
 import { WebPage, WithContext } from 'schema-dts';
 import { SITE_URL } from '@/core/services/endpoints';
 import { cookies } from 'next/headers';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Mes dons',
+	robots: { index: false, follow: false },
+};
 
 export default async function Page() {
 	const content = await getMesDonsPage(cookies().toString());

--- a/donaction-frontend/src/app/(main)/mes-dons/page.tsx
+++ b/donaction-frontend/src/app/(main)/mes-dons/page.tsx
@@ -3,7 +3,7 @@ import { getMesDonsPage } from '@/core/services/cms';
 import NeedHelp from '@/partials/mecenatPage/needHelp';
 import MyDonations from '@/partials/myDonations';
 import { WebPage, WithContext } from 'schema-dts';
-import { SITE_URL } from '@/core/services/endpoints';
+import { SITE_URL, OG_DEFAULT_IMAGE } from '@/core/services/endpoints';
 import { cookies } from 'next/headers';
 import { Metadata } from 'next';
 
@@ -34,7 +34,7 @@ export default async function Page() {
 		datePublished: '2024-10-16',
 		image: {
 			'@type': 'ImageObject',
-			url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+			url: OG_DEFAULT_IMAGE,
 			width: '800',
 			height: '385',
 		},

--- a/donaction-frontend/src/app/(main)/mes-dons/page.tsx
+++ b/donaction-frontend/src/app/(main)/mes-dons/page.tsx
@@ -9,6 +9,7 @@ import { Metadata } from 'next';
 
 export const metadata: Metadata = {
 	title: 'Mes dons',
+	description: 'Consultez l\'historique de vos dons et téléchargez vos reçus fiscaux.',
 	robots: { index: false, follow: false },
 };
 

--- a/donaction-frontend/src/app/(main)/new-club/congratulations/page.tsx
+++ b/donaction-frontend/src/app/(main)/new-club/congratulations/page.tsx
@@ -5,6 +5,7 @@ import { Metadata } from 'next';
 
 export const metadata: Metadata = {
 	title: 'Félicitations',
+	description: 'Votre demande d\'inscription a bien été envoyée sur Donaction.',
 	robots: { index: false, follow: false },
 };
 

--- a/donaction-frontend/src/app/(main)/new-club/congratulations/page.tsx
+++ b/donaction-frontend/src/app/(main)/new-club/congratulations/page.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import Image from 'next/image';
 import congrats from '../../../../../public/images/icons/congrats.svg';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Félicitations',
+	robots: { index: false, follow: false },
+};
 
 type PageProps = {
 	searchParams: Promise<{ clubUuid?: string; emailSent?: string }>;

--- a/donaction-frontend/src/app/(main)/new-club/page.tsx
+++ b/donaction-frontend/src/app/(main)/new-club/page.tsx
@@ -10,19 +10,21 @@ import { WebPage, WithContext } from 'schema-dts';
 
 export async function generateMetadata(): Promise<Metadata> {
 	return {
-		title: `Créez le compte de votre Klub`,
-		description: `Laissez-nous vos coordonnées et nous vous recontacterons rapidement.`,
+		title: 'Inscrivez votre association',
+		description:
+			'Inscrivez votre association sur Donaction et commencez à recevoir des dons et du mécénat en quelques minutes.',
 		openGraph: {
-			title: `Créez le compte de votre Klub`,
-			description: `Laissez-nous vos coordonnées et nous vous recontacterons rapidement.`,
+			title: 'Inscrivez votre association',
+			description:
+				'Inscrivez votre association sur Donaction et commencez à recevoir des dons et du mécénat en quelques minutes.',
 			url: `${new URL(SITE_URL)}/new-club`,
 			siteName: 'Donaction',
 			images: [
 				{
 					url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
-					width: 800,
-					height: 385,
-					alt: 'Créer votre club',
+					width: 1200,
+					height: 628,
+					alt: 'Inscrivez votre association - Donaction',
 				},
 			],
 			locale: 'fr_FR',
@@ -36,8 +38,9 @@ export default async function Page() {
 		'@context': 'https://schema.org',
 		'@type': 'WebPage',
 		url: `${SITE_URL}/new-club`,
-		name: `Créez le compte de votre Klub`,
-		description: `Laissez-nous vos coordonnées et nous vous recontacterons rapidement.`,
+		name: 'Inscrivez votre association',
+		description:
+			'Inscrivez votre association sur Donaction et commencez à recevoir des dons et du mécénat en quelques minutes.',
 		publisher: {
 			'@type': 'Organization',
 			name: 'Nakaa',

--- a/donaction-frontend/src/app/(main)/new-club/page.tsx
+++ b/donaction-frontend/src/app/(main)/new-club/page.tsx
@@ -5,7 +5,7 @@ import NewClubForm from '@/partials/authentication/newClubForm';
 import LottieAnimation from '@/components/LottieAnimation';
 import Script from 'next/script';
 import { Metadata } from 'next';
-import { SITE_URL } from '@/core/services/endpoints';
+import { SITE_URL, OG_DEFAULT_IMAGE } from '@/core/services/endpoints';
 import { WebPage, WithContext } from 'schema-dts';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -21,7 +21,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			siteName: 'Donaction',
 			images: [
 				{
-					url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+					url: OG_DEFAULT_IMAGE,
 					width: 1200,
 					height: 628,
 					alt: 'Inscrivez votre association - Donaction',
@@ -55,7 +55,7 @@ export default async function Page() {
 		datePublished: '2024-10-16',
 		image: {
 			'@type': 'ImageObject',
-			url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+			url: OG_DEFAULT_IMAGE,
 			width: '800',
 			height: '385',
 		},

--- a/donaction-frontend/src/app/(main)/page.tsx
+++ b/donaction-frontend/src/app/(main)/page.tsx
@@ -4,7 +4,7 @@ import { getProjets } from '@/core/services/projet';
 import { getHp } from '@/core/services/cms';
 import { cookies } from 'next/headers';
 import GetServerCookie from '@/core/helpers/getServerCookie';
-import { SITE_URL } from '@/core/services/endpoints';
+import { SITE_URL, OG_DEFAULT_IMAGE } from '@/core/services/endpoints';
 import { WebPage, WithContext } from 'schema-dts';
 
 export const revalidate = 3600;
@@ -32,7 +32,7 @@ export async function generateMetadata(): Promise<Metadata> {
 			siteName: 'Donaction',
 			images: [
 				{
-					url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+					url: OG_DEFAULT_IMAGE,
 					width: 800,
 					height: 385,
 					alt: 'Page home',
@@ -82,7 +82,7 @@ export default async function Page() {
 		datePublished: '2024-10-16',
 		image: {
 			'@type': 'ImageObject',
-			url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+			url: OG_DEFAULT_IMAGE,
 			width: '800',
 			height: '385',
 		},

--- a/donaction-frontend/src/app/(main)/page.tsx
+++ b/donaction-frontend/src/app/(main)/page.tsx
@@ -18,8 +18,9 @@ export async function generateMetadata(): Promise<Metadata> {
 
 	const title = res?.data?.attributes?.metaTitle
 		|| res?.data?.attributes?.titre
-		|| 'Le sport unit, le don renforce!';
-	const description = res?.data?.attributes?.metaDescription || '';
+		|| 'Donaction - Soutenez les associations qui vous tiennent à cœur';
+	const description = res?.data?.attributes?.metaDescription
+		|| 'Plateforme de dons et mécénat pour les associations sportives, humanitaires, sociales et culturelles.';
 
 	return {
 		title,
@@ -64,8 +65,9 @@ export default async function Page() {
 		url: SITE_URL,
 		name: hpResult?.data?.attributes?.metaTitle
 			|| hpResult?.data?.attributes?.titre
-			|| 'Le sport unit, le don renforce!',
-		description: hpResult?.data?.attributes?.metaDescription || '',
+			|| 'Donaction - Soutenez les associations qui vous tiennent à cœur',
+		description: hpResult?.data?.attributes?.metaDescription
+			|| 'Plateforme de dons et mécénat pour les associations sportives, humanitaires, sociales et culturelles.',
 		publisher: {
 			'@type': 'Organization',
 			name: 'Nakaa',

--- a/donaction-frontend/src/app/(main)/politique-de-confidentialite/page.tsx
+++ b/donaction-frontend/src/app/(main)/politique-de-confidentialite/page.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { getCookies } from '@/core/services/cms';
 import RichTextBlock from '@/components/RichTextBlock';
 import { notFound } from 'next/navigation';
-import { SITE_URL } from '@/core/services/endpoints';
+import { SITE_URL, OG_DEFAULT_IMAGE } from '@/core/services/endpoints';
 import { WebPage, WithContext } from 'schema-dts';
 import { cookies } from 'next/headers';
 
@@ -21,7 +21,7 @@ export async function generateMetadata() {
 			siteName: 'Donaction',
 			images: [
 				{
-					url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+					url: OG_DEFAULT_IMAGE,
 					width: 800,
 					height: 385,
 					alt: 'Politique de confidentialité',
@@ -59,7 +59,7 @@ export default async function Page() {
 		datePublished: '2024-10-16',
 		image: {
 			'@type': 'ImageObject',
-			url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+			url: OG_DEFAULT_IMAGE,
 			width: '800',
 			height: '385',
 		},

--- a/donaction-frontend/src/app/(main)/profile/page.tsx
+++ b/donaction-frontend/src/app/(main)/profile/page.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { getAvatars } from '@/core/services/auth';
 import ProfilePage from '@/partials/profilePage';
 import { WebPage, WithContext } from 'schema-dts';
-import { SITE_URL } from '@/core/services/endpoints';
+import { SITE_URL, OG_DEFAULT_IMAGE } from '@/core/services/endpoints';
 import { cookies } from 'next/headers';
 import { Metadata } from 'next';
 
@@ -35,7 +35,7 @@ export default async function Page() {
 		datePublished: '2024-10-16',
 		image: {
 			'@type': 'ImageObject',
-			url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+			url: OG_DEFAULT_IMAGE,
 			width: '800',
 			height: '385',
 		},

--- a/donaction-frontend/src/app/(main)/profile/page.tsx
+++ b/donaction-frontend/src/app/(main)/profile/page.tsx
@@ -8,6 +8,7 @@ import { Metadata } from 'next';
 
 export const metadata: Metadata = {
 	title: 'Mon profil',
+	description: 'Gérez votre profil et vos préférences sur Donaction.',
 	robots: { index: false, follow: false },
 };
 

--- a/donaction-frontend/src/app/(main)/profile/page.tsx
+++ b/donaction-frontend/src/app/(main)/profile/page.tsx
@@ -4,6 +4,12 @@ import ProfilePage from '@/partials/profilePage';
 import { WebPage, WithContext } from 'schema-dts';
 import { SITE_URL } from '@/core/services/endpoints';
 import { cookies } from 'next/headers';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Mon profil',
+	robots: { index: false, follow: false },
+};
 
 export default async function Page() {
 	const womenAvatars = await getAvatars('women', 1, 10, cookies().toString());

--- a/donaction-frontend/src/app/(main)/projets/page.tsx
+++ b/donaction-frontend/src/app/(main)/projets/page.tsx
@@ -15,20 +15,21 @@ import { WebPage, WithContext } from 'schema-dts';
 import { cookies } from 'next/headers';
 
 export const metadata: Metadata = {
-	title: 'Des projets de clubs sportifs à soutenir',
+	title: 'Des projets associatifs à soutenir',
 	description:
-		'Découvrez tous les projets des clubs sportifs inscrits sur Klubr et soutenez-les en faisant un don. Votre contribution permettra de concrétiser des projets.',
+		'Découvrez les projets des associations inscrites sur Donaction et soutenez-les en faisant un don. Votre contribution permettra de concrétiser des projets sportifs, humanitaires, sociaux et culturels.',
 	openGraph: {
-		title: `Des projets de clubs sportifs à soutenir`,
-		description: `Découvrez tous les projets des clubs sportifs inscrits sur Klubr et soutenez-les en faisant un don. Votre contribution permettra de concrétiser des projets.`,
+		title: 'Des projets associatifs à soutenir',
+		description:
+			'Découvrez les projets des associations inscrites sur Donaction et soutenez-les en faisant un don. Votre contribution permettra de concrétiser des projets sportifs, humanitaires, sociaux et culturels.',
 		url: `${new URL(SITE_URL)}/projets`,
 		siteName: 'Donaction',
 		images: [
 			{
 				url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
-				width: 800,
-				height: 385,
-				alt: 'Des projets de clubs sportifs à soutenir',
+				width: 1200,
+				height: 628,
+				alt: 'Des projets associatifs à soutenir - Donaction',
 			},
 		],
 		locale: 'fr_FR',
@@ -48,9 +49,9 @@ export default async function page() {
 		'@context': 'https://schema.org',
 		'@type': 'WebPage',
 		url: `${SITE_URL}/projets`,
-		name: 'Des projets de clubs sportifs à soutenir',
+		name: 'Des projets associatifs à soutenir',
 		description:
-			'Découvrez tous les projets des clubs sportifs inscrits sur Klubr et soutenez-les en faisant un don. Votre contribution permettra de concrétiser des projets.',
+			'Découvrez les projets des associations inscrites sur Donaction et soutenez-les en faisant un don. Votre contribution permettra de concrétiser des projets sportifs, humanitaires, sociaux et culturels.',
 		publisher: {
 			'@type': 'Organization',
 			name: 'Nakaa',

--- a/donaction-frontend/src/app/(main)/projets/page.tsx
+++ b/donaction-frontend/src/app/(main)/projets/page.tsx
@@ -10,7 +10,7 @@ import PaginatedProjectsList from 'src/layouts/partials/common/paginatedProjects
 import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
 import GetServerCookie from '@/core/helpers/getServerCookie';
-import { SITE_URL } from '@/core/services/endpoints';
+import { SITE_URL, OG_DEFAULT_IMAGE } from '@/core/services/endpoints';
 import { WebPage, WithContext } from 'schema-dts';
 import { cookies } from 'next/headers';
 
@@ -26,7 +26,7 @@ export const metadata: Metadata = {
 		siteName: 'Donaction',
 		images: [
 			{
-				url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+				url: OG_DEFAULT_IMAGE,
 				width: 1200,
 				height: 628,
 				alt: 'Des projets associatifs à soutenir - Donaction',
@@ -66,7 +66,7 @@ export default async function page() {
 		datePublished: '2024-10-16',
 		image: {
 			'@type': 'ImageObject',
-			url: 'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg',
+			url: OG_DEFAULT_IMAGE,
 			width: '800',
 			height: '385',
 		},

--- a/donaction-frontend/src/app/[slug]/nos-projets/[projectSlug]/page.tsx
+++ b/donaction-frontend/src/app/[slug]/nos-projets/[projectSlug]/page.tsx
@@ -85,6 +85,9 @@ export async function generateMetadata(
 		description:
 			projet.metaDescription ||
 			`${projet.klubr.denomination} - Soutenez le projet "${projet.titre}"`,
+		alternates: {
+			canonical: `/${params.slug}/nos-projets/${params.projectSlug}`,
+		},
 		openGraph: {
 			title: `${klub.denomination} | ${projet.titre}`,
 			description:

--- a/donaction-frontend/src/app/[slug]/nos-projets/[projectSlug]/page.tsx
+++ b/donaction-frontend/src/app/[slug]/nos-projets/[projectSlug]/page.tsx
@@ -27,7 +27,7 @@ import StatusIndicator from '@/partials/common/statusIndicator';
 import { getServerSession } from 'next-auth';
 import { SITE_URL } from '@/core/services/endpoints';
 import { getDonsByKlubOrProjet } from '@/core/services/don';
-import { SportsEvent, WithContext } from 'schema-dts';
+import { Event, WithContext } from 'schema-dts';
 import { endOfDay, format, isAfter } from 'date-fns';
 import frLocale from 'date-fns/locale/fr';
 import SponsorshipForm from '@/partials/_sponsorshipForm';
@@ -211,9 +211,9 @@ export default async function ProjectPage({
 		(_) => _.__component === 'club-presentation.localisation',
 	);
 
-	const jsonLd: WithContext<SportsEvent> = {
+	const jsonLd: WithContext<Event> = {
 		'@context': 'https://schema.org',
-		'@type': 'SportsEvent',
+		'@type': 'Event',
 		name: `${klub.denomination} | ${projet.titre}`,
 		description:
 			projet.metaDescription ||
@@ -243,7 +243,6 @@ export default async function ProjectPage({
 			longitude: localisation?.googleMap?.lng,
 			latitude: localisation?.googleMap?.lat,
 		},
-		sport: projet.sportType,
 		organizer: [
 			{
 				'@type': 'Person',
@@ -256,7 +255,7 @@ export default async function ProjectPage({
 				},
 			},
 			{
-				'@type': 'SportsClub',
+				'@type': 'Organization',
 				name: klub.denomination,
 				description: klubHouse.metaDescription,
 				url: `${SITE_URL}/${params.slug}`,
@@ -294,7 +293,7 @@ export default async function ProjectPage({
 					url: `${SITE_URL}/${params.slug}/${params.projectSlug}`,
 				},
 				{
-					'@type': 'SportsClub',
+					'@type': 'Organization',
 					name: klub.denomination,
 					description: klubHouse.metaDescription,
 					url: `${SITE_URL}/${params.slug}`,

--- a/donaction-frontend/src/app/[slug]/nos-projets/page.tsx
+++ b/donaction-frontend/src/app/[slug]/nos-projets/page.tsx
@@ -126,7 +126,7 @@ export default async function OurProjectsPage({ params }: { params: { slug: stri
 					<Link href={`/${klub.slug}`} className='flex items-center gap-2 px-6 md:px-0'>
 						<Image src={arrowCircleLeft as string} alt='arrow-circle-left' />
 						<p className='font-bold md:text-3xl text-xl'>
-							{klub?.denomination || 'Klubr'}: Nos projets
+							{klub?.denomination || 'Association'}: Nos projets
 						</p>
 					</Link>
 					{result?.data?.length > 0 ? (

--- a/donaction-frontend/src/app/[slug]/nos-projets/page.tsx
+++ b/donaction-frontend/src/app/[slug]/nos-projets/page.tsx
@@ -44,8 +44,13 @@ export async function generateMetadata({ params }: { params: { slug: string } })
 	});
 	return {
 		title: `${klub?.denomination || ''} | Nos projets`,
+		description: `Découvrez les projets de ${klub?.denomination || 'ce club'} et soutenez-les.`,
+		alternates: {
+			canonical: `/${params.slug}/nos-projets`,
+		},
 		openGraph: {
 			title: `${klub?.denomination || ''} | Nos projets`,
+			description: `Découvrez les projets de ${klub?.denomination || 'ce club'} et soutenez-les.`,
 			url: `${new URL(SITE_URL)}/${params.slug}/nos-projets`,
 			siteName: 'Donaction',
 			images: [

--- a/donaction-frontend/src/app/[slug]/page.tsx
+++ b/donaction-frontend/src/app/[slug]/page.tsx
@@ -95,6 +95,9 @@ export async function generateMetadata({ params }: { params: { slug: string } })
 		title: klub.denomination,
 		description:
 			klubHouse.metaDescription || `${klub.denomination} - Soutenez nous grâce au mécénat!`,
+		alternates: {
+			canonical: `/${params.slug}`,
+		},
 		openGraph: {
 			title: klub.denomination,
 			description:

--- a/donaction-frontend/src/app/[slug]/page.tsx
+++ b/donaction-frontend/src/app/[slug]/page.tsx
@@ -224,7 +224,7 @@ export default async function club({ params }: { params: { slug: string } }) {
 				url: `${SITE_URL}/${params.slug}?PAYEMENT_FORM=true`,
 				target: `${SITE_URL}/${params.slug}?PAYEMENT_FORM=true`,
 				recipient: {
-					'@type': 'SportsClub',
+					'@type': 'Organization',
 					name: klub.denomination,
 					url: `${SITE_URL}/${params.slug}`,
 					address: {
@@ -240,7 +240,7 @@ export default async function club({ params }: { params: { slug: string } }) {
 		: [];
 	const jsonLd = {
 		'@context': 'https://schema.org',
-		'@type': 'SportsClub',
+		'@type': 'Organization',
 		name: klub.denomination,
 		description:
 			klubHouse.metaDescription || `${klub.denomination} - Soutenez nous grâce au mécénat!`,

--- a/donaction-frontend/src/app/forbidden/page.tsx
+++ b/donaction-frontend/src/app/forbidden/page.tsx
@@ -7,6 +7,12 @@ import forbidden403 from '../../../public/animations/403.json';
 import Link from 'next/link';
 import { getServerSession } from 'next-auth';
 import { cookies } from 'next/headers';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+	title: 'Accès interdit',
+	robots: { index: false, follow: false },
+};
 
 export default async function page() {
 	const slugs = await getClubsSlugs(5, cookies().toString()).catch((error) => {

--- a/donaction-frontend/src/app/forbidden/page.tsx
+++ b/donaction-frontend/src/app/forbidden/page.tsx
@@ -11,6 +11,7 @@ import { Metadata } from 'next';
 
 export const metadata: Metadata = {
 	title: 'Accès interdit',
+	description: 'Vous n\'avez pas les droits nécessaires pour accéder à cette page.',
 	robots: { index: false, follow: false },
 };
 

--- a/donaction-frontend/src/app/layout.tsx
+++ b/donaction-frontend/src/app/layout.tsx
@@ -14,16 +14,16 @@ import * as process from 'node:process';
 export const metadata: Metadata = {
 	metadataBase: new URL(SITE_URL),
 	title: {
-		template: '%s | Klubr',
-		default: 'Klubr', // a default is required when creating a template
+		template: '%s | Donaction',
+		default: 'Donaction',
 	},
 	description:
-		'Donaction - Plateforme de dons et mécénat pour les clubs sportifs. Soutenez vos clubs préférés et leurs projets.',
-	generator: 'Klubr Website',
-	applicationName: 'Klubr Website',
+		'Donaction - Plateforme de dons et mécénat pour les associations sportives, humanitaires, sociales et culturelles. Soutenez vos associations préférées et leurs projets.',
+	generator: 'Donaction',
+	applicationName: 'Donaction',
 	// referrer: 'origin-when-cross-origin',
 	authors: [{ name: 'Karim Z.', url: 'https://nakaa.fr' }],
-	creator: 'Klubr',
+	creator: 'Donaction',
 	publisher: 'Karim Z.',
 	formatDetection: {
 		email: false,
@@ -60,7 +60,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
 		'@context': 'https://schema.org',
 		'@type': 'WebSite',
 		url: SITE_URL,
-		name: 'Klubr website',
+		name: 'Donaction',
 		publisher: {
 			'@type': 'Organization',
 			name: 'Nakaa',

--- a/donaction-frontend/src/app/layout.tsx
+++ b/donaction-frontend/src/app/layout.tsx
@@ -3,7 +3,7 @@ import theme from '@/config/theme.json';
 import Providers from '@/app/Providers';
 import '@/styles/main.scss';
 import { Metadata } from 'next';
-import { SITE_URL } from '@/core/services/endpoints';
+import { SITE_URL, OG_DEFAULT_IMAGE } from '@/core/services/endpoints';
 import PopAuth from '@/partials/authentication/popAuth';
 import Toaster from 'src/layouts/components/toaster';
 import React from 'react';
@@ -47,7 +47,7 @@ export const metadata: Metadata = {
 	},
 	twitter: {
 		card: 'summary_large_image',
-		images: ['https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg'],
+		images: [OG_DEFAULT_IMAGE],
 	},
 	alternates: {
 		canonical: './',

--- a/donaction-frontend/src/app/layout.tsx
+++ b/donaction-frontend/src/app/layout.tsx
@@ -47,6 +47,7 @@ export const metadata: Metadata = {
 	},
 	twitter: {
 		card: 'summary_large_image',
+		images: ['https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg'],
 	},
 	alternates: {
 		canonical: './',

--- a/donaction-frontend/src/app/layout.tsx
+++ b/donaction-frontend/src/app/layout.tsx
@@ -17,6 +17,8 @@ export const metadata: Metadata = {
 		template: '%s | Klubr',
 		default: 'Klubr', // a default is required when creating a template
 	},
+	description:
+		'Donaction - Plateforme de dons et mécénat pour les clubs sportifs. Soutenez vos clubs préférés et leurs projets.',
 	generator: 'Klubr Website',
 	applicationName: 'Klubr Website',
 	// referrer: 'origin-when-cross-origin',
@@ -28,7 +30,6 @@ export const metadata: Metadata = {
 		address: false,
 		telephone: false,
 	},
-	// viewport: 'width=device-width, initial-scale=1, maximum-scale=5',
 	icons: {
 		icon: [
 			{
@@ -37,15 +38,19 @@ export const metadata: Metadata = {
 				sizes: '128x128',
 				url: config.site.favicon_png,
 			},
-			// {
-			// 	rel: "icon",
-			// 	type: "image/ico",
-			// 	url: config.site.favicon,
-			// },
 		],
 	},
-	// locale: 'fr_FR',
-	// type: 'website',
+	openGraph: {
+		locale: 'fr_FR',
+		type: 'website',
+		siteName: 'Donaction',
+	},
+	twitter: {
+		card: 'summary_large_image',
+	},
+	alternates: {
+		canonical: './',
+	},
 };
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {

--- a/donaction-frontend/src/app/robots.tsx
+++ b/donaction-frontend/src/app/robots.tsx
@@ -1,22 +1,23 @@
-import { MetadataRoute } from 'next'
-import { SITE_URL } from "@/core/services/endpoints";
+import { MetadataRoute } from 'next';
+import { SITE_URL } from '@/core/services/endpoints';
 
 export default function robots(): MetadataRoute.Robots {
-	const robots: MetadataRoute.Robots = process.env.ENVIRONMENT === 'prod'
-		? {
-			rules: {
-				userAgent: '*',
-				allow: '/',
-				disallow: '/private/',
-			},
-			sitemap: `${SITE_URL}/sitemap.xml`,
-		}
-		: {
-			rules: {
-				userAgent: '*',
-				disallow: '/',
-			},
-			sitemap: `${SITE_URL}/sitemap.xml`,
-		}
+	const robots: MetadataRoute.Robots =
+		process.env.ENVIRONMENT === 'prod'
+			? {
+					rules: {
+						userAgent: '*',
+						allow: '/',
+						disallow: ['/private/', '/profile', '/mes-dons', '/forbidden', '/new-club/congratulations', '/google-signin'],
+					},
+					sitemap: `${SITE_URL}/sitemap.xml`,
+				}
+			: {
+					rules: {
+						userAgent: '*',
+						disallow: '/',
+					},
+					sitemap: `${SITE_URL}/sitemap.xml`,
+				};
 	return robots;
 }

--- a/donaction-frontend/src/app/sitemap.tsx
+++ b/donaction-frontend/src/app/sitemap.tsx
@@ -63,7 +63,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			url: `${SITE_URL}/mecenat`,
 			lastModified: new Date(),
 			changeFrequency: 'monthly',
-			priority: 0.7,
+			priority: 0.8,
 		},
 		{
 			url: `${SITE_URL}/contact`,

--- a/donaction-frontend/src/app/sitemap.tsx
+++ b/donaction-frontend/src/app/sitemap.tsx
@@ -16,14 +16,14 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 			{
 				url: `${SITE_URL}/${klubSlugs.slug}`,
 				lastModified: klubSlugs.updatedAt,
-				// changeFrequency: 'monthly',
-				// priority: 1,
+				changeFrequency: 'monthly',
+				priority: 0.8,
 			},
 			{
 				url: `${SITE_URL}/${klubSlugs.slug}/nos-projets`,
 				lastModified: klubSlugs.updatedAt,
-				// changeFrequency: 'monthly',
-				// priority: 0.5,
+				changeFrequency: 'monthly',
+				priority: 0.5,
 			},
 		];
 	});
@@ -36,28 +36,52 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 	const projects: MetadataRoute.Sitemap = projectsSugs.map((projectSlugs) => ({
 		url: `${SITE_URL}/${projectSlugs.klubSlug}/nos-projets/${projectSlugs.slug}`,
 		lastModified: projectSlugs.updatedAt,
-		// changeFrequency: 'weekly',
-		// priority: 0.8,
+		changeFrequency: 'weekly',
+		priority: 0.8,
 	}));
 
 	return [
 		{
 			url: `${SITE_URL}`,
 			lastModified: new Date(),
-			// changeFrequency: 'yearly',
-			// priority: 1,
+			changeFrequency: 'weekly',
+			priority: 1,
+		},
+		{
+			url: `${SITE_URL}/clubs`,
+			lastModified: new Date(),
+			changeFrequency: 'daily',
+			priority: 0.9,
+		},
+		{
+			url: `${SITE_URL}/projets`,
+			lastModified: new Date(),
+			changeFrequency: 'daily',
+			priority: 0.9,
 		},
 		{
 			url: `${SITE_URL}/mecenat`,
 			lastModified: new Date(),
-			// changeFrequency: 'monthly',
-			// priority: 1,
+			changeFrequency: 'monthly',
+			priority: 0.7,
 		},
 		{
 			url: `${SITE_URL}/contact`,
 			lastModified: new Date(),
-			// changeFrequency: 'yearly',
-			// priority: 1,
+			changeFrequency: 'yearly',
+			priority: 0.5,
+		},
+		{
+			url: `${SITE_URL}/politique-de-confidentialite`,
+			lastModified: new Date(),
+			changeFrequency: 'yearly',
+			priority: 0.3,
+		},
+		{
+			url: `${SITE_URL}/conditions-generales-d-utilisation`,
+			lastModified: new Date(),
+			changeFrequency: 'yearly',
+			priority: 0.3,
 		},
 		...klubs,
 		...projects,

--- a/donaction-frontend/src/core/services/endpoints.ts
+++ b/donaction-frontend/src/core/services/endpoints.ts
@@ -1,5 +1,11 @@
 // ENDPOINTS LIST
 export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://notavailable';
+
+/* SEO */
+export const OG_DEFAULT_IMAGE =
+	'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/donaction_home_page.jpg';
+export const OG_MECENAT_IMAGE =
+	'https://ik.imagekit.io/donaction/tr:w-1200,ar-1.91-1/Pages/mecenat-donaction.png';
 export const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
 export const BASE_URL_SC_DEV = process.env.NEXT_PUBLIC_SERVER_COMPONENTS_DEV_API_URL; // SC; Server components
 export const BASE_URL_SC_PROD = process.env.NEXT_PUBLIC_SERVER_COMPONENTS_DEV_API_URL; // SC; Server components


### PR DESCRIPTION
## Summary
- Add canonical URLs, Twitter cards, and missing meta descriptions across all pages
- Add `robots: noindex` to authenticated/utility pages (profile, mes-dons, forbidden, congratulations)
- Complete sitemap with missing static routes (`/clubs`, `/projets`, legal pages) and priorities
- Update robots.txt to disallow auth routes
- Fix broken OG image URLs on auth pages
- Fix image sizes config in next.config.js (moved inside `images` block, standard breakpoints)
- Rebrand all SEO content from "Klubr" to "Donaction"
- Generalize messaging from "clubs sportifs" to all association types (sportives, humanitaires, sociales, culturelles)
- Change JSON-LD schema types: `SportsClub` → `Organization`, `SportsEvent` → `Event`
- Fix mecenat page fallback title bug ("Politique de confidentialité" → "Le mécénat simplifié")

## Test plan
- [ ] Verify `<title>` tags render with `| Donaction` suffix on all pages
- [ ] Check OG meta tags with social media debugger (Facebook, Twitter)
- [ ] Validate sitemap.xml includes all public routes with priorities
- [ ] Confirm robots.txt disallows auth routes in production mode
- [ ] Verify authenticated pages have `noindex` robots directive
- [ ] Validate JSON-LD structured data with Google Rich Results Test
- [ ] Check canonical URLs resolve correctly on dynamic club/project pages

Closes #119