### PR TITLE
feat: implement calculateFees() for 3 fee_model modes (US-PAY-002)

### DIFF
--- a/donaction-api/src/helpers/fee-calculation-helper.test.ts
+++ b/donaction-api/src/helpers/fee-calculation-helper.test.ts
@@ -242,6 +242,17 @@ describe('Mode legacy (stripe_connect = false)', () => {
         expect(result.totalDonateur).toBe(5500);
         expect(result.netAssociation).toBe(5000);
     });
+
+    it('rejette montantDon <= 0 même en mode legacy', () => {
+        expect(() =>
+            calculateFees({
+                montantDon: 0,
+                contribution: 0,
+                donorPaysFee: false,
+                tradePolicy: makePolicy({ stripe_connect: false }),
+            })
+        ).toThrow('Montant de donation invalide');
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/donaction-api/src/helpers/fee-calculation-helper.test.ts
+++ b/donaction-api/src/helpers/fee-calculation-helper.test.ts
@@ -1,0 +1,373 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TradePolicyEntity } from '../_types';
+
+// Stub env vars before importing (stripe-connect-helper has top-level guard)
+vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_fake');
+vi.stubEnv('STRIPE_WEBHOOK_SECRET_CONNECT', 'whsec_fake');
+
+const { calculateFees } = await import('./fee-calculation-helper');
+
+/** Helper to build a minimal TradePolicyEntity for tests */
+const makePolicy = (
+    overrides: Partial<{
+        fee_model: string;
+        commissionPercentage: number;
+        fixed_amount: number;
+        stripe_fee_percentage: number;
+        stripe_fee_fixed: number;
+        stripe_connect: boolean;
+        donor_pays_fee: boolean;
+    }> = {}
+): TradePolicyEntity =>
+    ({
+        fee_model: overrides.fee_model ?? 'percentage_only',
+        commissionPercentage: overrides.commissionPercentage ?? 4,
+        fixed_amount: overrides.fixed_amount ?? 0,
+        stripe_fee_percentage: overrides.stripe_fee_percentage,
+        stripe_fee_fixed: overrides.stripe_fee_fixed,
+        stripe_connect: overrides.stripe_connect ?? true,
+        donor_pays_fee: overrides.donor_pays_fee,
+    }) as unknown as TradePolicyEntity;
+
+// ---------------------------------------------------------------------------
+// Scénario A — Le donateur paie les frais en supplément (donorPaysFee = true)
+// ---------------------------------------------------------------------------
+
+describe('Scénario A — donorPaysFee = true', () => {
+    describe('percentage_only 4%', () => {
+        it('don=10000, contribution=1000 : calcule les frais corrects', () => {
+            // commissionDonaction = Math.round(10000 * 4 / 100) = 400
+            // subtotal = 10000 + 400 + 1000 = 11400
+            // fraisStripeEstimes = Math.round(11400 * 1.5 / 100 + 0.25 * 100)
+            //                    = Math.round(171 + 25) = 196
+            // applicationFee = 400 + 196 = 596
+            // totalDonateur = 10000 + 400 + 196 + 1000 = 11596
+            // netAssociation = 10000
+            // montantRecuFiscal = 10000
+            const result = calculateFees({
+                montantDon: 10000,
+                contribution: 1000,
+                donorPaysFee: true,
+                tradePolicy: makePolicy({ commissionPercentage: 4 }),
+            });
+
+            expect(result.commissionDonaction).toBe(400);
+            expect(result.fraisStripeEstimes).toBe(196);
+            expect(result.applicationFee).toBe(596);
+            expect(result.totalDonateur).toBe(11596);
+            expect(result.netAssociation).toBe(10000);
+            expect(result.montantRecuFiscal).toBe(10000);
+        });
+    });
+
+    describe('fixed_only 5€', () => {
+        it('don=10000, contribution=0 : calcule les frais corrects', () => {
+            // commissionDonaction = Math.round(5 * 100) = 500
+            // subtotal = 10000 + 500 + 0 = 10500
+            // fraisStripeEstimes = Math.round(10500 * 1.5 / 100 + 25)
+            //                    = Math.round(157.5 + 25) = Math.round(182.5) = 183
+            // applicationFee = 500 + 183 = 683
+            // totalDonateur = 10000 + 500 + 183 + 0 = 10683
+            // netAssociation = 10000
+            // montantRecuFiscal = 10000
+            const result = calculateFees({
+                montantDon: 10000,
+                contribution: 0,
+                donorPaysFee: true,
+                tradePolicy: makePolicy({
+                    fee_model: 'fixed_only',
+                    fixed_amount: 5,
+                }),
+            });
+
+            expect(result.commissionDonaction).toBe(500);
+            expect(result.fraisStripeEstimes).toBe(183);
+            expect(result.applicationFee).toBe(683);
+            expect(result.totalDonateur).toBe(10683);
+            expect(result.netAssociation).toBe(10000);
+            expect(result.montantRecuFiscal).toBe(10000);
+        });
+    });
+
+    describe('percentage_plus_fixed 4% + 1€', () => {
+        it('don=10000, contribution=1000 : calcule les frais corrects', () => {
+            // commissionDonaction = Math.round(10000 * 4 / 100) + Math.round(1 * 100)
+            //                     = 400 + 100 = 500
+            // subtotal = 10000 + 500 + 1000 = 11500
+            // fraisStripeEstimes = Math.round(11500 * 1.5 / 100 + 25)
+            //                    = Math.round(172.5 + 25) = Math.round(197.5) = 198
+            // applicationFee = 500 + 198 = 698
+            // totalDonateur = 10000 + 500 + 198 + 1000 = 11698
+            // netAssociation = 10000
+            // montantRecuFiscal = 10000
+            const result = calculateFees({
+                montantDon: 10000,
+                contribution: 1000,
+                donorPaysFee: true,
+                tradePolicy: makePolicy({
+                    fee_model: 'percentage_plus_fixed',
+                    commissionPercentage: 4,
+                    fixed_amount: 1,
+                }),
+            });
+
+            expect(result.commissionDonaction).toBe(500);
+            expect(result.fraisStripeEstimes).toBe(198);
+            expect(result.applicationFee).toBe(698);
+            expect(result.totalDonateur).toBe(11698);
+            expect(result.netAssociation).toBe(10000);
+            expect(result.montantRecuFiscal).toBe(10000);
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Scénario B — Les frais sont déduits du don (donorPaysFee = false)
+// ---------------------------------------------------------------------------
+
+describe('Scénario B — donorPaysFee = false', () => {
+    describe('percentage_only 4%', () => {
+        it('don=10000, contribution=1000 : les frais sont déduits du net association', () => {
+            // commissionDonaction = 400
+            // totalDonateur = 10000 + 1000 = 11000
+            // fraisStripeEstimes = Math.round(11000 * 1.5 / 100 + 25)
+            //                    = Math.round(165 + 25) = 190
+            // applicationFee = 400 + 190 = 590
+            // netAssociation = 10000 - 590 = 9410
+            // montantRecuFiscal = 9410
+            const result = calculateFees({
+                montantDon: 10000,
+                contribution: 1000,
+                donorPaysFee: false,
+                tradePolicy: makePolicy({ commissionPercentage: 4 }),
+            });
+
+            expect(result.commissionDonaction).toBe(400);
+            expect(result.fraisStripeEstimes).toBe(190);
+            expect(result.applicationFee).toBe(590);
+            expect(result.totalDonateur).toBe(11000);
+            expect(result.netAssociation).toBe(9410);
+            expect(result.montantRecuFiscal).toBe(9410);
+        });
+    });
+
+    describe('fixed_only 5€', () => {
+        it('don=10000, contribution=0 : les frais sont déduits du net association', () => {
+            // commissionDonaction = 500
+            // totalDonateur = 10000 + 0 = 10000
+            // fraisStripeEstimes = Math.round(10000 * 1.5 / 100 + 25)
+            //                    = Math.round(150 + 25) = 175
+            // applicationFee = 500 + 175 = 675
+            // netAssociation = 10000 - 675 = 9325
+            // montantRecuFiscal = 9325
+            const result = calculateFees({
+                montantDon: 10000,
+                contribution: 0,
+                donorPaysFee: false,
+                tradePolicy: makePolicy({
+                    fee_model: 'fixed_only',
+                    fixed_amount: 5,
+                }),
+            });
+
+            expect(result.commissionDonaction).toBe(500);
+            expect(result.fraisStripeEstimes).toBe(175);
+            expect(result.applicationFee).toBe(675);
+            expect(result.totalDonateur).toBe(10000);
+            expect(result.netAssociation).toBe(9325);
+            expect(result.montantRecuFiscal).toBe(9325);
+        });
+    });
+
+    describe('percentage_plus_fixed 4% + 1€', () => {
+        it('don=10000, contribution=1000 : les frais sont déduits du net association', () => {
+            // commissionDonaction = 400 + 100 = 500
+            // totalDonateur = 10000 + 1000 = 11000
+            // fraisStripeEstimes = Math.round(11000 * 1.5 / 100 + 25) = 190
+            // applicationFee = 500 + 190 = 690
+            // netAssociation = 10000 - 690 = 9310
+            // montantRecuFiscal = 9310
+            const result = calculateFees({
+                montantDon: 10000,
+                contribution: 1000,
+                donorPaysFee: false,
+                tradePolicy: makePolicy({
+                    fee_model: 'percentage_plus_fixed',
+                    commissionPercentage: 4,
+                    fixed_amount: 1,
+                }),
+            });
+
+            expect(result.commissionDonaction).toBe(500);
+            expect(result.fraisStripeEstimes).toBe(190);
+            expect(result.applicationFee).toBe(690);
+            expect(result.totalDonateur).toBe(11000);
+            expect(result.netAssociation).toBe(9310);
+            expect(result.montantRecuFiscal).toBe(9310);
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Mode legacy — stripe_connect désactivé
+// ---------------------------------------------------------------------------
+
+describe('Mode legacy (stripe_connect = false)', () => {
+    it('retourne des frais à zéro et le net association égal au montant du don', () => {
+        const result = calculateFees({
+            montantDon: 10000,
+            contribution: 1000,
+            donorPaysFee: true,
+            tradePolicy: makePolicy({ stripe_connect: false }),
+        });
+
+        expect(result.applicationFee).toBe(0);
+        expect(result.commissionDonaction).toBe(0);
+        expect(result.fraisStripeEstimes).toBe(0);
+        expect(result.netAssociation).toBe(10000);
+        expect(result.montantRecuFiscal).toBe(10000);
+        expect(result.totalDonateur).toBe(11000);
+    });
+
+    it('le totalDonateur inclut la contribution même en mode legacy', () => {
+        const result = calculateFees({
+            montantDon: 5000,
+            contribution: 500,
+            donorPaysFee: false,
+            tradePolicy: makePolicy({ stripe_connect: false }),
+        });
+
+        expect(result.totalDonateur).toBe(5500);
+        expect(result.netAssociation).toBe(5000);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Vérification DONACTION maintient 4% net (Scénario B)
+// ---------------------------------------------------------------------------
+
+describe('Vérification DONACTION 4% net (Scénario B)', () => {
+    it('DONACTION perçoit exactement contribution + commission sur plusieurs montants', () => {
+        const testCases = [
+            { montantDon: 5000, contribution: 500 },
+            { montantDon: 10000, contribution: 1000 },
+            { montantDon: 50000, contribution: 2500 },
+        ];
+
+        const policy = makePolicy({ commissionPercentage: 4 });
+
+        for (const { montantDon, contribution } of testCases) {
+            const result = calculateFees({
+                montantDon,
+                contribution,
+                donorPaysFee: false,
+                tradePolicy: policy,
+            });
+
+            // Ce que DONACTION perçoit réellement :
+            // contribution (reversée intégralement) + applicationFee - fraisStripeEstimes
+            // = contribution + commissionDonaction + fraisStripeEstimes - fraisStripeEstimes
+            // = contribution + commissionDonaction
+            const netDonaction =
+                contribution + result.applicationFee - result.fraisStripeEstimes;
+
+            const expected = contribution + result.commissionDonaction;
+
+            expect(netDonaction).toBe(expected);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Cas limites
+// ---------------------------------------------------------------------------
+
+describe('Cas limites', () => {
+    it('contribution zéro fonctionne en Scénario A', () => {
+        const result = calculateFees({
+            montantDon: 10000,
+            contribution: 0,
+            donorPaysFee: true,
+            tradePolicy: makePolicy({ commissionPercentage: 4 }),
+        });
+
+        // commissionDonaction = 400
+        // subtotal = 10000 + 400 + 0 = 10400
+        // fraisStripeEstimes = Math.round(10400 * 1.5 / 100 + 25)
+        //                    = Math.round(156 + 25) = 181
+        // applicationFee = 400 + 181 = 581
+        // totalDonateur = 10000 + 400 + 181 + 0 = 10581
+        expect(result.commissionDonaction).toBe(400);
+        expect(result.fraisStripeEstimes).toBe(181);
+        expect(result.applicationFee).toBe(581);
+        expect(result.totalDonateur).toBe(10581);
+        expect(result.netAssociation).toBe(10000);
+        expect(result.montantRecuFiscal).toBe(10000);
+    });
+
+    it('contribution zéro fonctionne en Scénario B', () => {
+        const result = calculateFees({
+            montantDon: 10000,
+            contribution: 0,
+            donorPaysFee: false,
+            tradePolicy: makePolicy({ commissionPercentage: 4 }),
+        });
+
+        // commissionDonaction = 400
+        // totalDonateur = 10000 + 0 = 10000
+        // fraisStripeEstimes = Math.round(10000 * 1.5 / 100 + 25) = 175
+        // applicationFee = 400 + 175 = 575
+        // netAssociation = 10000 - 575 = 9425
+        expect(result.commissionDonaction).toBe(400);
+        expect(result.fraisStripeEstimes).toBe(175);
+        expect(result.applicationFee).toBe(575);
+        expect(result.totalDonateur).toBe(10000);
+        expect(result.netAssociation).toBe(9425);
+        expect(result.montantRecuFiscal).toBe(9425);
+    });
+
+    it('grand montant (100000 centimes = 1000€) sans overflow en Scénario A', () => {
+        const result = calculateFees({
+            montantDon: 100000,
+            contribution: 5000,
+            donorPaysFee: true,
+            tradePolicy: makePolicy({ commissionPercentage: 4 }),
+        });
+
+        // commissionDonaction = Math.round(100000 * 4 / 100) = 4000
+        // subtotal = 100000 + 4000 + 5000 = 109000
+        // fraisStripeEstimes = Math.round(109000 * 1.5 / 100 + 25)
+        //                    = Math.round(1635 + 25) = 1660
+        // applicationFee = 4000 + 1660 = 5660
+        // totalDonateur = 100000 + 4000 + 1660 + 5000 = 110660
+        // netAssociation = 100000
+        expect(result.commissionDonaction).toBe(4000);
+        expect(result.fraisStripeEstimes).toBe(1660);
+        expect(result.applicationFee).toBe(5660);
+        expect(result.totalDonateur).toBe(110660);
+        expect(result.netAssociation).toBe(100000);
+        expect(result.montantRecuFiscal).toBe(100000);
+    });
+
+    it('grand montant (100000 centimes = 1000€) sans overflow en Scénario B', () => {
+        const result = calculateFees({
+            montantDon: 100000,
+            contribution: 5000,
+            donorPaysFee: false,
+            tradePolicy: makePolicy({ commissionPercentage: 4 }),
+        });
+
+        // commissionDonaction = 4000
+        // totalDonateur = 100000 + 5000 = 105000
+        // fraisStripeEstimes = Math.round(105000 * 1.5 / 100 + 25)
+        //                    = Math.round(1575 + 25) = 1600
+        // applicationFee = 4000 + 1600 = 5600
+        // netAssociation = 100000 - 5600 = 94400
+        expect(result.commissionDonaction).toBe(4000);
+        expect(result.fraisStripeEstimes).toBe(1600);
+        expect(result.applicationFee).toBe(5600);
+        expect(result.totalDonateur).toBe(105000);
+        expect(result.netAssociation).toBe(94400);
+        expect(result.montantRecuFiscal).toBe(94400);
+    });
+});

--- a/donaction-api/src/helpers/fee-calculation-helper.test.ts
+++ b/donaction-api/src/helpers/fee-calculation-helper.test.ts
@@ -445,4 +445,46 @@ describe('Cas limites', () => {
             })
         ).toThrow('Contribution invalide');
     });
+
+    it('rejette un montantDon non-entier (centimes décimaux)', () => {
+        expect(() =>
+            calculateFees({
+                montantDon: 100.5,
+                contribution: 0,
+                donorPaysFee: true,
+                tradePolicy: makePolicy({ commissionPercentage: 4 }),
+            })
+        ).toThrow('Montant de donation invalide');
+    });
+
+    it('rejette une contribution non-entière', () => {
+        expect(() =>
+            calculateFees({
+                montantDon: 10000,
+                contribution: 10.5,
+                donorPaysFee: true,
+                tradePolicy: makePolicy({ commissionPercentage: 4 }),
+            })
+        ).toThrow('Contribution invalide');
+    });
+
+    it('fonctionne avec commissionPercentage = 0 (association sans frais plateforme)', () => {
+        const result = calculateFees({
+            montantDon: 10000,
+            contribution: 1000,
+            donorPaysFee: false,
+            tradePolicy: makePolicy({ commissionPercentage: 0 }),
+        });
+
+        // commissionDonaction = 0
+        // totalDonateur = 10000 + 1000 = 11000
+        // fraisStripeEstimes = Math.round(11000 * 1.5 / 100 + 25) = 190
+        // applicationFee = 0 + 190 = 190
+        // netAssociation = 10000 - 190 = 9810
+        expect(result.commissionDonaction).toBe(0);
+        expect(result.fraisStripeEstimes).toBe(190);
+        expect(result.applicationFee).toBe(190);
+        expect(result.netAssociation).toBe(9810);
+        expect(result.montantRecuFiscal).toBe(9810);
+    });
 });

--- a/donaction-api/src/helpers/fee-calculation-helper.test.ts
+++ b/donaction-api/src/helpers/fee-calculation-helper.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
 import { TradePolicyEntity } from '../_types';
 
-// Stub env vars before importing (stripe-connect-helper has top-level guard)
+// Dynamic import required: stripe-connect-helper.ts validates STRIPE_SECRET_KEY
+// and STRIPE_WEBHOOK_SECRET_CONNECT at module load time (fail-fast guard).
+// We must stub these env vars BEFORE the module is imported.
 vi.stubEnv('STRIPE_SECRET_KEY', 'sk_test_fake');
 vi.stubEnv('STRIPE_WEBHOOK_SECRET_CONNECT', 'whsec_fake');
 
@@ -420,5 +422,16 @@ describe('Cas limites', () => {
                 tradePolicy: makePolicy({ commissionPercentage: 4 }),
             })
         ).toThrow('Montant de donation invalide');
+    });
+
+    it('rejette une contribution négative', () => {
+        expect(() =>
+            calculateFees({
+                montantDon: 10000,
+                contribution: -500,
+                donorPaysFee: true,
+                tradePolicy: makePolicy({ commissionPercentage: 4 }),
+            })
+        ).toThrow('Contribution invalide');
     });
 });

--- a/donaction-api/src/helpers/fee-calculation-helper.test.ts
+++ b/donaction-api/src/helpers/fee-calculation-helper.test.ts
@@ -247,7 +247,7 @@ describe('Mode legacy (stripe_connect = false)', () => {
 // ---------------------------------------------------------------------------
 
 describe('Vérification DONACTION 4% net (Scénario B)', () => {
-    it('DONACTION perçoit exactement contribution + commission sur plusieurs montants', () => {
+    it('la commission DONACTION représente exactement 4% du montant du don', () => {
         const testCases = [
             { montantDon: 5000, contribution: 500 },
             { montantDon: 10000, contribution: 1000 },
@@ -264,16 +264,14 @@ describe('Vérification DONACTION 4% net (Scénario B)', () => {
                 tradePolicy: policy,
             });
 
-            // Ce que DONACTION perçoit réellement :
-            // contribution (reversée intégralement) + applicationFee - fraisStripeEstimes
-            // = contribution + commissionDonaction + fraisStripeEstimes - fraisStripeEstimes
-            // = contribution + commissionDonaction
-            const netDonaction =
-                contribution + result.applicationFee - result.fraisStripeEstimes;
+            // La commission DONACTION doit être exactement 4% du don
+            expect(result.commissionDonaction).toBe(Math.round(montantDon * 4 / 100));
 
-            const expected = contribution + result.commissionDonaction;
+            // L'association reçoit : don - applicationFee
+            expect(result.netAssociation).toBe(montantDon - result.applicationFee);
 
-            expect(netDonaction).toBe(expected);
+            // Le total prélevé couvre exactement don + contribution
+            expect(result.totalDonateur).toBe(montantDon + contribution);
         }
     });
 });
@@ -369,5 +367,58 @@ describe('Cas limites', () => {
         expect(result.totalDonateur).toBe(105000);
         expect(result.netAssociation).toBe(94400);
         expect(result.montantRecuFiscal).toBe(94400);
+    });
+
+    it('netAssociation ne descend pas sous zéro en Scénario B avec petit montant', () => {
+        // Petit don avec frais élevés : commission + Stripe > don
+        const result = calculateFees({
+            montantDon: 100, // 1€
+            contribution: 0,
+            donorPaysFee: false,
+            tradePolicy: makePolicy({
+                fee_model: 'fixed_only',
+                fixed_amount: 5, // 5€ fixe > 1€ don
+            }),
+        });
+
+        expect(result.netAssociation).toBe(0);
+        expect(result.montantRecuFiscal).toBe(0);
+    });
+
+    it('fonctionne avec des frais Stripe personnalisés (taux US)', () => {
+        // Stripe US: 2.9% + $0.30
+        const result = calculateFees({
+            montantDon: 10000,
+            contribution: 1000,
+            donorPaysFee: true,
+            tradePolicy: makePolicy({
+                commissionPercentage: 4,
+                stripe_fee_percentage: 2.9,
+                stripe_fee_fixed: 0.30,
+            }),
+        });
+
+        // commissionDonaction = 400
+        // subtotal = 10000 + 400 + 1000 = 11400
+        // fraisStripeEstimes = Math.round(11400 * 2.9 / 100 + 0.30 * 100)
+        //                    = Math.round(330.6 + 30) = Math.round(360.6) = 361
+        // applicationFee = 400 + 361 = 761
+        // totalDonateur = 10000 + 400 + 361 + 1000 = 11761
+        expect(result.commissionDonaction).toBe(400);
+        expect(result.fraisStripeEstimes).toBe(361);
+        expect(result.applicationFee).toBe(761);
+        expect(result.totalDonateur).toBe(11761);
+        expect(result.netAssociation).toBe(10000);
+    });
+
+    it('propage l\'erreur de calculatePlatformCommission si montantDon <= 0', () => {
+        expect(() =>
+            calculateFees({
+                montantDon: 0,
+                contribution: 1000,
+                donorPaysFee: true,
+                tradePolicy: makePolicy({ commissionPercentage: 4 }),
+            })
+        ).toThrow('Montant de donation invalide');
     });
 });

--- a/donaction-api/src/helpers/fee-calculation-helper.ts
+++ b/donaction-api/src/helpers/fee-calculation-helper.ts
@@ -54,12 +54,12 @@ export interface FeeCalculationOutput {
 export function calculateFees(input: FeeCalculationInput): FeeCalculationOutput {
     const { montantDon, contribution, donorPaysFee, tradePolicy } = input;
 
-    if (montantDon <= 0) {
-        throw new Error('Montant de donation invalide : doit être > 0');
+    if (montantDon <= 0 || !Number.isInteger(montantDon)) {
+        throw new Error('Montant de donation invalide : doit être un entier > 0 (centimes)');
     }
 
-    if (contribution < 0) {
-        throw new Error('Contribution invalide : ne peut pas être négative');
+    if (contribution < 0 || !Number.isInteger(contribution)) {
+        throw new Error('Contribution invalide : doit être un entier >= 0 (centimes)');
     }
 
     // Garde : mode legacy sans Stripe Connect

--- a/donaction-api/src/helpers/fee-calculation-helper.ts
+++ b/donaction-api/src/helpers/fee-calculation-helper.ts
@@ -44,11 +44,19 @@ export interface FeeCalculationOutput {
  * - Scénario A (donorPaysFee = true) : le donateur paie les frais en supplément
  * - Scénario B (donorPaysFee = false) : les frais sont déduits du don
  *
+ * Note : le paramètre `donorPaysFee` est une décision déjà résolue en amont
+ * (via `determineDonorPaysFee()`). Il prévaut sur `tradePolicy.donor_pays_fee`
+ * qui est le champ legacy avant Stripe Connect.
+ *
  * @param input - Paramètres de calcul (montant, contribution, choix donateur, politique)
  * @returns Décomposition complète des frais et montants
  */
 export function calculateFees(input: FeeCalculationInput): FeeCalculationOutput {
     const { montantDon, contribution, donorPaysFee, tradePolicy } = input;
+
+    if (contribution < 0) {
+        throw new Error('Contribution invalide : ne peut pas être négative');
+    }
 
     // Garde : mode legacy sans Stripe Connect
     if (!tradePolicy.stripe_connect) {

--- a/donaction-api/src/helpers/fee-calculation-helper.ts
+++ b/donaction-api/src/helpers/fee-calculation-helper.ts
@@ -106,6 +106,10 @@ const calculateScenarioA = (
  * Le donateur paie uniquement le montant du don (+ contribution éventuelle).
  * Les frais Stripe et la commission DONACTION sont prélevés sur la part de l'association.
  *
+ * Note : les frais Stripe sont estimés sur (montantDon + contribution), sans inclure
+ * la commission dans la base de calcul. C'est une simplification volontaire conforme
+ * à la spécification US-PAY-002 — la légère sous-estimation est absorbée par la plateforme.
+ *
  * @param montantDon - Montant du don en centimes
  * @param contribution - Contribution volontaire DONACTION en centimes
  * @param commissionDonaction - Commission DONACTION déjà calculée en centimes
@@ -122,7 +126,7 @@ const calculateScenarioB = (
     const fraisStripeEstimes = estimateStripeFees(totalDonateur, tradePolicy);
 
     const applicationFee = commissionDonaction + fraisStripeEstimes;
-    const netAssociation = montantDon - applicationFee;
+    const netAssociation = Math.max(0, montantDon - applicationFee);
     const montantRecuFiscal = netAssociation;
 
     return {

--- a/donaction-api/src/helpers/fee-calculation-helper.ts
+++ b/donaction-api/src/helpers/fee-calculation-helper.ts
@@ -54,6 +54,10 @@ export interface FeeCalculationOutput {
 export function calculateFees(input: FeeCalculationInput): FeeCalculationOutput {
     const { montantDon, contribution, donorPaysFee, tradePolicy } = input;
 
+    if (montantDon <= 0) {
+        throw new Error('Montant de donation invalide : doit être > 0');
+    }
+
     if (contribution < 0) {
         throw new Error('Contribution invalide : ne peut pas être négative');
     }

--- a/donaction-api/src/helpers/fee-calculation-helper.ts
+++ b/donaction-api/src/helpers/fee-calculation-helper.ts
@@ -1,0 +1,158 @@
+import { TradePolicyEntity } from '../_types';
+import {
+    calculatePlatformCommission,
+    estimateStripeFees,
+} from './stripe-connect-helper';
+
+/**
+ * Données d'entrée pour le calcul des frais d'une donation
+ */
+export interface FeeCalculationInput {
+    /** Montant du don en centimes */
+    montantDon: number;
+    /** Contribution volontaire DONACTION en centimes */
+    contribution: number;
+    /** Si true, le donateur paie les frais en supplément (Scénario A) */
+    donorPaysFee: boolean;
+    /** Politique tarifaire de l'association */
+    tradePolicy: TradePolicyEntity;
+}
+
+/**
+ * Résultat du calcul des frais d'une donation
+ */
+export interface FeeCalculationOutput {
+    /** Montant total débité du donateur en centimes */
+    totalDonateur: number;
+    /** Montant net reçu par l'association en centimes */
+    netAssociation: number;
+    /** Montant de l'application_fee_amount Stripe en centimes */
+    applicationFee: number;
+    /** Commission DONACTION en centimes */
+    commissionDonaction: number;
+    /** Estimation des frais Stripe en centimes */
+    fraisStripeEstimes: number;
+    /** Montant servant de base au reçu fiscal en centimes */
+    montantRecuFiscal: number;
+}
+
+/**
+ * Orchestrateur principal de calcul des frais pour une donation.
+ *
+ * Sélectionne automatiquement le scénario adapté selon la politique tarifaire :
+ * - Legacy (stripe_connect désactivé) : aucun frais calculé
+ * - Scénario A (donorPaysFee = true) : le donateur paie les frais en supplément
+ * - Scénario B (donorPaysFee = false) : les frais sont déduits du don
+ *
+ * @param input - Paramètres de calcul (montant, contribution, choix donateur, politique)
+ * @returns Décomposition complète des frais et montants
+ */
+export function calculateFees(input: FeeCalculationInput): FeeCalculationOutput {
+    const { montantDon, contribution, donorPaysFee, tradePolicy } = input;
+
+    // Garde : mode legacy sans Stripe Connect
+    if (!tradePolicy.stripe_connect) {
+        return calculateLegacyFees(input);
+    }
+
+    const commissionDonaction = calculatePlatformCommission(montantDon, tradePolicy);
+
+    if (donorPaysFee) {
+        return calculateScenarioA(montantDon, contribution, commissionDonaction, tradePolicy);
+    }
+
+    return calculateScenarioB(montantDon, contribution, commissionDonaction, tradePolicy);
+}
+
+/**
+ * Scénario A — Le donateur paie les frais en supplément du montant du don.
+ *
+ * Le montant du don est intégralement reversé à l'association.
+ * Les frais Stripe et la commission DONACTION sont ajoutés au total débité.
+ *
+ * @param montantDon - Montant du don en centimes
+ * @param contribution - Contribution volontaire DONACTION en centimes
+ * @param commissionDonaction - Commission DONACTION déjà calculée en centimes
+ * @param tradePolicy - Politique tarifaire de l'association
+ * @returns Décomposition des frais pour le scénario A
+ */
+const calculateScenarioA = (
+    montantDon: number,
+    contribution: number,
+    commissionDonaction: number,
+    tradePolicy: TradePolicyEntity
+): FeeCalculationOutput => {
+    const subtotalBeforeStripe = montantDon + commissionDonaction + contribution;
+    const fraisStripeEstimes = estimateStripeFees(subtotalBeforeStripe, tradePolicy);
+
+    const applicationFee = commissionDonaction + fraisStripeEstimes;
+    const totalDonateur = montantDon + commissionDonaction + fraisStripeEstimes + contribution;
+    const netAssociation = montantDon;
+    const montantRecuFiscal = montantDon;
+
+    return {
+        totalDonateur,
+        netAssociation,
+        applicationFee,
+        commissionDonaction,
+        fraisStripeEstimes,
+        montantRecuFiscal,
+    };
+};
+
+/**
+ * Scénario B — Les frais sont déduits du montant du don reçu par l'association.
+ *
+ * Le donateur paie uniquement le montant du don (+ contribution éventuelle).
+ * Les frais Stripe et la commission DONACTION sont prélevés sur la part de l'association.
+ *
+ * @param montantDon - Montant du don en centimes
+ * @param contribution - Contribution volontaire DONACTION en centimes
+ * @param commissionDonaction - Commission DONACTION déjà calculée en centimes
+ * @param tradePolicy - Politique tarifaire de l'association
+ * @returns Décomposition des frais pour le scénario B
+ */
+const calculateScenarioB = (
+    montantDon: number,
+    contribution: number,
+    commissionDonaction: number,
+    tradePolicy: TradePolicyEntity
+): FeeCalculationOutput => {
+    const totalDonateur = montantDon + contribution;
+    const fraisStripeEstimes = estimateStripeFees(totalDonateur, tradePolicy);
+
+    const applicationFee = commissionDonaction + fraisStripeEstimes;
+    const netAssociation = montantDon - applicationFee;
+    const montantRecuFiscal = netAssociation;
+
+    return {
+        totalDonateur,
+        netAssociation,
+        applicationFee,
+        commissionDonaction,
+        fraisStripeEstimes,
+        montantRecuFiscal,
+    };
+};
+
+/**
+ * Mode legacy — Stripe Connect désactivé, aucun frais de plateforme calculé.
+ *
+ * Le donateur paie le montant du don et la contribution.
+ * L'association reçoit le montant intégral du don sans déduction.
+ *
+ * @param input - Paramètres de calcul
+ * @returns Décomposition des frais en mode legacy (frais à zéro)
+ */
+const calculateLegacyFees = (input: FeeCalculationInput): FeeCalculationOutput => {
+    const { montantDon, contribution } = input;
+
+    return {
+        totalDonateur: montantDon + contribution,
+        netAssociation: montantDon,
+        applicationFee: 0,
+        commissionDonaction: 0,
+        fraisStripeEstimes: 0,
+        montantRecuFiscal: montantDon,
+    };
+};


### PR DESCRIPTION
## Summary

- Implement `calculateFees()` orchestrator function supporting `percentage_only`, `fixed_only`, and `percentage_plus_fixed` fee models
- Handle Scenario A (donor pays fees on top) and Scenario B (fees deducted from donation, with corrected Stripe fee base)
- Guard clause for legacy mode (`stripe_connect === false`) with zero-fee pass-through
- Floor `netAssociation` at 0 to prevent negative values on very small donations
- Input validation: `montantDon > 0`, `contribution >= 0`, both must be integers (cents)

> **Note:** Controller integration (`klub-don-payment.ts`) is intentionally deferred to **US-PAY-004** (Create PaymentIntent). This PR ships the pure calculation logic and tests only.

## Files

| File | Action |
|------|--------|
| `donaction-api/src/helpers/fee-calculation-helper.ts` | **New** — orchestrator + interfaces |
| `donaction-api/src/helpers/fee-calculation-helper.test.ts` | **New** — 21 tests |

## Test plan

- [x] 3 fee models × 2 scenarios = 6 core cases with exact cent values
- [x] Legacy mode non-regression (3 tests incl. montantDon=0 rejection)
- [x] DONACTION 4% net commission verification across multiple amounts
- [x] Edge cases: zero contribution, large amounts, negative net guard, custom Stripe rates
- [x] Input validation: montantDon <= 0, negative contribution, decimal cents, error propagation
- [x] commissionPercentage = 0 (no platform fee)
- [x] Existing 57 helper tests still pass (zero regressions)

Closes #58