### PR TITLE
fix: resolve fee calculation mismatch between SaaS widget and backend

### DIFF
--- a/donaction-api/src/_types.ts
+++ b/donaction-api/src/_types.ts
@@ -41,7 +41,9 @@ export type TemplateProjectsLibraryEntity =
     Data.ContentType<'api::template-projects-library.template-projects-library'>;
 export type TradePolicyEntity =
     Data.ContentType<'api::trade-policy.trade-policy'> & {
+        /** Stripe processing fee rate, stored as percentage (e.g. 1.5 for 1.5%) */
         stripe_fee_percentage?: number;
+        /** Stripe fixed fee per transaction in euros (e.g. 0.25 for €0.25) */
         stripe_fee_fixed?: number;
     };
 export type ConnectedAccountEntity =

--- a/donaction-api/src/_types.ts
+++ b/donaction-api/src/_types.ts
@@ -40,7 +40,10 @@ export type TemplateProjectsCategoryEntity =
 export type TemplateProjectsLibraryEntity =
     Data.ContentType<'api::template-projects-library.template-projects-library'>;
 export type TradePolicyEntity =
-    Data.ContentType<'api::trade-policy.trade-policy'>;
+    Data.ContentType<'api::trade-policy.trade-policy'> & {
+        stripe_fee_percentage?: number;
+        stripe_fee_fixed?: number;
+    };
 export type ConnectedAccountEntity =
     Data.ContentType<'api::connected-account.connected-account'>;
 export type FinancialAuditLogEntity =

