### PR TITLE
feat: add nullable donorPaysFee field with Legacy guard (US-PAY-003)

### DIFF
--- a/donaction-api/src/api/klub-don/content-types/klub-don/schema.json
+++ b/donaction-api/src/api/klub-don/content-types/klub-don/schema.json
@@ -133,7 +133,6 @@
     },
     "donorPaysFee": {
       "type": "boolean",
-      "default": false,
       "required": false
     }
   }

--- a/donaction-api/src/api/klub-don/controllers/klub-don.ts
+++ b/donaction-api/src/api/klub-don/controllers/klub-don.ts
@@ -23,6 +23,7 @@ import {
     BREVO_TEMPLATES,
     sendBrevoTransacEmail,
 } from '../../../helpers/emails/sendBrevoTransacEmail';
+import { resolveDonorPaysFee } from '../services/resolveDonorPaysFee';
 
 export default factories.createCoreController(
     'api::klub-don.klub-don',
@@ -370,7 +371,11 @@ export default factories.createCoreController(
                                 },
                             },
                             klub_projet: true,
-                            klubr: true,
+                            klubr: {
+                                populate: {
+                                    trade_policy: true,
+                                },
+                            },
                             klub_don_payments: true,
                         },
                     });
@@ -388,13 +393,19 @@ export default factories.createCoreController(
                     ...ctx.request.body,
                 };
 
+                let updateStripeConnect: boolean | null = null;
                 if (body?.data?.klubr) {
                     const klubr: KlubrEntity = await strapi.db
                         .query('api::klubr.klubr')
                         .findOne({
                             where: { uuid: ctx.request.body?.data?.klubr },
+                            populate: { trade_policy: true },
                         });
                     body.data.klubr = klubr.id;
+                    updateStripeConnect = klubr.trade_policy?.stripe_connect ?? null;
+                } else {
+                    // Use trade_policy from the already-populated existing klubr
+                    updateStripeConnect = entityWithUUID.klubr?.trade_policy?.stripe_connect ?? null;
                 }
                 if (body?.data?.klub_projet) {
                     const klubProjet: KlubProjetEntity = await strapi.db
@@ -409,6 +420,13 @@ export default factories.createCoreController(
                 body = strapi.services[
                     'api::klub-don.klub-don'
                 ].updateBodyWithDeductionFiscale(body, entityWithUUID);
+
+                // Resolve donorPaysFee based on klubr's trade policy (null in Legacy mode)
+                body.data.donorPaysFee = resolveDonorPaysFee(
+                    body.data?.donorPaysFee,
+                    updateStripeConnect,
+                );
+
                 const entity = await strapi
                     .documents('api::klub-don.klub-don')
                     .update({
@@ -472,13 +490,16 @@ export default factories.createCoreController(
                 if (!result) {
                     return ctx.badRequest('Captcha verification failed');
                 }
+                let klubrStripeConnect: boolean | null = null;
                 if (ctx.request.body?.data?.klubr) {
                     const klubr: KlubrEntity = await strapi.db
                         .query('api::klubr.klubr')
                         .findOne({
                             where: { uuid: ctx.request.body?.data?.klubr },
+                            populate: { trade_policy: true },
                         });
                     ctx.request.body.data.klubr = klubr.id;
+                    klubrStripeConnect = klubr.trade_policy?.stripe_connect ?? null;
                 }
                 if (ctx.request.body?.data?.klub_projet) {
                     const klubProjet: KlubProjetEntity = await strapi.db
@@ -504,6 +525,13 @@ export default factories.createCoreController(
                 ctx.request.body.data.relaunchCode = Math.floor(
                     1000 + Math.random() * 9000,
                 );
+
+                // Resolve donorPaysFee based on klubr's trade policy (null in Legacy mode)
+                ctx.request.body.data.donorPaysFee = resolveDonorPaysFee(
+                    ctx.request.body.data.donorPaysFee,
+                    klubrStripeConnect,
+                );
+
                 const entity = await super.create(ctx);
                 // prevent returning ids
                 const sanitizedResult = await this.sanitizeOutput(

--- a/donaction-api/src/api/klub-don/services/resolveDonorPaysFee.test.ts
+++ b/donaction-api/src/api/klub-don/services/resolveDonorPaysFee.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { resolveDonorPaysFee } from './resolveDonorPaysFee';
+
+/**
+ * Tests for resolveDonorPaysFee — the exported module-level function.
+ * This tests the real production code, not a copy.
+ */
+
+describe('resolveDonorPaysFee', () => {
+    // Branch 1: stripe_connect = false (Legacy mode) → always null
+    describe('Legacy mode (stripe_connect = false)', () => {
+        it('returns null regardless of donorPaysFee value', () => {
+            expect(resolveDonorPaysFee(true, false)).toBeNull();
+            expect(resolveDonorPaysFee(false, false)).toBeNull();
+            expect(resolveDonorPaysFee(null, false)).toBeNull();
+            expect(resolveDonorPaysFee(undefined, false)).toBeNull();
+        });
+    });
+
+    // Branch 2: stripe_connect = null/undefined (unknown) → always null
+    describe('Unknown mode (stripe_connect = null/undefined)', () => {
+        it('returns null when stripe_connect is null', () => {
+            expect(resolveDonorPaysFee(true, null)).toBeNull();
+        });
+
+        it('returns null when stripe_connect is undefined', () => {
+            expect(resolveDonorPaysFee(true, undefined)).toBeNull();
+        });
+    });
+
+    // Branch 3: stripe_connect = true (Connect mode) → passes through donor choice
+    describe('Connect mode (stripe_connect = true)', () => {
+        it('returns true when donorPaysFee is true', () => {
+            expect(resolveDonorPaysFee(true, true)).toBe(true);
+        });
+
+        it('returns false when donorPaysFee is false', () => {
+            expect(resolveDonorPaysFee(false, true)).toBe(false);
+        });
+
+        it('returns null when donorPaysFee is null', () => {
+            expect(resolveDonorPaysFee(null, true)).toBeNull();
+        });
+
+        it('returns null when donorPaysFee is undefined', () => {
+            expect(resolveDonorPaysFee(undefined, true)).toBeNull();
+        });
+    });
+});

--- a/donaction-api/src/api/klub-don/services/resolveDonorPaysFee.ts
+++ b/donaction-api/src/api/klub-don/services/resolveDonorPaysFee.ts
@@ -1,0 +1,24 @@
+/**
+ * Resolves the donorPaysFee value based on Stripe Connect mode.
+ * Returns null when the klubr uses Legacy mode (stripe_connect = false),
+ * or when the mode cannot be determined (default-safe).
+ * In Stripe Connect mode, returns the original value as-is.
+ *
+ * Pure function with no dependencies — safe to import in tests.
+ *
+ * @param donorPaysFee - The donor's fee choice from the request
+ * @param stripeConnect - Whether the klubr's trade policy has stripe_connect enabled (null/undefined = unknown)
+ * @returns The resolved donorPaysFee value
+ */
+export function resolveDonorPaysFee(
+    donorPaysFee: boolean | null | undefined,
+    stripeConnect: boolean | null | undefined,
+): boolean | null {
+    if (stripeConnect !== true) {
+        // Legacy mode or unknown → default-safe null
+        return null;
+    }
+
+    // Stripe Connect mode → pass through donor's choice
+    return donorPaysFee ?? null;
+}

--- a/donaction-api/types/generated/contentTypes.d.ts
+++ b/donaction-api/types/generated/contentTypes.d.ts
@@ -1000,6 +1000,7 @@ export interface ApiKlubDonKlubDon extends Struct.CollectionTypeSchema {
             Schema.Attribute.Private;
         datePaiment: Schema.Attribute.DateTime;
         deductionFiscale: Schema.Attribute.Decimal;
+        donorPaysFee: Schema.Attribute.Boolean;
         emailSent: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
         estOrganisme: Schema.Attribute.Boolean;
         hasBeenRelaunched: Schema.Attribute.Boolean &
@@ -2478,7 +2479,7 @@ export interface ApiTradePolicyTradePolicy extends Struct.CollectionTypeSchema {
         billingDescription: Schema.Attribute.String;
         commissionPercentage: Schema.Attribute.Decimal &
             Schema.Attribute.Required &
-            Schema.Attribute.DefaultTo<6>;
+            Schema.Attribute.DefaultTo<4>;
         createdAt: Schema.Attribute.DateTime;
         createdBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
             Schema.Attribute.Private;
@@ -2516,6 +2517,10 @@ export interface ApiTradePolicyTradePolicy extends Struct.CollectionTypeSchema {
         stripe_connect: Schema.Attribute.Boolean &
             Schema.Attribute.Required &
             Schema.Attribute.DefaultTo<true>;
+        stripe_fee_fixed: Schema.Attribute.Decimal &
+            Schema.Attribute.DefaultTo<0.25>;
+        stripe_fee_percentage: Schema.Attribute.Decimal &
+            Schema.Attribute.DefaultTo<1.5>;
         tradePolicyLabel: Schema.Attribute.String & Schema.Attribute.Required;
         updatedAt: Schema.Attribute.DateTime;
         updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &


### PR DESCRIPTION
## Summary
- Remove `default: false` from `donorPaysFee` schema field → field now defaults to `null`
- Extract `resolveDonorPaysFee()` as pure function in `services/resolveDonorPaysFee.ts` (no Strapi deps, directly importable in tests)
- Call from both `create()` and `update()` controllers
- Eliminate N+1 query: populate `trade_policy` in existing klubr lookups, pass `stripe_connect` boolean directly to the resolver
- Returns `null` in: Legacy mode, unknown mode, no klubr context, undefined donor choice
- Passes through donor's choice only when `stripe_connect === true`

**Note on type changes:** `contentTypes.d.ts` includes `commissionPercentage` default update (6→4) and new `stripe_fee_*` fields — these reflect existing schema changes already on the epic branch, brought in sync by `gen:types`.

## Test plan
- [x] Build passes (`npm run build`)
- [x] 85/85 tests pass (`npm test`) — 7 new (real code) + 78 existing
- [ ] Manual: create donation with Stripe Connect klubr → `donorPaysFee` stores donor's choice
- [ ] Manual: create donation with Legacy klubr → `donorPaysFee` is `null`
- [ ] Manual: update donation on Legacy klubr → `donorPaysFee` forced to `null`
- [ ] Manual: existing donations are unaffected (no data migration)

Closes #59