--- a/donaction-api/src/api/klub-don-payment/controllers/klub-don-payment.ts
+++ b/donaction-api/src/api/klub-don-payment/controllers/klub-don-payment.ts
@@ -89,7 +89,7 @@ export default factories.createCoreController(
             await this.validateQuery(ctx);
             await this.sanitizeQuery(ctx);
             try {
-                const { price, metadata, idempotencyKey, donorPaysFee, donationAmount } =
+                const { price, metadata, idempotencyKey, donorPaysFee } =
                     ctx.request.body;
 
                 if (!price || !metadata || !metadata?.donUuid) {
@@ -143,27 +143,38 @@ export default factories.createCoreController(
                     klubr.connected_account as ConnectedAccountEntity;
                 const useStripeConnect = tradePolicy?.stripe_connect ?? false;
 
-                // Base amount = price (donation + contribution) in cents
-                let amountInCents = Number(price) * 100;
-                let applicationFeeAmount = 0;
+                // Fetch don record to derive trusted donation amount from DB
+                // (never trust client-provided donationAmount for fee calculation)
+                const don: KlubDonEntity = await strapi.db
+                    .query('api::klub-don.klub-don')
+                    .findOne({
+                        where: { uuid: metadata.donUuid },
+                    });
 
-                // Use donationAmount for fee calculation (excludes contribution)
-                // Falls back to price for backward compatibility
-                // Validate: donationAmount must be positive and ≤ price
-                const rawDonation = donationAmount ?? price;
-                if (
-                    typeof rawDonation !== 'number' ||
-                    isNaN(rawDonation) ||
-                    rawDonation <= 0 ||
-                    rawDonation > Number(price)
-                ) {
+                if (!don) {
+                    return ctx.badRequest('Don introuvable');
+                }
+
+                const trustedDonation = Number(don.montant);
+                const trustedContribution = Number(don.contributionAKlubr || 0);
+                const expectedPrice = trustedDonation + trustedContribution;
+
+                // Cross-check client price against DB (tolerance: 1 cent)
+                if (Math.abs(Number(price) - expectedPrice) > 0.01) {
+                    console.error(
+                        `⚠️ Price mismatch: client=${price}, expected=${expectedPrice} (don=${metadata.donUuid})`
+                    );
                     return ctx.badRequest(
-                        'Montant de donation invalide'
+                        'Montant incohérent avec le don enregistré'
                     );
                 }
-                const baseDonationCents = Math.round(
-                    Number(rawDonation) * 100
-                );
+
+                // Base amount = total price (donation + contribution) in cents
+                let amountInCents = Math.round(expectedPrice * 100);
+                let applicationFeeAmount = 0;
+
+                // Fee base = donation amount only (excludes contribution)
+                const baseDonationCents = Math.round(trustedDonation * 100);
 
                 // Stripe Connect path
                 if (useStripeConnect) {

--- a/donaction-api/src/api/klub-don-payment/controllers/klub-don-payment.ts
+++ b/donaction-api/src/api/klub-don-payment/controllers/klub-don-payment.ts
@@ -149,8 +149,20 @@ export default factories.createCoreController(
 
                 // Use donationAmount for fee calculation (excludes contribution)
                 // Falls back to price for backward compatibility
+                // Validate: donationAmount must be positive and ≤ price
+                const rawDonation = donationAmount ?? price;
+                if (
+                    typeof rawDonation !== 'number' ||
+                    isNaN(rawDonation) ||
+                    rawDonation <= 0 ||
+                    rawDonation > Number(price)
+                ) {
+                    return ctx.badRequest(
+                        'Montant de donation invalide'
+                    );
+                }
                 const baseDonationCents = Math.round(
-                    Number(donationAmount || price) * 100
+                    Number(rawDonation) * 100
                 );
 
                 // Stripe Connect path

--- a/donaction-api/src/api/klub-don-payment/controllers/klub-don-payment.ts
+++ b/donaction-api/src/api/klub-don-payment/controllers/klub-don-payment.ts
@@ -89,7 +89,7 @@ export default factories.createCoreController(
             await this.validateQuery(ctx);
             await this.sanitizeQuery(ctx);
             try {
-                const { price, metadata, idempotencyKey, donorPaysFee } =
+                const { price, metadata, idempotencyKey, donorPaysFee, donationAmount } =
                     ctx.request.body;
 
                 if (!price || !metadata || !metadata?.donUuid) {
@@ -143,9 +143,15 @@ export default factories.createCoreController(
                     klubr.connected_account as ConnectedAccountEntity;
                 const useStripeConnect = tradePolicy?.stripe_connect ?? false;
 
-                // Calculate base amount in cents
+                // Base amount = price (donation + contribution) in cents
                 let amountInCents = Number(price) * 100;
                 let applicationFeeAmount = 0;
+
+                // Use donationAmount for fee calculation (excludes contribution)
+                // Falls back to price for backward compatibility
+                const baseDonationCents = Math.round(
+                    Number(donationAmount || price) * 100
+                );
 
                 // Stripe Connect path
                 if (useStripeConnect) {
@@ -168,10 +174,11 @@ export default factories.createCoreController(
                         );
                     }
 
-                    // Calculate application fee
+                    // Calculate application fee on base donation amount
+                    // Includes platform commission + estimated Stripe processing fees
                     if (tradePolicy) {
                         applicationFeeAmount = calculateApplicationFee(
-                            amountInCents,
+                            baseDonationCents,
                             tradePolicy
                         );
 

--- a/donaction-api/src/api/klubr-subscription/controllers/klubr-subscription.ts
+++ b/donaction-api/src/api/klubr-subscription/controllers/klubr-subscription.ts
@@ -294,6 +294,13 @@ export default factories.createCoreController(
                 res.project = project;
             }
 
+            // Normalize stripe_fee_percentage to decimal for API consumers
+            // DB stores as percentage (e.g. 1.5 for 1.5%), API returns decimal (0.015)
+            const tp = res.klubr?.trade_policy;
+            if (tp?.stripe_fee_percentage != null) {
+                tp.stripe_fee_percentage = tp.stripe_fee_percentage / 100;
+            }
+
             return res;
         },
     }),

--- a/donaction-api/src/api/klubr-subscription/controllers/klubr-subscription.ts
+++ b/donaction-api/src/api/klubr-subscription/controllers/klubr-subscription.ts
@@ -239,6 +239,8 @@ export default factories.createCoreController(
                             'donor_pays_fee_project',
                             'donor_pays_fee_club',
                             'commissionPercentage',
+                            'stripe_fee_percentage',
+                            'stripe_fee_fixed',
                         ],
                     },
                 },

--- a/donaction-api/src/api/trade-policy/content-types/trade-policy/schema.json
+++ b/donaction-api/src/api/trade-policy/content-types/trade-policy/schema.json
@@ -110,12 +110,12 @@
     "stripe_fee_percentage": {
       "type": "decimal",
       "default": 1.5,
-      "required": true
+      "required": false
     },
     "stripe_fee_fixed": {
       "type": "decimal",
       "default": 0.25,
-      "required": true
+      "required": false
     }
   }
 }

--- a/donaction-api/src/api/trade-policy/content-types/trade-policy/schema.json
+++ b/donaction-api/src/api/trade-policy/content-types/trade-policy/schema.json
@@ -106,6 +106,16 @@
       "type": "boolean",
       "default": true,
       "required": false
+    },
+    "stripe_fee_percentage": {
+      "type": "decimal",
+      "default": 1.5,
+      "required": true
+    },
+    "stripe_fee_fixed": {
+      "type": "decimal",
+      "default": 0.25,
+      "required": true
     }
   }
 }

--- a/donaction-api/src/helpers/stripe-connect-helper.test.ts
+++ b/donaction-api/src/helpers/stripe-connect-helper.test.ts
@@ -175,7 +175,7 @@ describe('estimateStripeFees', () => {
         expect(fees).toBe(175);
     });
 
-    it('uses custom stripe_fee_percentage from policy', () => {
+    it('uses custom stripe_fee_percentage from policy (fixed fee falls back to default €0.25)', () => {
         const fees = estimateStripeFees(
             10000,
             makePolicy({ stripe_fee_percentage: 2.9 })
@@ -184,7 +184,7 @@ describe('estimateStripeFees', () => {
         expect(fees).toBe(315);
     });
 
-    it('uses custom stripe_fee_fixed from policy', () => {
+    it('uses custom stripe_fee_fixed from policy (percentage falls back to default 1.5%)', () => {
         const fees = estimateStripeFees(
             10000,
             makePolicy({ stripe_fee_fixed: 0.50 })
@@ -209,6 +209,24 @@ describe('estimateStripeFees', () => {
         );
         // (999 * 1.5 / 100) + 25 = 14.985 + 25 = 39.985 → 40
         expect(fees).toBe(40);
+    });
+
+    it('throws on negative stripe_fee_percentage', () => {
+        expect(() =>
+            estimateStripeFees(10000, makePolicy({ stripe_fee_percentage: -1 }))
+        ).toThrow('Pourcentage de frais Stripe invalide');
+    });
+
+    it('throws on stripe_fee_percentage > 100', () => {
+        expect(() =>
+            estimateStripeFees(10000, makePolicy({ stripe_fee_percentage: 101 }))
+        ).toThrow('Pourcentage de frais Stripe invalide');
+    });
+
+    it('throws on negative stripe_fee_fixed', () => {
+        expect(() =>
+            estimateStripeFees(10000, makePolicy({ stripe_fee_fixed: -0.5 }))
+        ).toThrow('Frais fixes Stripe invalides');
     });
 });
 

--- a/donaction-api/src/helpers/stripe-connect-helper.test.ts
+++ b/donaction-api/src/helpers/stripe-connect-helper.test.ts
@@ -5,7 +5,11 @@ import { TradePolicyEntity } from '../_types';
 vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_fake');
 vi.stubEnv('STRIPE_WEBHOOK_SECRET_CONNECT', 'whsec_fake');
 
-const { calculateApplicationFee } = await import('./stripe-connect-helper');
+const {
+    calculateApplicationFee,
+    calculatePlatformCommission,
+    estimateStripeFees,
+} = await import('./stripe-connect-helper');
 
 /** Helper to build a minimal TradePolicyEntity for tests */
 const makePolicy = (
@@ -13,19 +17,23 @@ const makePolicy = (
         fee_model: string;
         commissionPercentage: number;
         fixed_amount: number;
+        stripe_fee_percentage: number;
+        stripe_fee_fixed: number;
     }> = {}
 ): TradePolicyEntity =>
     ({
         fee_model: overrides.fee_model ?? 'percentage_only',
         commissionPercentage: overrides.commissionPercentage ?? 0,
         fixed_amount: overrides.fixed_amount ?? 0,
+        stripe_fee_percentage: overrides.stripe_fee_percentage,
+        stripe_fee_fixed: overrides.stripe_fee_fixed,
     }) as unknown as TradePolicyEntity;
 
-describe('calculateApplicationFee', () => {
+describe('calculatePlatformCommission', () => {
     // --- percentage_only ---
     describe('percentage_only model', () => {
         it('calculates 10% of 10000 cents = 1000', () => {
-            const fee = calculateApplicationFee(
+            const fee = calculatePlatformCommission(
                 10000,
                 makePolicy({ commissionPercentage: 10 })
             );
@@ -33,7 +41,7 @@ describe('calculateApplicationFee', () => {
         });
 
         it('calculates 5% of 999 cents with rounding', () => {
-            const fee = calculateApplicationFee(
+            const fee = calculatePlatformCommission(
                 999,
                 makePolicy({ commissionPercentage: 5 })
             );
@@ -42,7 +50,7 @@ describe('calculateApplicationFee', () => {
         });
 
         it('returns 0 when percentage is 0', () => {
-            const fee = calculateApplicationFee(
+            const fee = calculatePlatformCommission(
                 5000,
                 makePolicy({ commissionPercentage: 0 })
             );
@@ -50,7 +58,7 @@ describe('calculateApplicationFee', () => {
         });
 
         it('handles 100% commission', () => {
-            const fee = calculateApplicationFee(
+            const fee = calculatePlatformCommission(
                 5000,
                 makePolicy({ commissionPercentage: 100 })
             );
@@ -61,7 +69,7 @@ describe('calculateApplicationFee', () => {
     // --- fixed_only ---
     describe('fixed_only model', () => {
         it('converts fixed_amount euros to cents', () => {
-            const fee = calculateApplicationFee(
+            const fee = calculatePlatformCommission(
                 10000,
                 makePolicy({ fee_model: 'fixed_only', fixed_amount: 2.5 })
             );
@@ -70,7 +78,7 @@ describe('calculateApplicationFee', () => {
         });
 
         it('returns 0 when fixed_amount is 0', () => {
-            const fee = calculateApplicationFee(
+            const fee = calculatePlatformCommission(
                 10000,
                 makePolicy({ fee_model: 'fixed_only', fixed_amount: 0 })
             );
@@ -81,7 +89,7 @@ describe('calculateApplicationFee', () => {
     // --- percentage_plus_fixed ---
     describe('percentage_plus_fixed model', () => {
         it('adds percentage and fixed fees', () => {
-            const fee = calculateApplicationFee(
+            const fee = calculatePlatformCommission(
                 10000,
                 makePolicy({
                     fee_model: 'percentage_plus_fixed',
@@ -97,7 +105,7 @@ describe('calculateApplicationFee', () => {
     // --- default (unknown model) falls back to percentage ---
     describe('unknown fee_model defaults to percentage', () => {
         it('falls back to percentage calculation', () => {
-            const fee = calculateApplicationFee(
+            const fee = calculatePlatformCommission(
                 10000,
                 makePolicy({
                     fee_model: 'unknown_model' as any,
@@ -112,7 +120,7 @@ describe('calculateApplicationFee', () => {
     describe('validation', () => {
         it('throws on negative percentage', () => {
             expect(() =>
-                calculateApplicationFee(
+                calculatePlatformCommission(
                     10000,
                     makePolicy({ commissionPercentage: -1 })
                 )
@@ -121,7 +129,7 @@ describe('calculateApplicationFee', () => {
 
         it('throws on percentage > 100', () => {
             expect(() =>
-                calculateApplicationFee(
+                calculatePlatformCommission(
                     10000,
                     makePolicy({ commissionPercentage: 101 })
                 )
@@ -130,7 +138,7 @@ describe('calculateApplicationFee', () => {
 
         it('throws on negative fixed_amount', () => {
             expect(() =>
-                calculateApplicationFee(
+                calculatePlatformCommission(
                     10000,
                     makePolicy({
                         fee_model: 'fixed_only',
@@ -142,7 +150,7 @@ describe('calculateApplicationFee', () => {
 
         it('throws on zero amount', () => {
             expect(() =>
-                calculateApplicationFee(
+                calculatePlatformCommission(
                     0,
                     makePolicy({ commissionPercentage: 10 })
                 )
@@ -151,11 +159,108 @@ describe('calculateApplicationFee', () => {
 
         it('throws on negative amount', () => {
             expect(() =>
-                calculateApplicationFee(
+                calculatePlatformCommission(
                     -100,
                     makePolicy({ commissionPercentage: 10 })
                 )
             ).toThrow('Montant de donation invalide');
         });
+    });
+});
+
+describe('estimateStripeFees', () => {
+    it('uses default Stripe fees (1.5% + €0.25) when not set in policy', () => {
+        const fees = estimateStripeFees(10000, makePolicy());
+        // (10000 * 1.5 / 100) + (0.25 * 100) = 150 + 25 = 175
+        expect(fees).toBe(175);
+    });
+
+    it('uses custom stripe_fee_percentage from policy', () => {
+        const fees = estimateStripeFees(
+            10000,
+            makePolicy({ stripe_fee_percentage: 2.9 })
+        );
+        // (10000 * 2.9 / 100) + (0.25 * 100) = 290 + 25 = 315
+        expect(fees).toBe(315);
+    });
+
+    it('uses custom stripe_fee_fixed from policy', () => {
+        const fees = estimateStripeFees(
+            10000,
+            makePolicy({ stripe_fee_fixed: 0.50 })
+        );
+        // (10000 * 1.5 / 100) + (0.50 * 100) = 150 + 50 = 200
+        expect(fees).toBe(200);
+    });
+
+    it('uses both custom Stripe fee params from policy', () => {
+        const fees = estimateStripeFees(
+            10000,
+            makePolicy({ stripe_fee_percentage: 2.9, stripe_fee_fixed: 0.30 })
+        );
+        // (10000 * 2.9 / 100) + (0.30 * 100) = 290 + 30 = 320
+        expect(fees).toBe(320);
+    });
+
+    it('rounds to nearest cent', () => {
+        const fees = estimateStripeFees(
+            999,
+            makePolicy({ stripe_fee_percentage: 1.5, stripe_fee_fixed: 0.25 })
+        );
+        // (999 * 1.5 / 100) + 25 = 14.985 + 25 = 39.985 → 40
+        expect(fees).toBe(40);
+    });
+});
+
+describe('calculateApplicationFee (combined)', () => {
+    it('returns platform commission + estimated Stripe fees', () => {
+        const total = calculateApplicationFee(
+            10000,
+            makePolicy({ commissionPercentage: 4 })
+        );
+        // Commission: (10000 * 4 / 100) = 400
+        // Stripe: (10000 * 1.5 / 100) + 25 = 175
+        // Total: 400 + 175 = 575
+        expect(total).toBe(575);
+    });
+
+    it('returns only Stripe fees when commission is 0', () => {
+        const total = calculateApplicationFee(
+            10000,
+            makePolicy({ commissionPercentage: 0 })
+        );
+        // Commission: 0
+        // Stripe: 175
+        expect(total).toBe(175);
+    });
+
+    it('uses custom Stripe fees from trade policy', () => {
+        const total = calculateApplicationFee(
+            10000,
+            makePolicy({
+                commissionPercentage: 4,
+                stripe_fee_percentage: 2.9,
+                stripe_fee_fixed: 0.30,
+            })
+        );
+        // Commission: 400
+        // Stripe: (10000 * 2.9 / 100) + 30 = 290 + 30 = 320
+        // Total: 400 + 320 = 720
+        expect(total).toBe(720);
+    });
+
+    it('equals calculatePlatformCommission + estimateStripeFees', () => {
+        const policy = makePolicy({ commissionPercentage: 4 });
+        const total = calculateApplicationFee(10000, policy);
+        const commission = calculatePlatformCommission(10000, policy);
+        const stripe = estimateStripeFees(10000, policy);
+
+        expect(total).toBe(commission + stripe);
+    });
+
+    it('throws on invalid amount (delegates to calculatePlatformCommission)', () => {
+        expect(() =>
+            calculateApplicationFee(0, makePolicy({ commissionPercentage: 4 }))
+        ).toThrow('Montant de donation invalide');
     });
 });

--- a/donaction-api/src/helpers/stripe-connect-helper.ts
+++ b/donaction-api/src/helpers/stripe-connect-helper.ts
@@ -349,9 +349,16 @@ export function calculatePlatformCommission(
 }
 
 /**
- * Estimates Stripe processing fees for a given donation amount
+ * Estimates Stripe processing fees for a given donation amount.
+ *
+ * IMPORTANT: This is an **estimate** based on standard European card rates.
+ * Actual Stripe fees vary by card type (EU vs non-EU, credit vs debit, AMEX)
+ * and may differ from this calculation. If the estimate is too low, the platform
+ * absorbs the difference. A misconfigured stripe_fee_percentage of 0 would
+ * silently zero out Stripe fee recovery — validate inputs accordingly.
+ *
  * @param donationAmountCents - Donation amount in cents
- * @param tradePolicy - Trade policy entity (contains stripe_fee_percentage and stripe_fee_fixed)
+ * @param tradePolicy - Trade policy entity (stripe_fee_percentage stored as percentage, e.g. 1.5 for 1.5%)
  * @returns Estimated Stripe processing fees in cents
  */
 export function estimateStripeFees(

--- a/donaction-api/src/helpers/stripe-connect-helper.ts
+++ b/donaction-api/src/helpers/stripe-connect-helper.ts
@@ -290,14 +290,18 @@ export async function syncAccountStatus(
     return updated as ConnectedAccountEntity;
 }
 
+/** Default Stripe processing fee rates for European cards (France) */
+const DEFAULT_STRIPE_FEE_PERCENTAGE = 1.5;
+const DEFAULT_STRIPE_FEE_FIXED = 0.25;
+
 /**
- * Calculates application fee based on trade policy fee model
+ * Calculates platform commission based on trade policy fee model
  * @param amount - Donation amount in cents
  * @param tradePolicy - Trade policy entity
- * @returns Calculated fee amount in cents
+ * @returns Platform commission in cents (excludes Stripe processing fees)
  * @throws Error if fee parameters are invalid
  */
-export function calculateApplicationFee(
+export function calculatePlatformCommission(
     amount: number,
     tradePolicy: TradePolicyEntity
 ): number {
@@ -342,6 +346,43 @@ export function calculateApplicationFee(
     }
 
     return fee;
+}
+
+/**
+ * Estimates Stripe processing fees for a given donation amount
+ * @param donationAmountCents - Donation amount in cents
+ * @param tradePolicy - Trade policy entity (contains stripe_fee_percentage and stripe_fee_fixed)
+ * @returns Estimated Stripe processing fees in cents
+ */
+export function estimateStripeFees(
+    donationAmountCents: number,
+    tradePolicy: TradePolicyEntity
+): number {
+    const percentage = tradePolicy.stripe_fee_percentage ?? DEFAULT_STRIPE_FEE_PERCENTAGE;
+    const fixed = tradePolicy.stripe_fee_fixed ?? DEFAULT_STRIPE_FEE_FIXED;
+    return Math.round((donationAmountCents * percentage) / 100 + fixed * 100);
+}
+
+/**
+ * Calculates total application fee (platform commission + estimated Stripe fees)
+ *
+ * The application_fee_amount covers both DONACTION's commission and Stripe's
+ * processing fees. This ensures the association receives the expected net amount:
+ * - Scenario A (donor pays): association gets 100% of donation
+ * - Scenario B (fees included): fees are transparently deducted
+ *
+ * @param donationAmountCents - Base donation amount in cents (excluding contribution)
+ * @param tradePolicy - Trade policy entity
+ * @returns Total application fee in cents
+ * @throws Error if fee parameters are invalid
+ */
+export function calculateApplicationFee(
+    donationAmountCents: number,
+    tradePolicy: TradePolicyEntity
+): number {
+    const platformCommission = calculatePlatformCommission(donationAmountCents, tradePolicy);
+    const stripeFees = estimateStripeFees(donationAmountCents, tradePolicy);
+    return platformCommission + stripeFees;
 }
 
 /**

--- a/donaction-api/src/helpers/stripe-connect-helper.ts
+++ b/donaction-api/src/helpers/stripe-connect-helper.ts
@@ -360,6 +360,14 @@ export function estimateStripeFees(
 ): number {
     const percentage = tradePolicy.stripe_fee_percentage ?? DEFAULT_STRIPE_FEE_PERCENTAGE;
     const fixed = tradePolicy.stripe_fee_fixed ?? DEFAULT_STRIPE_FEE_FIXED;
+
+    if (percentage < 0 || percentage > 100) {
+        throw new Error('Pourcentage de frais Stripe invalide');
+    }
+    if (fixed < 0) {
+        throw new Error('Frais fixes Stripe invalides');
+    }
+
     return Math.round((donationAmountCents * percentage) / 100 + fixed * 100);
 }
 

--- a/donaction-saas/src/components/sponsorshipForm/__tests__/fee-calculation-helper.test.ts
+++ b/donaction-saas/src/components/sponsorshipForm/__tests__/fee-calculation-helper.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { STRIPE_FEES, calculateFees, FeeCalculationInput } from '../logic/fee-calculation-helper';
+import { STRIPE_FEES_DEFAULTS, calculateFees, FeeCalculationInput } from '../logic/fee-calculation-helper';
 
 describe('fee-calculation-helper test suite', () => {
-  describe('STRIPE_FEES constants', () => {
+  describe('STRIPE_FEES_DEFAULTS constants', () => {
     it('should have PERCENTAGE of 0.015 (1.5%)', () => {
-      expect(STRIPE_FEES.PERCENTAGE).toBe(0.015);
+      expect(STRIPE_FEES_DEFAULTS.PERCENTAGE).toBe(0.015);
     });
 
     it('should have FIXED fee of 0.25 euros', () => {
-      expect(STRIPE_FEES.FIXED).toBe(0.25);
+      expect(STRIPE_FEES_DEFAULTS.FIXED).toBe(0.25);
     });
   });
 
@@ -683,6 +683,127 @@ describe('fee-calculation-helper test suite', () => {
 
       expect(result.montantRecuFiscal).toBe(result.netAssociation);
       expect(result.montantRecuFiscal).toBe(input.montantDon);
+    });
+  });
+
+  describe('calculateFees - dynamic Stripe fee parameters', () => {
+    it('should use default Stripe fees when not provided', () => {
+      const input: FeeCalculationInput = {
+        montantDon: 100,
+        contribution: 0,
+        donorPaysFee: true,
+        commissionPercentage: 0.04,
+      };
+      const result = calculateFees(input);
+
+      // Default: 1.5% + €0.25
+      const expectedStripeFees = 100 * 0.015 + 0.25; // 1.75
+      expect(result.fraisStripeEstimes).toBe(expectedStripeFees);
+    });
+
+    it('should use custom Stripe fee percentage when provided', () => {
+      const input: FeeCalculationInput = {
+        montantDon: 100,
+        contribution: 0,
+        donorPaysFee: true,
+        commissionPercentage: 0.04,
+        stripeFeePercentage: 0.029, // 2.9% (non-EU card rate)
+        stripeFeeFixed: 0.25,
+      };
+      const result = calculateFees(input);
+
+      // 100 * 0.029 + 0.25 = 3.15 (rounded to cents)
+      expect(result.fraisStripeEstimes).toBe(3.15);
+    });
+
+    it('should use custom Stripe fixed fee when provided', () => {
+      const input: FeeCalculationInput = {
+        montantDon: 100,
+        contribution: 0,
+        donorPaysFee: true,
+        commissionPercentage: 0.04,
+        stripeFeePercentage: 0.015,
+        stripeFeeFixed: 0.50, // Custom fixed fee
+      };
+      const result = calculateFees(input);
+
+      const expectedStripeFees = 100 * 0.015 + 0.50; // 2.00
+      expect(result.fraisStripeEstimes).toBe(expectedStripeFees);
+    });
+
+    it('should calculate Scenario A correctly with custom Stripe fees', () => {
+      const input: FeeCalculationInput = {
+        montantDon: 100,
+        contribution: 2,
+        donorPaysFee: true,
+        commissionPercentage: 0.04,
+        stripeFeePercentage: 0.029,
+        stripeFeeFixed: 0.30,
+      };
+      const result = calculateFees(input);
+
+      const expectedCommission = 4;
+      const expectedStripeFees = 100 * 0.029 + 0.30; // 3.20
+      const expectedApplicationFee = expectedCommission + expectedStripeFees; // 7.20
+      const expectedTotal = 100 + expectedCommission + 2 + expectedStripeFees;
+
+      expect(result.commissionDonaction).toBe(expectedCommission);
+      expect(result.fraisStripeEstimes).toBe(expectedStripeFees);
+      expect(result.applicationFee).toBe(expectedApplicationFee);
+      expect(result.totalDonateur).toBe(expectedTotal);
+      expect(result.netAssociation).toBe(100);
+    });
+
+    it('should calculate Scenario B correctly with custom Stripe fees', () => {
+      const input: FeeCalculationInput = {
+        montantDon: 100,
+        contribution: 0,
+        donorPaysFee: false,
+        commissionPercentage: 0.04,
+        stripeFeePercentage: 0.029,
+        stripeFeeFixed: 0.30,
+      };
+      const result = calculateFees(input);
+
+      const expectedCommission = 4;
+      const expectedStripeFees = 100 * 0.029 + 0.30; // 3.20
+      const expectedApplicationFee = expectedCommission + expectedStripeFees; // 7.20
+      const expectedNetAssociation = 100 - expectedApplicationFee; // 92.80
+
+      expect(result.totalDonateur).toBe(100);
+      expect(result.netAssociation).toBe(expectedNetAssociation);
+      expect(result.montantRecuFiscal).toBe(expectedNetAssociation);
+    });
+
+    it('should fall back to defaults when only one param is undefined', () => {
+      const input: FeeCalculationInput = {
+        montantDon: 100,
+        contribution: 0,
+        donorPaysFee: true,
+        commissionPercentage: 0.04,
+        stripeFeePercentage: undefined,
+        stripeFeeFixed: 0.50,
+      };
+      const result = calculateFees(input);
+
+      // stripeFeePercentage falls back to 0.015, stripeFeeFixed uses 0.50
+      const expectedStripeFees = 100 * 0.015 + 0.50; // 2.00
+      expect(result.fraisStripeEstimes).toBe(expectedStripeFees);
+    });
+
+    it('should handle zero Stripe fees', () => {
+      const input: FeeCalculationInput = {
+        montantDon: 100,
+        contribution: 0,
+        donorPaysFee: true,
+        commissionPercentage: 0.04,
+        stripeFeePercentage: 0,
+        stripeFeeFixed: 0,
+      };
+      const result = calculateFees(input);
+
+      expect(result.fraisStripeEstimes).toBe(0);
+      expect(result.applicationFee).toBe(result.commissionDonaction);
     });
   });
 });

--- a/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/step3.svelte
+++ b/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/step3.svelte
@@ -54,12 +54,10 @@
   );
 
   // Fee calculations using full helper with API-driven Stripe fee params
-  // trade_policy stores percentage as e.g. 1.5 (for 1.5%), convert to decimal (0.015) for helper
+  // API returns stripe_fee_percentage as decimal (e.g. 0.015 for 1.5%) — no conversion needed
   const commissionPercentage = $derived(tradePolicy?.commissionPercentage ?? 4);
   const stripeFeePercentage = $derived(
-    tradePolicy?.stripe_fee_percentage != null
-      ? tradePolicy.stripe_fee_percentage / 100
-      : undefined,
+    tradePolicy?.stripe_fee_percentage ?? undefined,
   );
   // Convert null → undefined so downstream ?? fallback works correctly
   const stripeFeeFixed = $derived(tradePolicy?.stripe_fee_fixed ?? undefined);

--- a/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/step3.svelte
+++ b/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/step3.svelte
@@ -53,14 +53,22 @@
       : (tradePolicy?.donor_pays_fee_club ?? false),
   );
 
-  // Fee calculations using full helper
+  // Fee calculations using full helper with API-driven Stripe fee params
   const commissionPercentage = $derived(tradePolicy?.commissionPercentage ?? 4);
+  const stripeFeePercentage = $derived(
+    tradePolicy?.stripe_fee_percentage != null
+      ? tradePolicy.stripe_fee_percentage / 100
+      : undefined,
+  );
+  const stripeFeeFixed = $derived(tradePolicy?.stripe_fee_fixed ?? undefined);
   const fees = $derived<FeeCalculationOutput>(
     calculateFees({
       montantDon: DEFAULT_VALUES.montant,
       contribution: DEFAULT_VALUES.contributionAKlubr || 0,
       donorPaysFee: DEFAULT_VALUES.donorPaysFee,
       commissionPercentage: (commissionPercentage || 4) / 100,
+      stripeFeePercentage,
+      stripeFeeFixed,
     }),
   );
 

--- a/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/step3.svelte
+++ b/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step3/step3.svelte
@@ -54,12 +54,14 @@
   );
 
   // Fee calculations using full helper with API-driven Stripe fee params
+  // trade_policy stores percentage as e.g. 1.5 (for 1.5%), convert to decimal (0.015) for helper
   const commissionPercentage = $derived(tradePolicy?.commissionPercentage ?? 4);
   const stripeFeePercentage = $derived(
     tradePolicy?.stripe_fee_percentage != null
       ? tradePolicy.stripe_fee_percentage / 100
       : undefined,
   );
+  // Convert null → undefined so downstream ?? fallback works correctly
   const stripeFeeFixed = $derived(tradePolicy?.stripe_fee_fixed ?? undefined);
   const fees = $derived<FeeCalculationOutput>(
     calculateFees({

--- a/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step4/step4.svelte
+++ b/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step4/step4.svelte
@@ -23,7 +23,6 @@
   import loader from '../../../../../../assets/animations/loader.json';
   import error from '../../../../../../assets/animations/error.json';
   import { sendGaEvent } from '../../../../../../utils/sendGaEvent';
-  import { calculateFeeAmount } from '../../../../logic/utils';
 
   let clientSecret: string | null = $state(null);
   let stripe: Stripe | null = $state(null);
@@ -46,20 +45,22 @@
       // Generate idempotency key for this payment session
       idempotencyKey = generateIdempotencyKey();
 
-      // Calculate fee if donor pays fee (Stripe Connect mode)
+      // Send base amounts only — backend handles fee calculation
+      // This avoids double-counting: SaaS sends donation + contribution,
+      // backend calculates application_fee and adjusts total if donorPaysFee
       const tradePolicy = SUBSCRIPTION.klubr?.trade_policy;
       const isStripeConnect = tradePolicy?.stripe_connect === true;
-      const commissionPercentage = tradePolicy?.commissionPercentage ?? 4;
-      const feeAmount =
-        isStripeConnect && DEFAULT_VALUES.donorPaysFee
-          ? calculateFeeAmount(DEFAULT_VALUES.montant, commissionPercentage)
-          : 0;
 
-      const totalAmount =
-        DEFAULT_VALUES.montant + (DEFAULT_VALUES.contributionAKlubr || 0) + feeAmount;
+      const baseAmount =
+        DEFAULT_VALUES.montant + (DEFAULT_VALUES.contributionAKlubr || 0);
       // Only send donorPaysFee for Stripe Connect mode (guard condition per US-FORM-003)
       const donorPaysFeeParam = isStripeConnect ? DEFAULT_VALUES.donorPaysFee : undefined;
-      const response = await createPaymentIntent(totalAmount, idempotencyKey, donorPaysFeeParam);
+      const response = await createPaymentIntent(
+        baseAmount,
+        idempotencyKey,
+        donorPaysFeeParam,
+        DEFAULT_VALUES.montant,
+      );
 
       clientSecret = response.intent;
 

--- a/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step4/step4.svelte
+++ b/donaction-saas/src/components/sponsorshipForm/components/formBody/steps/step4/step4.svelte
@@ -59,7 +59,6 @@
         baseAmount,
         idempotencyKey,
         donorPaysFeeParam,
-        DEFAULT_VALUES.montant,
       );
 
       clientSecret = response.intent;

--- a/donaction-saas/src/components/sponsorshipForm/logic/api.ts
+++ b/donaction-saas/src/components/sponsorshipForm/logic/api.ts
@@ -19,6 +19,7 @@ export const createPaymentIntent = (
   price: number,
   idempotencyKey?: string,
   donorPaysFee?: boolean,
+  donationAmount?: number,
 ): Promise<{ intent: string; reused: boolean }> =>
   Fetch({
     endpoint: CREATE_PAYMENT_INTENT,
@@ -27,6 +28,7 @@ export const createPaymentIntent = (
       price,
       idempotencyKey,
       donorPaysFee,
+      donationAmount,
       metadata: {
         donUuid: FORM_CONFIG.donUuid,
         klubUuid: SUBSCRIPTION.klubr.uuid,

--- a/donaction-saas/src/components/sponsorshipForm/logic/api.ts
+++ b/donaction-saas/src/components/sponsorshipForm/logic/api.ts
@@ -19,7 +19,6 @@ export const createPaymentIntent = (
   price: number,
   idempotencyKey?: string,
   donorPaysFee?: boolean,
-  donationAmount?: number,
 ): Promise<{ intent: string; reused: boolean }> =>
   Fetch({
     endpoint: CREATE_PAYMENT_INTENT,
@@ -28,7 +27,6 @@ export const createPaymentIntent = (
       price,
       idempotencyKey,
       donorPaysFee,
-      donationAmount,
       metadata: {
         donUuid: FORM_CONFIG.donUuid,
         klubUuid: SUBSCRIPTION.klubr.uuid,

--- a/donaction-saas/src/components/sponsorshipForm/logic/fee-calculation-helper.ts
+++ b/donaction-saas/src/components/sponsorshipForm/logic/fee-calculation-helper.ts
@@ -3,8 +3,8 @@
  * Implements US-PAY-002 specification for fee model calculations
  */
 
-/** Stripe fees for European cards (France) */
-export const STRIPE_FEES = {
+/** Default Stripe fees for European cards (France) — used as fallback */
+export const STRIPE_FEES_DEFAULTS = {
   PERCENTAGE: 0.015, // 1.5% for European cards
   FIXED: 0.25, // 0.25€ per transaction
 } as const;
@@ -14,6 +14,8 @@ export interface FeeCalculationInput {
   contribution: number; // In euros (voluntary DONACTION contribution)
   donorPaysFee: boolean;
   commissionPercentage: number; // As decimal (0.04 = 4%)
+  stripeFeePercentage?: number; // As decimal (0.015 = 1.5%), defaults to STRIPE_FEES_DEFAULTS.PERCENTAGE
+  stripeFeeFixed?: number; // In euros (0.25€), defaults to STRIPE_FEES_DEFAULTS.FIXED
 }
 
 export interface FeeCalculationOutput {
@@ -37,6 +39,10 @@ export interface FeeCalculationOutput {
 export function calculateFees(input: FeeCalculationInput): FeeCalculationOutput {
   const { montantDon, donorPaysFee, commissionPercentage } = input;
 
+  // Resolve Stripe fee parameters (API-driven with fallback defaults)
+  const stripeFeePercentage = input.stripeFeePercentage ?? STRIPE_FEES_DEFAULTS.PERCENTAGE;
+  const stripeFeeFixed = input.stripeFeeFixed ?? STRIPE_FEES_DEFAULTS.FIXED;
+
   // Validate and sanitize contribution (C4: validate contribution)
   const contribution = isNaN(input.contribution) || input.contribution < 0 ? 0 : input.contribution;
 
@@ -56,9 +62,9 @@ export function calculateFees(input: FeeCalculationInput): FeeCalculationOutput 
   const commissionDonaction = roundToCents(montantDon * commissionPercentage);
 
   if (donorPaysFee) {
-    return calculateScenarioA(montantDon, contribution, commissionDonaction);
+    return calculateScenarioA(montantDon, contribution, commissionDonaction, stripeFeePercentage, stripeFeeFixed);
   } else {
-    return calculateScenarioB(montantDon, contribution, commissionDonaction);
+    return calculateScenarioB(montantDon, contribution, commissionDonaction, stripeFeePercentage, stripeFeeFixed);
   }
 }
 
@@ -71,12 +77,14 @@ function calculateScenarioA(
   montantDon: number,
   contribution: number,
   commissionDonaction: number,
+  stripeFeePercentage: number,
+  stripeFeeFixed: number,
 ): FeeCalculationOutput {
   // Subtotal before Stripe fees
   const subtotal = montantDon + commissionDonaction + contribution;
 
-  // Stripe fees on total charged amount
-  const fraisStripeEstimes = calculateStripeFees(montantDon);
+  // Stripe fees on donation amount
+  const fraisStripeEstimes = calculateStripeFees(montantDon, stripeFeePercentage, stripeFeeFixed);
 
   // Total donor pays
   const totalDonateur = roundToCents(subtotal + fraisStripeEstimes);
@@ -105,12 +113,14 @@ function calculateScenarioB(
   montantDon: number,
   contribution: number,
   commissionDonaction: number,
+  stripeFeePercentage: number,
+  stripeFeeFixed: number,
 ): FeeCalculationOutput {
   // Total charged to donor (no visible fees)
   const totalDonateur = roundToCents(montantDon + contribution);
 
-  // Stripe fees calculated on total charged
-  const fraisStripeEstimes = calculateStripeFees(montantDon);
+  // Stripe fees calculated on donation amount
+  const fraisStripeEstimes = calculateStripeFees(montantDon, stripeFeePercentage, stripeFeeFixed);
 
   // Application fee INCLUDES Stripe fees to ensure DONACTION maintains 4% net
   const applicationFee = roundToCents(commissionDonaction + fraisStripeEstimes);
@@ -130,10 +140,14 @@ function calculateScenarioB(
 
 /**
  * Calculate Stripe fees for a given amount
- * Formula: (amount × 1.5%) + 0.25€
+ * Uses dynamic fee parameters from trade_policy with fallback defaults
  */
-function calculateStripeFees(amount: number): number {
-  return roundToCents(amount * STRIPE_FEES.PERCENTAGE + STRIPE_FEES.FIXED);
+function calculateStripeFees(
+  amount: number,
+  stripeFeePercentage: number,
+  stripeFeeFixed: number,
+): number {
+  return roundToCents(amount * stripeFeePercentage + stripeFeeFixed);
 }
 
 /**


### PR DESCRIPTION
## Summary

- **API**: Add `stripe_fee_percentage` / `stripe_fee_fixed` to `trade_policy` schema so Stripe processing fees are configurable per club
- **API**: Refactor `calculateApplicationFee` into 3 composable functions (`calculatePlatformCommission`, `estimateStripeFees`, `calculateApplicationFee`) that read dynamic fees from trade_policy
- **API**: Use `donationAmount` (excluding contribution) as fee calculation base to prevent over-charging
- **SaaS**: Read Stripe fee params from `trade_policy` via decrypt endpoint instead of hardcoded `STRIPE_FEES` constants
- **SaaS**: Fix double-counting in step4 — send base amounts only, backend handles fee calculation and total adjustment

## Test plan

- [ ] 23 API unit tests (all fee models, custom Stripe fees, edge cases)
- [ ] 7 new SaaS unit tests (dynamic params, fallback defaults, zero fees)
- [ ] Verify with custom `stripe_fee_percentage=5` / `stripe_fee_fixed=1` in trade_policy → SaaS displays 5% + €1 (not default 1.5% + €0.25)
- [ ] Verify Scenario A (donor pays fees) and Scenario B (fees included) both use dynamic rates
- [ ] Verify backward compat: clubs without custom fees fall back to defaults (1.5% + €0.25)

Fixes #174