### PR TITLE
feat: implement Stripe dispute webhook handlers (US-WH-005) #65

### DIFF
--- a/docs/memory-bank/backend/AGENTS.md
+++ b/docs/memory-bank/backend/AGENTS.md
@@ -183,6 +183,7 @@ const results = await strapi.db.query('api::klubr.klubr').findMany({
 |------|-----------------|
 | `API_DOCS.md` | Endpoint list, middlewares, rate limits |
 | `DATABASE.md` | Entity relationships, schema, migrations |
+| `ROLES.md` | Member roles hierarchy, notification patterns, Admin vs club-level roles |
 
 ## Critical Strapi v5 Documentation
 | File | Purpose |

--- a/docs/memory-bank/backend/ROLES.md
+++ b/docs/memory-bank/backend/ROLES.md
@@ -1,0 +1,78 @@
+# Roles & Permissions - Donaction
+
+> **Last Updated**: 2026-03-09
+
+## Two Role Systems
+
+Donaction has **two distinct role systems** that must not be confused:
+
+### 1. Platform-level roles (`users-permissions` plugin)
+- Managed by Strapi's built-in users-permissions plugin
+- Defines global access level to the platform
+- Roles: `Authenticated`, `Public`, etc.
+- The **Super Admin** is the platform operator with access to all clubs
+
+### 2. Club-level roles (`klubr-membre.role`)
+- Defined in `klubr-membre` schema as an enumeration
+- Each member record is **attached to a specific klubr** via the `klubr` relation
+- Hierarchy (by weight):
+
+| Role | Weight | Scope | Description |
+|------|--------|-------|-------------|
+| `KlubMember` | 20 | Club | Standard member |
+| `KlubMemberLeader` | 30 | Club | Club leader/director |
+| `NetworkLeader` | 40 | Club | Network-level leader |
+| `AdminEditor` | 50 | Club | Club admin with editing rights |
+| `Admin` | 60 | **Platform** | Super admin — cross-club access, NOT bound to one club |
+
+**Source**: `src/helpers/memberRoles.ts`
+
+## Critical Distinction: `Admin` Role
+
+The `Admin` role in `klubr-membre` is special:
+- It is **NOT a club-level role** — it represents the platform super admin
+- An `Admin` member may or may not have a `klubr-membre` record for a given club
+- **Never use** `getKlubMembres(klubrDocId, ['Admin'])` to notify the super admin — unreliable
+- **Always use** `sendBrevoTransacEmail({ destIsAdmin: true })` to reach the super admin
+
+## Notification Patterns
+
+### Notify club leaders (for a specific club)
+```typescript
+const leaders = await strapiInstance
+    .service('api::klubr-membre.klubr-membre')
+    .getKlubMembres(klubr.documentId, ['KlubMemberLeader', 'AdminEditor']);
+```
+
+### Notify platform super admin
+```typescript
+await sendBrevoTransacEmail({
+    templateId: BREVO_TEMPLATES.SOME_TEMPLATE,
+    destIsAdmin: true,  // Routes to ADMIN_EMAIL_PRIMARY + BCC
+    params: { ... },
+    tags: ['admin-alert', ...],
+});
+```
+
+### Notify both (e.g., dispute lost)
+1. `getKlubMembres()` with `['KlubMemberLeader', 'AdminEditor']` for club leaders
+2. Separate `sendBrevoTransacEmail({ destIsAdmin: true })` for super admin
+
+## Permission Helpers
+
+File: `src/helpers/permissions.ts`
+
+| Helper | Checks |
+|--------|--------|
+| `memberIsAdmin(m)` | `role === 'Admin'` |
+| `memberIsAdminEditor(m)` | `role === 'AdminEditor'` |
+| `memberIsLeader(m)` | `role === 'KlubMemberLeader'` |
+| `memberIsAtLeastLeader(m)` | `weight >= 30` (KlubMemberLeader+) |
+| `profileIsAtLeastKlubrLeader(p, uuid)` | At least leader **AND** belongs to that klubr |
+
+## Key Service
+
+`getKlubMembres(klubrDocumentId, roles[])` — queries `klubr-membre` filtered by:
+- `klubr.documentId === klubrDocumentId` (club-scoped)
+- `role $in roles` (role filter)
+- Returns members with populated `users_permissions_user.email`

--- a/donaction-api/src/_types.ts
+++ b/donaction-api/src/_types.ts
@@ -100,7 +100,8 @@ export type StripeWebhookPayload =
     | Stripe.Capability
     | Stripe.Person
     | Stripe.AccountSession
-    | Stripe.ExternalAccount;
+    | Stripe.ExternalAccount
+    | Stripe.Dispute;
 
 /**
  * Webhook log entity for storing Stripe webhook events

--- a/donaction-api/src/_types.ts
+++ b/donaction-api/src/_types.ts
@@ -129,3 +129,30 @@ export type WebhookLogEntity = Data.ContentType<'api::webhook-log.webhook-log'> 
     related_don?: KlubDonEntity;
     related_klubr?: KlubrEntity;
 };
+
+/**
+ * Possible values for dispute status
+ */
+export type DisputeStatusValue =
+    | 'none'
+    | 'warning_received'
+    | 'warning_under_review'
+    | 'warning_closed'
+    | 'open'
+    | 'under_review'
+    | 'won'
+    | 'lost';
+
+/**
+ * Minimal shape for klub_don used by dispute helpers
+ */
+export interface DisputeKlubDon {
+    documentId: string;
+    disputeId?: string | null;
+    disputeClosedAt?: string | Date | null;
+    klubr?: {
+        documentId: string;
+        denomination?: string;
+        uuid?: string;
+    } | null;
+}

--- a/donaction-api/src/api/financial-audit-log/content-types/financial-audit-log/schema.json
+++ b/donaction-api/src/api/financial-audit-log/content-types/financial-audit-log/schema.json
@@ -16,9 +16,13 @@
       "type": "enumeration",
       "enum": [
         "transfer_created",
+        "transfer_reversed",
         "payout_initiated",
         "refund_processed",
-        "fee_calculated"
+        "fee_calculated",
+        "dispute_opened",
+        "dispute_won",
+        "dispute_lost"
       ],
       "required": true
     },

--- a/donaction-api/src/api/financial-audit-log/content-types/financial-audit-log/schema.json
+++ b/donaction-api/src/api/financial-audit-log/content-types/financial-audit-log/schema.json
@@ -23,7 +23,8 @@
         "fee_calculated",
         "dispute_opened",
         "dispute_won",
-        "dispute_lost"
+        "dispute_lost",
+        "transfer_creation_failed"
       ],
       "required": true
     },

--- a/donaction-api/src/api/financial-audit-log/content-types/financial-audit-log/schema.json
+++ b/donaction-api/src/api/financial-audit-log/content-types/financial-audit-log/schema.json
@@ -17,6 +17,7 @@
       "enum": [
         "transfer_created",
         "transfer_reversed",
+        "transfer_reversal_failed",
         "payout_initiated",
         "refund_processed",
         "fee_calculated",

--- a/donaction-api/src/api/klub-don/content-types/klub-don/schema.json
+++ b/donaction-api/src/api/klub-don/content-types/klub-don/schema.json
@@ -140,6 +140,7 @@
       "enum": [
         "none",
         "warning_received",
+        "warning_closed",
         "open",
         "under_review",
         "won",

--- a/donaction-api/src/api/klub-don/content-types/klub-don/schema.json
+++ b/donaction-api/src/api/klub-don/content-types/klub-don/schema.json
@@ -140,6 +140,7 @@
       "enum": [
         "none",
         "warning_received",
+        "warning_under_review",
         "warning_closed",
         "open",
         "under_review",

--- a/donaction-api/src/api/klub-don/content-types/klub-don/schema.json
+++ b/donaction-api/src/api/klub-don/content-types/klub-don/schema.json
@@ -134,6 +134,27 @@
     "donorPaysFee": {
       "type": "boolean",
       "required": false
+    },
+    "disputeStatus": {
+      "type": "enumeration",
+      "enum": [
+        "none",
+        "warning_received",
+        "open",
+        "under_review",
+        "won",
+        "lost"
+      ],
+      "default": "none"
+    },
+    "disputeId": {
+      "type": "string"
+    },
+    "disputeReason": {
+      "type": "string"
+    },
+    "disputeClosedAt": {
+      "type": "datetime"
     }
   }
 }

--- a/donaction-api/src/helpers/stripe-connect-helper.ts
+++ b/donaction-api/src/helpers/stripe-connect-helper.ts
@@ -103,6 +103,7 @@ export type BusinessType = 'individual' | 'company' | 'non_profit';
 export type FinancialActionType =
     | 'transfer_created'
     | 'transfer_reversed'
+    | 'transfer_reversal_failed'
     | 'payout_initiated'
     | 'refund_processed'
     | 'fee_calculated'

--- a/donaction-api/src/helpers/stripe-connect-helper.ts
+++ b/donaction-api/src/helpers/stripe-connect-helper.ts
@@ -109,7 +109,8 @@ export type FinancialActionType =
     | 'fee_calculated'
     | 'dispute_opened'
     | 'dispute_won'
-    | 'dispute_lost';
+    | 'dispute_lost'
+    | 'transfer_creation_failed';
 
 /**
  * Creates a Stripe connected account for a klubr

--- a/donaction-api/src/helpers/stripe-connect-helper.ts
+++ b/donaction-api/src/helpers/stripe-connect-helper.ts
@@ -102,9 +102,13 @@ export type BusinessType = 'individual' | 'company' | 'non_profit';
  */
 export type FinancialActionType =
     | 'transfer_created'
+    | 'transfer_reversed'
     | 'payout_initiated'
     | 'refund_processed'
-    | 'fee_calculated';
+    | 'fee_calculated'
+    | 'dispute_opened'
+    | 'dispute_won'
+    | 'dispute_lost';
 
 /**
  * Creates a Stripe connected account for a klubr

--- a/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
@@ -770,10 +770,10 @@ describe('handleDispute', () => {
         // Flush async fire-and-forget
         await new Promise(process.nextTick);
 
-        expect(mockGetKlubMembres).toHaveBeenCalledWith(
-            'doc_klubr_456',
-            ['KlubMemberLeader'],
-        );
+        expect(mockGetKlubMembres).toHaveBeenCalledWith('doc_klubr_456', [
+            'KlubMemberLeader',
+            'AdminEditor',
+        ]);
         expect(sendBrevoTransacEmail).toHaveBeenCalledWith(
             expect.objectContaining({
                 templateId: BREVO_TEMPLATES.LEADER_ALERT,
@@ -999,5 +999,159 @@ describe('handleDispute', () => {
                 }),
             })
         );
+    });
+
+    it('skips reversal on funds_withdrawn when accountId is unknown', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+        const event = {
+            ...makeDisputeEvent('charge.dispute.funds_withdrawn'),
+            account: undefined,
+        } as unknown as Stripe.Event;
+
+        await handleDispute(mockDisputeStrapi, event);
+
+        expect(mockStripeClient.transfers.list).not.toHaveBeenCalled();
+    });
+
+    it('logs transfer_reversed audit after successful reversal', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+
+        const mockTransfers = [
+            {
+                id: 'tr_test_789',
+                amount: 5000,
+                metadata: { payment_intent_id: 'pi_test_456' },
+            },
+        ];
+        vi.mocked(mockStripeClient.transfers.list).mockReturnValue({
+            [Symbol.asyncIterator]: async function* () {
+                for (const t of mockTransfers) yield t;
+            },
+        } as any);
+        vi.mocked(mockStripeClient.transfers.listReversals).mockResolvedValue({
+            data: [],
+        } as any);
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.funds_withdrawn')
+        );
+
+        expect(logFinancialAction).toHaveBeenCalledWith(
+            mockDisputeStrapi,
+            'transfer_reversed',
+            'doc_klubr_456',
+            'doc_don_123',
+            5000,
+            'trr_test',
+            expect.objectContaining({
+                dispute_id: 'dp_test_123',
+                original_transfer_id: 'tr_test_789',
+            }),
+        );
+    });
+
+    it('logs failed reversal audit when createReversal throws', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+
+        const mockTransfers = [
+            {
+                id: 'tr_test_789',
+                amount: 5000,
+                metadata: { payment_intent_id: 'pi_test_456' },
+            },
+        ];
+        vi.mocked(mockStripeClient.transfers.list).mockReturnValue({
+            [Symbol.asyncIterator]: async function* () {
+                for (const t of mockTransfers) yield t;
+            },
+        } as any);
+        vi.mocked(mockStripeClient.transfers.listReversals).mockResolvedValue({
+            data: [],
+        } as any);
+        vi.mocked(mockStripeClient.transfers.createReversal).mockRejectedValueOnce(
+            new Error('Insufficient funds')
+        );
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.funds_withdrawn')
+        );
+
+        // Should log a failed transfer_reversed audit
+        expect(logFinancialAction).toHaveBeenCalledWith(
+            mockDisputeStrapi,
+            'transfer_reversed',
+            'doc_klubr_456',
+            'doc_don_123',
+            5000,
+            'failed_dp_test_123',
+            expect.objectContaining({
+                dispute_id: 'dp_test_123',
+                status: 'failed',
+                error: 'Insufficient funds',
+            }),
+        );
+    });
+
+    it('warns on unknown dispute status', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.updated', { status: 'some_future_status' })
+        );
+
+        expect(strapiLog.warn).toHaveBeenCalledWith(
+            expect.stringContaining("Statut dispute inconnu: 'some_future_status'")
+        );
+    });
+
+    it('handles expanded payment_intent object', async () => {
+        const mockUpdateDoc = vi.fn().mockResolvedValue({});
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockUpdateDoc });
+
+        // payment_intent as expanded object instead of string
+        const event = makeDisputeEvent('charge.dispute.created', {
+            payment_intent: { id: 'pi_test_456', object: 'payment_intent' },
+        });
+
+        await handleDispute(mockDisputeStrapi, event);
+
+        expect(mockUpdateDoc).toHaveBeenCalledWith(
+            expect.objectContaining({
+                documentId: 'doc_don_123',
+            })
+        );
+    });
+
+    it('skips duplicate closed event when disputeClosedAt already set', async () => {
+        const mockUpdateDoc = vi.fn().mockResolvedValue({});
+        const mockFindOnePayment = vi.fn().mockResolvedValue({
+            intent_id: 'pi_test_456',
+            klub_don: {
+                id: 1,
+                documentId: 'doc_don_123',
+                disputeId: 'dp_test_123',
+                disputeClosedAt: '2026-03-08T10:00:00Z', // Already closed
+                klubr: {
+                    id: 10,
+                    documentId: 'doc_klubr_456',
+                    denomination: 'Mon Association',
+                    uuid: 'klubr-uuid-789',
+                },
+            },
+        });
+        const mockDisputeStrapi = makeDisputeMockStrapi({
+            mockUpdateDoc,
+            mockFindOnePayment,
+        });
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.closed', { status: 'lost' })
+        );
+
+        expect(mockUpdateDoc).not.toHaveBeenCalled();
     });
 });

--- a/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
@@ -9,6 +9,7 @@ vi.mock('./stripe-connect-helper', () => ({
         transfers: {
             list: vi.fn().mockResolvedValue({ data: [] }),
             createReversal: vi.fn().mockResolvedValue({ id: 'trr_test', amount: 5000 }),
+            listReversals: vi.fn().mockResolvedValue({ data: [] }),
         },
     },
 }));
@@ -691,6 +692,10 @@ describe('handleDispute', () => {
                 for (const t of mockTransfers) yield t;
             },
         } as any);
+        // No existing reversals
+        vi.mocked(mockStripeClient.transfers.listReversals).mockResolvedValue({
+            data: [],
+        } as any);
 
         await handleDispute(
             mockDisputeStrapi,
@@ -701,6 +706,10 @@ describe('handleDispute', () => {
             expect.objectContaining({
                 destination: 'acct_connect_test',
             })
+        );
+        expect(mockStripeClient.transfers.listReversals).toHaveBeenCalledWith(
+            'tr_test_789',
+            { limit: 10 },
         );
         expect(mockStripeClient.transfers.createReversal).toHaveBeenCalledWith(
             'tr_test_789',
@@ -876,6 +885,119 @@ describe('handleDispute', () => {
                 dispute_status: 'needs_response',
                 dispute_reason: 'fraudulent',
             }),
+        );
+    });
+
+    it('catches and logs reversal Stripe API errors without throwing', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+
+        const mockTransfers = [
+            {
+                id: 'tr_test_789',
+                amount: 5000,
+                metadata: { payment_intent_id: 'pi_test_456' },
+            },
+        ];
+        vi.mocked(mockStripeClient.transfers.list).mockReturnValue({
+            [Symbol.asyncIterator]: async function* () {
+                for (const t of mockTransfers) yield t;
+            },
+        } as any);
+        vi.mocked(mockStripeClient.transfers.listReversals).mockResolvedValue({
+            data: [],
+        } as any);
+        vi.mocked(mockStripeClient.transfers.createReversal).mockRejectedValueOnce(
+            new Error('Stripe API failure')
+        );
+
+        // Should not throw — error is caught and logged
+        await expect(
+            handleDispute(
+                mockDisputeStrapi,
+                makeDisputeEvent('charge.dispute.funds_withdrawn')
+            )
+        ).resolves.toBeUndefined();
+
+        expect(strapiLog.error).toHaveBeenCalledWith(
+            expect.stringContaining('Echec du reversal'),
+            expect.any(Error),
+        );
+    });
+
+    it('sends admin alert on charge.dispute.closed', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.closed', { status: 'won' })
+        );
+
+        await new Promise(process.nextTick);
+
+        expect(sendBrevoTransacEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                destIsAdmin: true,
+                tags: expect.arrayContaining(['admin-alert', 'dispute-won']),
+            })
+        );
+    });
+
+    it('skips reversal when already reversed for this dispute (idempotency)', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+
+        const mockTransfers = [
+            {
+                id: 'tr_test_789',
+                amount: 5000,
+                metadata: { payment_intent_id: 'pi_test_456' },
+            },
+        ];
+        vi.mocked(mockStripeClient.transfers.list).mockReturnValue({
+            [Symbol.asyncIterator]: async function* () {
+                for (const t of mockTransfers) yield t;
+            },
+        } as any);
+        // Existing reversal for this dispute
+        vi.mocked(mockStripeClient.transfers.listReversals).mockResolvedValue({
+            data: [{ id: 'trr_existing', metadata: { dispute_id: 'dp_test_123' } }],
+        } as any);
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.funds_withdrawn')
+        );
+
+        expect(mockStripeClient.transfers.createReversal).not.toHaveBeenCalled();
+    });
+
+    it('does NOT set disputeClosedAt on non-terminal status', async () => {
+        const mockUpdateDoc = vi.fn().mockResolvedValue({});
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockUpdateDoc });
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.updated', { status: 'under_review' })
+        );
+
+        const updateCall = mockUpdateDoc.mock.calls[0][0];
+        expect(updateCall.data).not.toHaveProperty('disputeClosedAt');
+    });
+
+    it('maps warning_under_review to distinct status', async () => {
+        const mockUpdateDoc = vi.fn().mockResolvedValue({});
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockUpdateDoc });
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.updated', { status: 'warning_under_review' })
+        );
+
+        expect(mockUpdateDoc).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    disputeStatus: 'warning_under_review',
+                }),
+            })
         );
     });
 });

--- a/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
@@ -3,8 +3,13 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock stripe-connect-helper before importing handlers
 vi.mock('./stripe-connect-helper', () => ({
     syncAccountStatus: vi.fn().mockResolvedValue({}),
+    logFinancialAction: vi.fn().mockResolvedValue({}),
     stripe: {
         events: { retrieve: vi.fn() },
+        transfers: {
+            list: vi.fn().mockResolvedValue({ data: [] }),
+            createReversal: vi.fn().mockResolvedValue({ id: 'trr_test', amount: 5000 }),
+        },
     },
 }));
 
@@ -25,8 +30,9 @@ vi.mock('./emails/sendBrevoTransacEmail', () => ({
 import {
     handleWebhookEvent,
     handleAccountDeauthorized,
+    handleDispute,
 } from './stripe-webhook-handlers';
-import { syncAccountStatus } from './stripe-connect-helper';
+import { syncAccountStatus, logFinancialAction, stripe as mockStripeClient } from './stripe-connect-helper';
 import { logSimple, strapiLog } from './logger';
 import { sendBrevoTransacEmail, BREVO_TEMPLATES } from './emails/sendBrevoTransacEmail';
 import Stripe from 'stripe';
@@ -46,6 +52,71 @@ const makeEvent = (
         account: 'acct_test',
         ...overrides,
     }) as unknown as Stripe.Event;
+
+/** Build a dispute-specific Stripe event */
+const makeDisputeEvent = (
+    type: string,
+    overrides: Record<string, any> = {}
+): Stripe.Event =>
+    ({
+        id: 'evt_dispute_123',
+        type,
+        data: {
+            object: {
+                id: 'dp_test_123',
+                payment_intent: 'pi_test_456',
+                status: 'needs_response',
+                reason: 'fraudulent',
+                amount: 5000,
+                evidence_details: { due_by: Math.floor(Date.now() / 1000) + 86400 },
+                ...overrides,
+            },
+        },
+        account: 'acct_connect_test',
+    }) as unknown as Stripe.Event;
+
+/** Build a mock Strapi instance for dispute tests */
+const makeDisputeMockStrapi = (overrides: Record<string, any> = {}) => {
+    const mockUpdateDoc = overrides.mockUpdateDoc || vi.fn().mockResolvedValue({});
+    const mockFindOnePayment = overrides.mockFindOnePayment || vi.fn().mockResolvedValue({
+        intent_id: 'pi_test_456',
+        klub_don: {
+            id: 1,
+            documentId: 'doc_don_123',
+            klubr: {
+                id: 10,
+                documentId: 'doc_klubr_456',
+                denomination: 'Mon Association',
+                uuid: 'klubr-uuid-789',
+            },
+        },
+    });
+    const mockGetKlubMembres = overrides.mockGetKlubMembres || vi.fn().mockResolvedValue([]);
+
+    return {
+        db: {
+            query: vi.fn().mockImplementation((uid: string) => {
+                if (uid === 'api::klub-don-payment.klub-don-payment') {
+                    return { findOne: mockFindOnePayment };
+                }
+                if (uid === 'api::connected-account.connected-account') {
+                    return { findOne: vi.fn().mockResolvedValue(null) };
+                }
+                return { findOne: vi.fn() };
+            }),
+        },
+        documents: vi.fn().mockReturnValue({
+            update: mockUpdateDoc,
+            create: vi.fn().mockResolvedValue({}),
+        }),
+        service: vi.fn().mockImplementation((uid: string) => {
+            if (uid === 'api::klubr-membre.klubr-membre') {
+                return { getKlubMembres: mockGetKlubMembres };
+            }
+            return {};
+        }),
+    } as unknown as Core.Strapi;
+};
 
 describe('handleWebhookEvent', () => {
     beforeEach(() => {
@@ -131,73 +202,50 @@ describe('handleWebhookEvent', () => {
         expect(syncAccountStatus).not.toHaveBeenCalled();
     });
 
-    it('routes charge.dispute.created and logs dispute info', async () => {
-        const event = makeEvent('charge.dispute.created');
+    it('routes charge.dispute.created to handleDispute', async () => {
+        // handleDispute now requires db access; use a mock strapi with db.query
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+        const event = makeDisputeEvent('charge.dispute.created');
         await expect(
-            handleWebhookEvent(mockStrapi, event)
+            handleWebhookEvent(mockDisputeStrapi, event)
         ).resolves.toBeUndefined();
         expect(syncAccountStatus).not.toHaveBeenCalled();
-        expect(logSimple).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message: expect.stringContaining('charge.dispute.created'),
-            })
-        );
     });
 
-    it('routes charge.dispute.updated and logs dispute info', async () => {
-        const event = makeEvent('charge.dispute.updated');
+    it('routes charge.dispute.updated to handleDispute', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+        const event = makeDisputeEvent('charge.dispute.updated');
         await expect(
-            handleWebhookEvent(mockStrapi, event)
+            handleWebhookEvent(mockDisputeStrapi, event)
         ).resolves.toBeUndefined();
         expect(syncAccountStatus).not.toHaveBeenCalled();
-        expect(logSimple).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message: expect.stringContaining('charge.dispute.updated'),
-            })
-        );
     });
 
-    it('routes charge.dispute.closed and logs dispute info', async () => {
-        const event = makeEvent('charge.dispute.closed');
+    it('routes charge.dispute.closed to handleDispute', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+        const event = makeDisputeEvent('charge.dispute.closed');
         await expect(
-            handleWebhookEvent(mockStrapi, event)
+            handleWebhookEvent(mockDisputeStrapi, event)
         ).resolves.toBeUndefined();
         expect(syncAccountStatus).not.toHaveBeenCalled();
-        expect(logSimple).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message: expect.stringContaining('charge.dispute.closed'),
-            })
-        );
     });
 
-    it('routes charge.dispute.funds_withdrawn and logs dispute info', async () => {
-        const event = makeEvent('charge.dispute.funds_withdrawn');
+    it('routes charge.dispute.funds_withdrawn to handleDispute', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+        const event = makeDisputeEvent('charge.dispute.funds_withdrawn');
         await expect(
-            handleWebhookEvent(mockStrapi, event)
+            handleWebhookEvent(mockDisputeStrapi, event)
         ).resolves.toBeUndefined();
         expect(syncAccountStatus).not.toHaveBeenCalled();
-        expect(logSimple).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message: expect.stringContaining(
-                    'charge.dispute.funds_withdrawn'
-                ),
-            })
-        );
     });
 
-    it('routes charge.dispute.funds_reinstated and logs dispute info', async () => {
-        const event = makeEvent('charge.dispute.funds_reinstated');
+    it('routes charge.dispute.funds_reinstated to handleDispute', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+        const event = makeDisputeEvent('charge.dispute.funds_reinstated');
         await expect(
-            handleWebhookEvent(mockStrapi, event)
+            handleWebhookEvent(mockDisputeStrapi, event)
         ).resolves.toBeUndefined();
         expect(syncAccountStatus).not.toHaveBeenCalled();
-        expect(logSimple).toHaveBeenCalledWith(
-            expect.objectContaining({
-                message: expect.stringContaining(
-                    'charge.dispute.funds_reinstated'
-                ),
-            })
-        );
     });
 
     it('routes payout.paid and logs payout info', async () => {
@@ -479,5 +527,277 @@ describe('handleAccountDeauthorized', () => {
             (c: string[]) => c[0] === 'api::klubr.klubr'
         );
         expect(klubrCalls).toHaveLength(0);
+    });
+});
+
+// ---------- handleDispute ----------
+
+describe('handleDispute', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns early when dispute has no payment_intent', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+        const event = makeDisputeEvent('charge.dispute.created', {
+            payment_intent: null,
+        });
+
+        await handleDispute(mockDisputeStrapi, event);
+
+        expect(strapiLog.error).toHaveBeenCalledWith(
+            expect.stringContaining('sans payment_intent')
+        );
+    });
+
+    it('returns early when payment/don not found', async () => {
+        const mockFindOnePayment = vi.fn().mockResolvedValue(null);
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockFindOnePayment });
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.created')
+        );
+
+        expect(strapiLog.warn).toHaveBeenCalledWith(
+            expect.stringContaining('Don non trouvé')
+        );
+    });
+
+    it('updates klub_don with dispute status (charge.dispute.created)', async () => {
+        const mockUpdateDoc = vi.fn().mockResolvedValue({});
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockUpdateDoc });
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.created')
+        );
+
+        expect(mockDisputeStrapi.documents).toHaveBeenCalledWith(
+            'api::klub-don.klub-don'
+        );
+        expect(mockUpdateDoc).toHaveBeenCalledWith(
+            expect.objectContaining({
+                documentId: 'doc_don_123',
+                data: expect.objectContaining({
+                    disputeStatus: 'open',
+                    disputeId: 'dp_test_123',
+                    disputeReason: 'fraudulent',
+                }),
+            })
+        );
+    });
+
+    it('maps dispute status correctly for "under_review"', async () => {
+        const mockUpdateDoc = vi.fn().mockResolvedValue({});
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockUpdateDoc });
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.updated', { status: 'under_review' })
+        );
+
+        expect(mockUpdateDoc).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    disputeStatus: 'under_review',
+                }),
+            })
+        );
+    });
+
+    it('sets disputeClosedAt when dispute is won', async () => {
+        const mockUpdateDoc = vi.fn().mockResolvedValue({});
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockUpdateDoc });
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.closed', { status: 'won' })
+        );
+
+        expect(mockUpdateDoc).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    disputeStatus: 'won',
+                    disputeClosedAt: expect.any(Date),
+                }),
+            })
+        );
+    });
+
+    it('sets disputeClosedAt when dispute is lost', async () => {
+        const mockUpdateDoc = vi.fn().mockResolvedValue({});
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockUpdateDoc });
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.closed', { status: 'lost' })
+        );
+
+        expect(mockUpdateDoc).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    disputeStatus: 'lost',
+                    disputeClosedAt: expect.any(Date),
+                }),
+            })
+        );
+    });
+
+    it('sends admin alert on charge.dispute.created', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.created')
+        );
+
+        // Flush async fire-and-forget
+        await new Promise(process.nextTick);
+
+        expect(sendBrevoTransacEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                destIsAdmin: true,
+                tags: expect.arrayContaining(['admin-alert', 'dispute-created']),
+                params: expect.objectContaining({
+                    CLUB_NAME: 'Mon Association',
+                    STRIPE_ACCOUNT_ID: 'acct_connect_test',
+                }),
+            })
+        );
+    });
+
+    it('attempts reverse transfer on charge.dispute.created when amount > 0', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+
+        // Mock stripe.transfers.list to return a matching transfer
+        vi.mocked(mockStripeClient.transfers.list).mockResolvedValue({
+            data: [
+                {
+                    id: 'tr_test_789',
+                    amount: 5000,
+                    metadata: { payment_intent_id: 'pi_test_456' },
+                },
+            ],
+        } as any);
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.created')
+        );
+
+        expect(mockStripeClient.transfers.list).toHaveBeenCalledWith(
+            expect.objectContaining({
+                destination: 'acct_connect_test',
+            })
+        );
+        expect(mockStripeClient.transfers.createReversal).toHaveBeenCalledWith(
+            'tr_test_789',
+            expect.objectContaining({
+                amount: 5000,
+                metadata: expect.objectContaining({
+                    dispute_id: 'dp_test_123',
+                }),
+            })
+        );
+    });
+
+    it('skips reverse transfer when no matching transfer found', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+
+        vi.mocked(mockStripeClient.transfers.list).mockResolvedValue({
+            data: [],
+        } as any);
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.created')
+        );
+
+        expect(mockStripeClient.transfers.createReversal).not.toHaveBeenCalled();
+    });
+
+    it('sends LEADER_ALERT notification when dispute is lost', async () => {
+        const mockGetKlubMembres = vi.fn().mockResolvedValue([
+            {
+                email: 'leader@asso.fr',
+                nom: 'Martin',
+                prenom: 'Pierre',
+                users_permissions_user: { email: 'leader-user@asso.fr' },
+            },
+        ]);
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockGetKlubMembres });
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.closed', { status: 'lost' })
+        );
+
+        // Flush async fire-and-forget
+        await new Promise(process.nextTick);
+
+        expect(mockGetKlubMembres).toHaveBeenCalledWith(
+            'doc_klubr_456',
+            ['KlubMemberLeader'],
+        );
+        expect(sendBrevoTransacEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                templateId: BREVO_TEMPLATES.LEADER_ALERT,
+                to: [{ email: 'leader@asso.fr', name: 'Pierre Martin' }],
+                tags: expect.arrayContaining(['klubr-notification', 'dispute-lost']),
+            })
+        );
+    });
+
+    it('does NOT send LEADER_ALERT when dispute is won', async () => {
+        const mockGetKlubMembres = vi.fn().mockResolvedValue([]);
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockGetKlubMembres });
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.closed', { status: 'won' })
+        );
+
+        // Flush async fire-and-forget
+        await new Promise(process.nextTick);
+
+        // Leaders should NOT be queried for won disputes
+        expect(mockGetKlubMembres).not.toHaveBeenCalled();
+    });
+
+    it('logs financial audit on dispute closure', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.closed', { status: 'lost' })
+        );
+
+        // Flush async fire-and-forget
+        await new Promise(process.nextTick);
+
+        expect(logFinancialAction).toHaveBeenCalledWith(
+            mockDisputeStrapi,
+            'dispute_lost',
+            'doc_klubr_456',
+            'doc_don_123',
+            5000,
+            'dp_test_123',
+            expect.objectContaining({
+                dispute_status: 'lost',
+                dispute_reason: 'fraudulent',
+            }),
+        );
+    });
+
+    it('does not reverse transfer when amount is 0', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.created', { amount: 0 })
+        );
+
+        expect(mockStripeClient.transfers.list).not.toHaveBeenCalled();
     });
 });

--- a/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
@@ -4,10 +4,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('./stripe-connect-helper', () => ({
     syncAccountStatus: vi.fn().mockResolvedValue({}),
     logFinancialAction: vi.fn().mockResolvedValue({}),
+    createTransferToConnectedAccount: vi.fn().mockResolvedValue({ id: 'tr_new_transfer', amount: 5000 }),
     stripe: {
         events: { retrieve: vi.fn() },
+        charges: {
+            retrieve: vi.fn(),
+        },
         transfers: {
             list: vi.fn().mockResolvedValue({ data: [] }),
+            retrieve: vi.fn(),
             createReversal: vi.fn().mockResolvedValue({ id: 'trr_test', amount: 5000 }),
             listReversals: vi.fn().mockResolvedValue({ data: [] }),
         },
@@ -33,7 +38,7 @@ import {
     handleAccountDeauthorized,
     handleDispute,
 } from './stripe-webhook-handlers';
-import { syncAccountStatus, logFinancialAction, stripe as mockStripeClient } from './stripe-connect-helper';
+import { syncAccountStatus, logFinancialAction, createTransferToConnectedAccount, stripe as mockStripeClient } from './stripe-connect-helper';
 import { logSimple, strapiLog } from './logger';
 import { sendBrevoTransacEmail, BREVO_TEMPLATES } from './emails/sendBrevoTransacEmail';
 import Stripe from 'stripe';
@@ -65,6 +70,7 @@ const makeDisputeEvent = (
         data: {
             object: {
                 id: 'dp_test_123',
+                charge: 'ch_test_123',
                 payment_intent: 'pi_test_456',
                 status: 'needs_response',
                 reason: 'fraudulent',
@@ -75,6 +81,29 @@ const makeDisputeEvent = (
         },
         account: 'acct_connect_test',
     }) as unknown as Stripe.Event;
+
+/** Mock Stripe charge+transfer lookup used by reverseTransferForDispute and reTransferForDisputeWon */
+const mockChargeTransferLookup = (opts: { withReversals?: boolean; rejectReversal?: Error } = {}) => {
+    vi.mocked(mockStripeClient.charges.retrieve).mockResolvedValue({
+        id: 'ch_test_123',
+        transfer: 'tr_test_789',
+    } as any);
+    vi.mocked(mockStripeClient.transfers.retrieve).mockResolvedValue({
+        id: 'tr_test_789',
+        amount: 5000,
+        metadata: { payment_intent_id: 'pi_test_456' },
+    } as any);
+    vi.mocked(mockStripeClient.transfers.listReversals).mockResolvedValue({
+        data: opts.withReversals
+            ? [{ id: 'trr_existing', metadata: { dispute_id: 'dp_test_123' } }]
+            : [],
+    } as any);
+    if (opts.rejectReversal) {
+        vi.mocked(mockStripeClient.transfers.createReversal).mockRejectedValueOnce(
+            opts.rejectReversal
+        );
+    }
+};
 
 /** Build a mock Strapi instance for dispute tests */
 const makeDisputeMockStrapi = (overrides: Record<string, any> = {}) => {
@@ -678,35 +707,15 @@ describe('handleDispute', () => {
 
     it('attempts reverse transfer on charge.dispute.funds_withdrawn when amount > 0', async () => {
         const mockDisputeStrapi = makeDisputeMockStrapi();
-
-        // Mock stripe.transfers.list auto-pagination (for await...of)
-        const mockTransfers = [
-            {
-                id: 'tr_test_789',
-                amount: 5000,
-                metadata: { payment_intent_id: 'pi_test_456' },
-            },
-        ];
-        vi.mocked(mockStripeClient.transfers.list).mockReturnValue({
-            [Symbol.asyncIterator]: async function* () {
-                for (const t of mockTransfers) yield t;
-            },
-        } as any);
-        // No existing reversals
-        vi.mocked(mockStripeClient.transfers.listReversals).mockResolvedValue({
-            data: [],
-        } as any);
+        mockChargeTransferLookup();
 
         await handleDispute(
             mockDisputeStrapi,
             makeDisputeEvent('charge.dispute.funds_withdrawn')
         );
 
-        expect(mockStripeClient.transfers.list).toHaveBeenCalledWith(
-            expect.objectContaining({
-                destination: 'acct_connect_test',
-            })
-        );
+        expect(mockStripeClient.charges.retrieve).toHaveBeenCalledWith('ch_test_123');
+        expect(mockStripeClient.transfers.retrieve).toHaveBeenCalledWith('tr_test_789');
         expect(mockStripeClient.transfers.listReversals).toHaveBeenCalledWith(
             'tr_test_789',
             { limit: 10 },
@@ -722,13 +731,12 @@ describe('handleDispute', () => {
         );
     });
 
-    it('skips reverse transfer when no matching transfer found', async () => {
+    it('skips when charge has no transfer', async () => {
         const mockDisputeStrapi = makeDisputeMockStrapi();
 
-        vi.mocked(mockStripeClient.transfers.list).mockReturnValue({
-            [Symbol.asyncIterator]: async function* () {
-                // empty
-            },
+        vi.mocked(mockStripeClient.charges.retrieve).mockResolvedValue({
+            id: 'ch_test_123',
+            transfer: null,
         } as any);
 
         await handleDispute(
@@ -747,7 +755,7 @@ describe('handleDispute', () => {
             makeDisputeEvent('charge.dispute.created')
         );
 
-        expect(mockStripeClient.transfers.list).not.toHaveBeenCalled();
+        expect(mockStripeClient.charges.retrieve).not.toHaveBeenCalled();
         expect(mockStripeClient.transfers.createReversal).not.toHaveBeenCalled();
     });
 
@@ -774,11 +782,20 @@ describe('handleDispute', () => {
             'KlubMemberLeader',
             'AdminEditor',
         ]);
+        // Club leaders notification
         expect(sendBrevoTransacEmail).toHaveBeenCalledWith(
             expect.objectContaining({
                 templateId: BREVO_TEMPLATES.LEADER_ALERT,
                 to: [{ email: 'leader@asso.fr', name: 'Pierre Martin' }],
                 tags: expect.arrayContaining(['klubr-notification', 'dispute-lost']),
+            })
+        );
+        // Platform super admin notification
+        expect(sendBrevoTransacEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                templateId: BREVO_TEMPLATES.LEADER_ALERT,
+                destIsAdmin: true,
+                tags: expect.arrayContaining(['admin-alert', 'dispute-lost']),
             })
         );
     });
@@ -890,25 +907,7 @@ describe('handleDispute', () => {
 
     it('catches and logs reversal Stripe API errors without throwing', async () => {
         const mockDisputeStrapi = makeDisputeMockStrapi();
-
-        const mockTransfers = [
-            {
-                id: 'tr_test_789',
-                amount: 5000,
-                metadata: { payment_intent_id: 'pi_test_456' },
-            },
-        ];
-        vi.mocked(mockStripeClient.transfers.list).mockReturnValue({
-            [Symbol.asyncIterator]: async function* () {
-                for (const t of mockTransfers) yield t;
-            },
-        } as any);
-        vi.mocked(mockStripeClient.transfers.listReversals).mockResolvedValue({
-            data: [],
-        } as any);
-        vi.mocked(mockStripeClient.transfers.createReversal).mockRejectedValueOnce(
-            new Error('Stripe API failure')
-        );
+        mockChargeTransferLookup({ rejectReversal: new Error('Stripe API failure') });
 
         // Should not throw — error is caught and logged
         await expect(
@@ -944,23 +943,7 @@ describe('handleDispute', () => {
 
     it('skips reversal when already reversed for this dispute (idempotency)', async () => {
         const mockDisputeStrapi = makeDisputeMockStrapi();
-
-        const mockTransfers = [
-            {
-                id: 'tr_test_789',
-                amount: 5000,
-                metadata: { payment_intent_id: 'pi_test_456' },
-            },
-        ];
-        vi.mocked(mockStripeClient.transfers.list).mockReturnValue({
-            [Symbol.asyncIterator]: async function* () {
-                for (const t of mockTransfers) yield t;
-            },
-        } as any);
-        // Existing reversal for this dispute
-        vi.mocked(mockStripeClient.transfers.listReversals).mockResolvedValue({
-            data: [{ id: 'trr_existing', metadata: { dispute_id: 'dp_test_123' } }],
-        } as any);
+        mockChargeTransferLookup({ withReversals: true });
 
         await handleDispute(
             mockDisputeStrapi,
@@ -1015,22 +998,7 @@ describe('handleDispute', () => {
 
     it('logs transfer_reversed audit after successful reversal', async () => {
         const mockDisputeStrapi = makeDisputeMockStrapi();
-
-        const mockTransfers = [
-            {
-                id: 'tr_test_789',
-                amount: 5000,
-                metadata: { payment_intent_id: 'pi_test_456' },
-            },
-        ];
-        vi.mocked(mockStripeClient.transfers.list).mockReturnValue({
-            [Symbol.asyncIterator]: async function* () {
-                for (const t of mockTransfers) yield t;
-            },
-        } as any);
-        vi.mocked(mockStripeClient.transfers.listReversals).mockResolvedValue({
-            data: [],
-        } as any);
+        mockChargeTransferLookup();
 
         await handleDispute(
             mockDisputeStrapi,
@@ -1053,35 +1021,17 @@ describe('handleDispute', () => {
 
     it('logs failed reversal audit when createReversal throws', async () => {
         const mockDisputeStrapi = makeDisputeMockStrapi();
-
-        const mockTransfers = [
-            {
-                id: 'tr_test_789',
-                amount: 5000,
-                metadata: { payment_intent_id: 'pi_test_456' },
-            },
-        ];
-        vi.mocked(mockStripeClient.transfers.list).mockReturnValue({
-            [Symbol.asyncIterator]: async function* () {
-                for (const t of mockTransfers) yield t;
-            },
-        } as any);
-        vi.mocked(mockStripeClient.transfers.listReversals).mockResolvedValue({
-            data: [],
-        } as any);
-        vi.mocked(mockStripeClient.transfers.createReversal).mockRejectedValueOnce(
-            new Error('Insufficient funds')
-        );
+        mockChargeTransferLookup({ rejectReversal: new Error('Insufficient funds') });
 
         await handleDispute(
             mockDisputeStrapi,
             makeDisputeEvent('charge.dispute.funds_withdrawn')
         );
 
-        // Should log a failed transfer_reversed audit
+        // Should log a failed transfer_reversal_failed audit
         expect(logFinancialAction).toHaveBeenCalledWith(
             mockDisputeStrapi,
-            'transfer_reversed',
+            'transfer_reversal_failed',
             'doc_klubr_456',
             'doc_don_123',
             5000,
@@ -1153,5 +1103,88 @@ describe('handleDispute', () => {
         );
 
         expect(mockUpdateDoc).not.toHaveBeenCalled();
+    });
+
+    it('maps funds_reinstated to won status', async () => {
+        const mockUpdateDoc = vi.fn().mockResolvedValue({});
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockUpdateDoc });
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.funds_reinstated', { status: 'won' })
+        );
+
+        expect(mockUpdateDoc).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({
+                    disputeStatus: 'won',
+                }),
+            })
+        );
+    });
+
+    it('re-transfers funds on charge.dispute.funds_reinstated', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+        mockChargeTransferLookup();
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.funds_reinstated', { status: 'won' })
+        );
+
+        expect(mockStripeClient.charges.retrieve).toHaveBeenCalledWith('ch_test_123');
+        expect(mockStripeClient.transfers.retrieve).toHaveBeenCalledWith('tr_test_789');
+        expect(logFinancialAction).toHaveBeenCalledWith(
+            mockDisputeStrapi,
+            'transfer_created',
+            'doc_klubr_456',
+            'doc_don_123',
+            5000,
+            'tr_new_transfer',
+            expect.objectContaining({
+                reason: 'dispute_funds_reinstated',
+            }),
+        );
+    });
+
+    it('sends admin alert when reversal fails', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+        mockChargeTransferLookup({ rejectReversal: new Error('Stripe API failure') });
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.funds_withdrawn')
+        );
+
+        await new Promise(process.nextTick);
+
+        expect(sendBrevoTransacEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                destIsAdmin: true,
+                tags: expect.arrayContaining(['admin-alert', 'dispute-reversal_failed']),
+            })
+        );
+    });
+
+    it('uses transfer_reversal_failed audit type on failed reversal', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+        mockChargeTransferLookup({ rejectReversal: new Error('Insufficient funds') });
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.funds_withdrawn')
+        );
+
+        expect(logFinancialAction).toHaveBeenCalledWith(
+            mockDisputeStrapi,
+            'transfer_reversal_failed',
+            'doc_klubr_456',
+            'doc_don_123',
+            5000,
+            'failed_dp_test_123',
+            expect.objectContaining({
+                status: 'failed',
+            }),
+        );
     });
 });

--- a/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
@@ -849,7 +849,7 @@ describe('handleDispute', () => {
             makeDisputeEvent('charge.dispute.funds_withdrawn', { amount: 0 })
         );
 
-        expect(mockStripeClient.transfers.list).not.toHaveBeenCalled();
+        expect(mockStripeClient.charges.retrieve).not.toHaveBeenCalled();
     });
 
     it('skips processing on duplicate charge.dispute.created (idempotency)', async () => {
@@ -993,7 +993,7 @@ describe('handleDispute', () => {
 
         await handleDispute(mockDisputeStrapi, event);
 
-        expect(mockStripeClient.transfers.list).not.toHaveBeenCalled();
+        expect(mockStripeClient.charges.retrieve).not.toHaveBeenCalled();
     });
 
     it('logs transfer_reversed audit after successful reversal', async () => {

--- a/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
@@ -718,7 +718,7 @@ describe('handleDispute', () => {
         expect(mockStripeClient.transfers.retrieve).toHaveBeenCalledWith('tr_test_789');
         expect(mockStripeClient.transfers.listReversals).toHaveBeenCalledWith(
             'tr_test_789',
-            { limit: 10 },
+            { limit: 100 },
         );
         expect(mockStripeClient.transfers.createReversal).toHaveBeenCalledWith(
             'tr_test_789',

--- a/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
@@ -202,50 +202,58 @@ describe('handleWebhookEvent', () => {
         expect(syncAccountStatus).not.toHaveBeenCalled();
     });
 
-    it('routes charge.dispute.created to handleDispute', async () => {
-        // handleDispute now requires db access; use a mock strapi with db.query
-        const mockDisputeStrapi = makeDisputeMockStrapi();
+    it('routes charge.dispute.created to handleDispute and updates klub_don', async () => {
+        const mockUpdateDoc = vi.fn().mockResolvedValue({});
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockUpdateDoc });
         const event = makeDisputeEvent('charge.dispute.created');
-        await expect(
-            handleWebhookEvent(mockDisputeStrapi, event)
-        ).resolves.toBeUndefined();
+        await handleWebhookEvent(mockDisputeStrapi, event);
         expect(syncAccountStatus).not.toHaveBeenCalled();
+        expect(mockUpdateDoc).toHaveBeenCalledWith(
+            expect.objectContaining({
+                documentId: 'doc_don_123',
+                data: expect.objectContaining({ disputeId: 'dp_test_123' }),
+            })
+        );
     });
 
-    it('routes charge.dispute.updated to handleDispute', async () => {
-        const mockDisputeStrapi = makeDisputeMockStrapi();
+    it('routes charge.dispute.updated to handleDispute and updates klub_don', async () => {
+        const mockUpdateDoc = vi.fn().mockResolvedValue({});
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockUpdateDoc });
         const event = makeDisputeEvent('charge.dispute.updated');
-        await expect(
-            handleWebhookEvent(mockDisputeStrapi, event)
-        ).resolves.toBeUndefined();
+        await handleWebhookEvent(mockDisputeStrapi, event);
         expect(syncAccountStatus).not.toHaveBeenCalled();
+        expect(mockUpdateDoc).toHaveBeenCalled();
     });
 
-    it('routes charge.dispute.closed to handleDispute', async () => {
-        const mockDisputeStrapi = makeDisputeMockStrapi();
-        const event = makeDisputeEvent('charge.dispute.closed');
-        await expect(
-            handleWebhookEvent(mockDisputeStrapi, event)
-        ).resolves.toBeUndefined();
+    it('routes charge.dispute.closed to handleDispute and updates klub_don', async () => {
+        const mockUpdateDoc = vi.fn().mockResolvedValue({});
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockUpdateDoc });
+        const event = makeDisputeEvent('charge.dispute.closed', { status: 'won' });
+        await handleWebhookEvent(mockDisputeStrapi, event);
         expect(syncAccountStatus).not.toHaveBeenCalled();
+        expect(mockUpdateDoc).toHaveBeenCalledWith(
+            expect.objectContaining({
+                data: expect.objectContaining({ disputeStatus: 'won' }),
+            })
+        );
     });
 
-    it('routes charge.dispute.funds_withdrawn to handleDispute', async () => {
-        const mockDisputeStrapi = makeDisputeMockStrapi();
+    it('routes charge.dispute.funds_withdrawn to handleDispute and updates klub_don', async () => {
+        const mockUpdateDoc = vi.fn().mockResolvedValue({});
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockUpdateDoc });
         const event = makeDisputeEvent('charge.dispute.funds_withdrawn');
-        await expect(
-            handleWebhookEvent(mockDisputeStrapi, event)
-        ).resolves.toBeUndefined();
+        await handleWebhookEvent(mockDisputeStrapi, event);
         expect(syncAccountStatus).not.toHaveBeenCalled();
+        expect(mockUpdateDoc).toHaveBeenCalled();
     });
 
-    it('routes charge.dispute.funds_reinstated to handleDispute', async () => {
-        const mockDisputeStrapi = makeDisputeMockStrapi();
+    it('routes charge.dispute.funds_reinstated to handleDispute and updates klub_don', async () => {
+        const mockUpdateDoc = vi.fn().mockResolvedValue({});
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockUpdateDoc });
         const event = makeDisputeEvent('charge.dispute.funds_reinstated');
-        await expect(
-            handleWebhookEvent(mockDisputeStrapi, event)
-        ).resolves.toBeUndefined();
+        await handleWebhookEvent(mockDisputeStrapi, event);
         expect(syncAccountStatus).not.toHaveBeenCalled();
+        expect(mockUpdateDoc).toHaveBeenCalled();
     });
 
     it('routes payout.paid and logs payout info', async () => {
@@ -667,23 +675,26 @@ describe('handleDispute', () => {
         );
     });
 
-    it('attempts reverse transfer on charge.dispute.created when amount > 0', async () => {
+    it('attempts reverse transfer on charge.dispute.funds_withdrawn when amount > 0', async () => {
         const mockDisputeStrapi = makeDisputeMockStrapi();
 
-        // Mock stripe.transfers.list to return a matching transfer
-        vi.mocked(mockStripeClient.transfers.list).mockResolvedValue({
-            data: [
-                {
-                    id: 'tr_test_789',
-                    amount: 5000,
-                    metadata: { payment_intent_id: 'pi_test_456' },
-                },
-            ],
+        // Mock stripe.transfers.list auto-pagination (for await...of)
+        const mockTransfers = [
+            {
+                id: 'tr_test_789',
+                amount: 5000,
+                metadata: { payment_intent_id: 'pi_test_456' },
+            },
+        ];
+        vi.mocked(mockStripeClient.transfers.list).mockReturnValue({
+            [Symbol.asyncIterator]: async function* () {
+                for (const t of mockTransfers) yield t;
+            },
         } as any);
 
         await handleDispute(
             mockDisputeStrapi,
-            makeDisputeEvent('charge.dispute.created')
+            makeDisputeEvent('charge.dispute.funds_withdrawn')
         );
 
         expect(mockStripeClient.transfers.list).toHaveBeenCalledWith(
@@ -705,15 +716,29 @@ describe('handleDispute', () => {
     it('skips reverse transfer when no matching transfer found', async () => {
         const mockDisputeStrapi = makeDisputeMockStrapi();
 
-        vi.mocked(mockStripeClient.transfers.list).mockResolvedValue({
-            data: [],
+        vi.mocked(mockStripeClient.transfers.list).mockReturnValue({
+            [Symbol.asyncIterator]: async function* () {
+                // empty
+            },
         } as any);
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.funds_withdrawn')
+        );
+
+        expect(mockStripeClient.transfers.createReversal).not.toHaveBeenCalled();
+    });
+
+    it('does NOT reverse transfer on charge.dispute.created (waits for funds_withdrawn)', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
 
         await handleDispute(
             mockDisputeStrapi,
             makeDisputeEvent('charge.dispute.created')
         );
 
+        expect(mockStripeClient.transfers.list).not.toHaveBeenCalled();
         expect(mockStripeClient.transfers.createReversal).not.toHaveBeenCalled();
     });
 
@@ -795,9 +820,62 @@ describe('handleDispute', () => {
 
         await handleDispute(
             mockDisputeStrapi,
-            makeDisputeEvent('charge.dispute.created', { amount: 0 })
+            makeDisputeEvent('charge.dispute.funds_withdrawn', { amount: 0 })
         );
 
         expect(mockStripeClient.transfers.list).not.toHaveBeenCalled();
+    });
+
+    it('skips processing on duplicate charge.dispute.created (idempotency)', async () => {
+        const mockUpdateDoc = vi.fn().mockResolvedValue({});
+        const mockFindOnePayment = vi.fn().mockResolvedValue({
+            intent_id: 'pi_test_456',
+            klub_don: {
+                id: 1,
+                documentId: 'doc_don_123',
+                disputeId: 'dp_test_123', // Already processed
+                klubr: {
+                    id: 10,
+                    documentId: 'doc_klubr_456',
+                    denomination: 'Mon Association',
+                    uuid: 'klubr-uuid-789',
+                },
+            },
+        });
+        const mockDisputeStrapi = makeDisputeMockStrapi({
+            mockUpdateDoc,
+            mockFindOnePayment,
+        });
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.created')
+        );
+
+        expect(mockUpdateDoc).not.toHaveBeenCalled();
+    });
+
+    it('logs dispute_opened audit on charge.dispute.created', async () => {
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.created')
+        );
+
+        await new Promise(process.nextTick);
+
+        expect(logFinancialAction).toHaveBeenCalledWith(
+            mockDisputeStrapi,
+            'dispute_opened',
+            'doc_klubr_456',
+            'doc_don_123',
+            5000,
+            'dp_test_123',
+            expect.objectContaining({
+                dispute_status: 'needs_response',
+                dispute_reason: 'fraudulent',
+            }),
+        );
     });
 });

--- a/donaction-api/src/helpers/stripe-webhook-handlers.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.ts
@@ -1,6 +1,6 @@
 import type Stripe from 'stripe';
 import { Core } from '@strapi/strapi';
-import { syncAccountStatus, stripe } from './stripe-connect-helper';
+import { syncAccountStatus, stripe, logFinancialAction } from './stripe-connect-helper';
 import { logBlock, logSimple, strapiLog, COLORS } from './logger';
 import {
     sendBrevoTransacEmail,
@@ -473,11 +473,24 @@ async function sendDeauthorizedKlubrNotification(
 }
 
 /**
+ * Maps Stripe dispute status to internal dispute status
+ */
+const DISPUTE_STATUS_MAP: Record<string, string> = {
+    warning_needs_response: 'warning_received',
+    warning_under_review: 'warning_received',
+    warning_closed: 'none',
+    needs_response: 'open',
+    under_review: 'under_review',
+    won: 'won',
+    lost: 'lost',
+};
+
+/**
  * Handles charge.dispute.* webhook events
- * Stub handler - detailed dispute logic in follow-up US-WH-005
+ * Updates klub_don dispute status, sends admin alerts, and reverses transfers when needed.
  */
 export async function handleDispute(
-    _strapiInstance: Core.Strapi,
+    strapiInstance: Core.Strapi,
     event: Stripe.Event
 ): Promise<void> {
     logBlock({
@@ -491,14 +504,352 @@ export async function handleDispute(
 
     const dispute = event.data.object as Stripe.Dispute;
     const accountId = event.account ?? 'unknown';
+    const paymentIntentId = dispute.payment_intent as string;
+
+    if (!paymentIntentId) {
+        strapiLog.error(
+            `Dispute ${dispute.id} reçue sans payment_intent`
+        );
+        return;
+    }
+
+    // Find the donation via the payment record
+    const payment = await strapiInstance.db
+        .query('api::klub-don-payment.klub-don-payment')
+        .findOne({
+            where: { intent_id: paymentIntentId },
+            populate: {
+                klub_don: {
+                    populate: {
+                        klubr: true,
+                    },
+                },
+            },
+        });
+
+    if (!payment?.klub_don) {
+        strapiLog.warn(
+            `Don non trouvé pour dispute ${dispute.id} (payment_intent: ${paymentIntentId})`
+        );
+        return;
+    }
+
+    const klubDon = payment.klub_don;
+    const disputeStatus = (DISPUTE_STATUS_MAP[dispute.status] || 'open') as
+        'none' | 'warning_received' | 'open' | 'under_review' | 'won' | 'lost';
+
+    // Update klub_don with dispute info
+    await strapiInstance
+        .documents('api::klub-don.klub-don')
+        .update({
+            documentId: klubDon.documentId,
+            data: {
+                disputeStatus,
+                disputeId: dispute.id,
+                disputeReason: dispute.reason,
+                disputeClosedAt: ['won', 'lost'].includes(disputeStatus)
+                    ? new Date()
+                    : null,
+            },
+        });
 
     logSimple({
-        message: `Dispute ${dispute.id} (${event.type}) pour compte ${accountId}`,
+        message: `Don ${klubDon.documentId} mis à jour: disputeStatus=${disputeStatus}`,
         color: 'yellow',
         prefix: 'StripeConnect',
     });
 
-    // TODO: Implement dispute handling logic in US-WH-005
+    // Event-specific actions
+    if (event.type === 'charge.dispute.created') {
+        // Send urgent admin alert
+        void sendDisputeAdminAlert(
+            strapiInstance,
+            dispute,
+            klubDon,
+            accountId,
+            'created',
+        );
+
+        // Reverse transfer if dispute involves funds
+        if (dispute.amount > 0 && accountId !== 'unknown') {
+            await reverseTransferForDispute(
+                strapiInstance,
+                dispute,
+                klubDon,
+                accountId,
+            );
+        }
+    }
+
+    if (event.type === 'charge.dispute.closed') {
+        const auditActionType = disputeStatus === 'won' ? 'dispute_won' : 'dispute_lost';
+
+        // Log audit for closure
+        if (klubDon.klubr?.documentId) {
+            void logFinancialAction(
+                strapiInstance,
+                auditActionType,
+                klubDon.klubr.documentId,
+                klubDon.documentId,
+                dispute.amount,
+                dispute.id,
+                {
+                    dispute_status: dispute.status,
+                    dispute_reason: dispute.reason,
+                },
+            );
+        }
+
+        // Notify association leaders if dispute is lost
+        if (dispute.status === 'lost') {
+            void sendDisputeLostKlubrNotification(
+                strapiInstance,
+                dispute,
+                klubDon,
+            );
+        }
+
+        // Send admin alert for closure
+        void sendDisputeAdminAlert(
+            strapiInstance,
+            dispute,
+            klubDon,
+            accountId,
+            dispute.status === 'lost' ? 'lost' : 'won',
+        );
+    }
+
+    logSimple({
+        message: `Dispute ${dispute.id} traité: ${disputeStatus}`,
+        color: 'green',
+        prefix: 'StripeConnect',
+    });
+}
+
+/**
+ * Reverses the transfer to the connected account when a dispute is opened.
+ * Non-blocking if it fails (logged but not propagated).
+ */
+async function reverseTransferForDispute(
+    strapiInstance: Core.Strapi,
+    dispute: Stripe.Dispute,
+    klubDon: any,
+    accountId: string,
+): Promise<void> {
+    try {
+        // Find transfers associated with this charge
+        const paymentIntentId = dispute.payment_intent as string;
+        const transfers = await stripe.transfers.list({
+            destination: accountId,
+            limit: 10,
+        });
+
+        // Find the transfer linked to this payment via transfer_group or metadata
+        const relatedTransfer = transfers.data.find(
+            (t) =>
+                t.metadata?.payment_intent_id === paymentIntentId ||
+                t.metadata?.klub_don_id === klubDon.documentId,
+        );
+
+        if (!relatedTransfer) {
+            logSimple({
+                message: `Aucun transfert trouvé pour dispute ${dispute.id}, reversal ignoré`,
+                color: 'yellow',
+                prefix: 'StripeConnect',
+            });
+            return;
+        }
+
+        // Create transfer reversal
+        const reversal = await stripe.transfers.createReversal(
+            relatedTransfer.id,
+            {
+                amount: Math.min(dispute.amount, relatedTransfer.amount),
+                metadata: {
+                    dispute_id: dispute.id,
+                    reason: 'dispute_opened',
+                },
+            },
+        );
+
+        logSimple({
+            message: `Transfert ${relatedTransfer.id} reversé: ${reversal.id} (${reversal.amount / 100}€)`,
+            color: 'yellow',
+            prefix: 'StripeConnect',
+        });
+
+        // Audit log
+        if (klubDon.klubr?.documentId) {
+            await logFinancialAction(
+                strapiInstance,
+                'transfer_reversed',
+                klubDon.klubr.documentId,
+                klubDon.documentId,
+                reversal.amount,
+                reversal.id,
+                {
+                    dispute_id: dispute.id,
+                    original_transfer_id: relatedTransfer.id,
+                },
+            );
+        }
+    } catch (error) {
+        strapiLog.error(
+            `Echec du reversal de transfert pour dispute ${dispute.id}:`,
+            error,
+        );
+    }
+}
+
+/**
+ * Sends an admin alert for dispute events.
+ * Non-blocking: errors are logged but not propagated.
+ */
+async function sendDisputeAdminAlert(
+    _strapiInstance: Core.Strapi,
+    dispute: Stripe.Dispute,
+    klubDon: any,
+    accountId: string,
+    alertType: 'created' | 'lost' | 'won',
+): Promise<void> {
+    try {
+        const klubrName = klubDon.klubr?.denomination || 'Inconnu';
+        const klubrUuid = klubDon.klubr?.uuid || 'N/A';
+        const amountEuros = (dispute.amount / 100).toFixed(2);
+
+        const alertMessages: Record<string, string> = {
+            created: `Nouveau litige ouvert - ${amountEuros}€`,
+            lost: `Litige perdu - ${amountEuros}€ définitivement perdus`,
+            won: `Litige gagné - ${amountEuros}€ récupérés`,
+        };
+
+        const deadline = dispute.evidence_details?.due_by
+            ? new Date(dispute.evidence_details.due_by * 1000).toLocaleDateString('fr-FR')
+            : 'N/A';
+
+        await sendBrevoTransacEmail({
+            subject: `[ALERTE${alertType === 'created' ? ' URGENTE' : ''}] Litige Stripe ${alertType}: ${klubrName}`,
+            templateId: BREVO_TEMPLATES.SUPER_ADMIN_ALERT_STRIPE,
+            destIsAdmin: true,
+            params: {
+                ALERT_TYPE: alertMessages[alertType],
+                CLUB_NAME: klubrName,
+                KLUBR_UUID: klubrUuid,
+                STRIPE_ACCOUNT_ID: accountId,
+                ACCOUNT_STATUS: `dispute_${alertType}`,
+                DISABLED_REASON: `Litige: ${dispute.reason} (${dispute.id})`,
+                CURRENTLY_DUE: deadline,
+                CHARGES_ENABLED: 'N/A',
+                PAYOUTS_ENABLED: 'N/A',
+            },
+            tags: ['admin-alert', 'stripe-connect', `dispute-${alertType}`],
+        });
+
+        logSimple({
+            message: `Alerte admin envoyée pour dispute ${alertType}: ${dispute.id}`,
+            color: 'yellow',
+            prefix: 'StripeConnect',
+        });
+    } catch (alertError) {
+        strapiLog.error(
+            `Echec de l'envoi de l'alerte admin pour dispute ${dispute.id}:`,
+            alertError,
+        );
+    }
+}
+
+/**
+ * Sends notification to klubr leaders when a dispute is lost.
+ * Non-blocking: errors are logged but not propagated.
+ */
+async function sendDisputeLostKlubrNotification(
+    strapiInstance: Core.Strapi,
+    dispute: Stripe.Dispute,
+    klubDon: any,
+): Promise<void> {
+    try {
+        const klubr = klubDon.klubr;
+
+        if (!klubr || typeof klubr !== 'object' || !klubr.documentId) {
+            logSimple({
+                message: `Pas de klubr associé pour la notification de dispute perdue: ${dispute.id}`,
+                color: 'yellow',
+                prefix: 'StripeConnect',
+            });
+            return;
+        }
+
+        const klubrName = klubr.denomination || 'Votre association';
+        const amountEuros = (dispute.amount / 100).toFixed(2);
+
+        // Find KlubMemberLeader members to notify
+        const leaders = await strapiInstance
+            .service('api::klubr-membre.klubr-membre')
+            .getKlubMembres(klubr.documentId, ['KlubMemberLeader']);
+
+        const leadersWithEmail = leaders.filter(
+            (member) => member.email || member.users_permissions_user?.email,
+        );
+
+        if (leadersWithEmail.length === 0) {
+            logSimple({
+                message: `Aucun dirigeant avec email trouvé pour le klubr ${klubrName}`,
+                color: 'yellow',
+                prefix: 'StripeConnect',
+            });
+            return;
+        }
+
+        const results = await Promise.allSettled(
+            leadersWithEmail.map(async (leader) => {
+                const leaderEmail =
+                    leader.email || leader.users_permissions_user?.email;
+
+                await sendBrevoTransacEmail({
+                    subject: `Litige perdu - ${amountEuros}€ pour ${klubrName}`,
+                    templateId: BREVO_TEMPLATES.LEADER_ALERT,
+                    to: [
+                        {
+                            email: leaderEmail,
+                            name: `${leader.prenom || ''} ${leader.nom || ''}`.trim(),
+                        },
+                    ],
+                    params: {
+                        CLUB_NAME: klubrName,
+                        ALERT_MESSAGE:
+                            `Un litige de ${amountEuros}€ concernant un don a été perdu. ` +
+                            `Le montant a été définitivement débité. ` +
+                            `Raison du litige : ${dispute.reason || 'non précisée'}. ` +
+                            `Veuillez contacter votre administrateur pour plus d'informations.`,
+                    },
+                    tags: ['klubr-notification', 'stripe-connect', 'dispute-lost'],
+                });
+
+                logSimple({
+                    message: `Notification dispute perdue envoyée à ${leaderEmail}`,
+                    color: 'yellow',
+                    prefix: 'StripeConnect',
+                });
+            }),
+        );
+
+        results.forEach((result, i) => {
+            if (result.status === 'rejected') {
+                const leaderEmail =
+                    leadersWithEmail[i].email ||
+                    leadersWithEmail[i].users_permissions_user?.email;
+                strapiLog.error(
+                    `Echec envoi notification dispute à ${leaderEmail}:`,
+                    result.reason,
+                );
+            }
+        });
+    } catch (notifError) {
+        strapiLog.error(
+            `Echec de l'envoi de la notification klubr pour dispute ${dispute.id}:`,
+            notifError,
+        );
+    }
 }
 
 /**

--- a/donaction-api/src/helpers/stripe-webhook-handlers.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.ts
@@ -1,12 +1,12 @@
 import type Stripe from 'stripe';
 import { Core } from '@strapi/strapi';
-import { syncAccountStatus, stripe, logFinancialAction } from './stripe-connect-helper';
+import { syncAccountStatus, stripe, logFinancialAction, createTransferToConnectedAccount } from './stripe-connect-helper';
 import { logBlock, logSimple, strapiLog, COLORS } from './logger';
 import {
     sendBrevoTransacEmail,
     BREVO_TEMPLATES,
 } from './emails/sendBrevoTransacEmail';
-import { ConnectedAccountWithOptionalKlubr } from '../_types';
+import { ConnectedAccountWithOptionalKlubr, DisputeKlubDon, DisputeStatusValue } from '../_types';
 
 /**
  * Handles account.updated webhook event
@@ -473,25 +473,6 @@ async function sendDeauthorizedKlubrNotification(
 }
 
 /**
- * Minimal shape for klub_don used by dispute helpers
- */
-interface DisputeKlubDon {
-    documentId: string;
-    disputeId?: string | null;
-    disputeClosedAt?: string | Date | null;
-    klubr?: {
-        documentId: string;
-        denomination?: string;
-        uuid?: string;
-    } | null;
-}
-
-/**
- * Possible values for dispute status
- */
-type DisputeStatusValue = 'none' | 'warning_received' | 'warning_under_review' | 'warning_closed' | 'open' | 'under_review' | 'won' | 'lost';
-
-/**
  * Maps Stripe dispute status to internal dispute status
  */
 const DISPUTE_STATUS_MAP: Record<string, DisputeStatusValue> = {
@@ -502,6 +483,7 @@ const DISPUTE_STATUS_MAP: Record<string, DisputeStatusValue> = {
     under_review: 'under_review',
     won: 'won',
     lost: 'lost',
+    funds_reinstated: 'won',
 };
 
 /**
@@ -661,6 +643,26 @@ export async function handleDispute(
         }
     }
 
+    // Re-transfer funds when dispute is won and Stripe reinstates funds
+    if (event.type === 'charge.dispute.funds_reinstated') {
+        if (dispute.amount > 0 && accountId !== 'unknown') {
+            await reTransferForDisputeWon(
+                strapiInstance,
+                dispute,
+                klubDon,
+                accountId,
+            );
+        }
+
+        // Send admin alert
+        void sendDisputeAdminAlert(
+            dispute,
+            klubDon,
+            accountId,
+            'won',
+        );
+    }
+
     if (event.type === 'charge.dispute.closed') {
         const auditActionType = disputeStatus === 'won' ? 'dispute_won' : 'dispute_lost';
 
@@ -723,32 +725,34 @@ async function reverseTransferForDispute(
     accountId: string,
 ): Promise<void> {
     try {
-        const paymentIntentId = typeof dispute.payment_intent === 'string'
-            ? dispute.payment_intent
-            : dispute.payment_intent?.id;
-        let relatedTransfer: Stripe.Transfer | undefined;
+        const chargeId = typeof dispute.charge === 'string'
+            ? dispute.charge
+            : dispute.charge?.id;
 
-        for await (const transfer of stripe.transfers.list({
-            destination: accountId,
-            limit: 100,
-        })) {
-            if (
-                transfer.metadata?.payment_intent_id === paymentIntentId ||
-                transfer.metadata?.klub_don_id === klubDon.documentId
-            ) {
-                relatedTransfer = transfer;
-                break;
-            }
-        }
-
-        if (!relatedTransfer) {
+        if (!chargeId) {
             logSimple({
-                message: `Aucun transfert trouvé pour dispute ${dispute.id}, reversal ignoré`,
+                message: `Dispute ${dispute.id} sans charge, reversal ignoré`,
                 color: 'yellow',
                 prefix: 'StripeConnect',
             });
             return;
         }
+
+        const charge = await stripe.charges.retrieve(chargeId);
+        const transferId = typeof charge.transfer === 'string'
+            ? charge.transfer
+            : charge.transfer?.id;
+
+        if (!transferId) {
+            logSimple({
+                message: `Aucun transfert trouvé sur charge ${chargeId} pour dispute ${dispute.id}, reversal ignoré`,
+                color: 'yellow',
+                prefix: 'StripeConnect',
+            });
+            return;
+        }
+
+        const relatedTransfer = await stripe.transfers.retrieve(transferId);
 
         // Idempotency: check if reversal already exists for this dispute
         const existingReversals = await stripe.transfers.listReversals(
@@ -811,7 +815,7 @@ async function reverseTransferForDispute(
             try {
                 await logFinancialAction(
                     strapiInstance,
-                    'transfer_reversed',
+                    'transfer_reversal_failed',
                     klubDon.klubr.documentId,
                     klubDon.documentId,
                     dispute.amount,
@@ -829,6 +833,121 @@ async function reverseTransferForDispute(
                 );
             }
         }
+
+        // Send admin alert about the failure
+        void sendDisputeAdminAlert(
+            dispute,
+            klubDon,
+            accountId,
+            'reversal_failed',
+        );
+    }
+}
+
+/**
+ * Re-transfers funds to the connected account when dispute is won (charge.dispute.funds_reinstated).
+ * Non-blocking if it fails (logged but not propagated).
+ */
+async function reTransferForDisputeWon(
+    strapiInstance: Core.Strapi,
+    dispute: Stripe.Dispute,
+    klubDon: DisputeKlubDon,
+    accountId: string,
+): Promise<void> {
+    try {
+        const chargeId = typeof dispute.charge === 'string'
+            ? dispute.charge
+            : dispute.charge?.id;
+
+        if (!chargeId) {
+            logSimple({
+                message: `Dispute ${dispute.id} sans charge, re-transfer ignoré`,
+                color: 'yellow',
+                prefix: 'StripeConnect',
+            });
+            return;
+        }
+
+        const charge = await stripe.charges.retrieve(chargeId);
+        const transferId = typeof charge.transfer === 'string'
+            ? charge.transfer
+            : charge.transfer?.id;
+
+        if (!transferId) {
+            logSimple({
+                message: `Aucun transfert trouvé sur charge ${chargeId} pour dispute ${dispute.id}, re-transfer ignoré`,
+                color: 'yellow',
+                prefix: 'StripeConnect',
+            });
+            return;
+        }
+
+        const originalTransfer = await stripe.transfers.retrieve(transferId);
+        const reinstatedAmount = Math.min(dispute.amount, originalTransfer.amount);
+
+        // Create new transfer to the connected account for the reinstated amount
+        const newTransfer = await createTransferToConnectedAccount(
+            reinstatedAmount,
+            accountId,
+            {
+                dispute_id: dispute.id,
+                original_transfer_id: originalTransfer.id,
+                reason: 'dispute_funds_reinstated',
+            },
+        );
+
+        logSimple({
+            message: `Transfert créé pour fonds réintégrés: ${newTransfer.id} (${newTransfer.amount / 100}€)`,
+            color: 'green',
+            prefix: 'StripeConnect',
+        });
+
+        // Audit log
+        if (klubDon.klubr?.documentId) {
+            await logFinancialAction(
+                strapiInstance,
+                'transfer_created',
+                klubDon.klubr.documentId,
+                klubDon.documentId,
+                newTransfer.amount,
+                newTransfer.id,
+                {
+                    dispute_id: dispute.id,
+                    reason: 'dispute_funds_reinstated',
+                    original_transfer_id: originalTransfer.id,
+                },
+            );
+        }
+    } catch (error) {
+        strapiLog.error(
+            `Echec du re-transfer pour dispute gagnée ${dispute.id}:`,
+            error,
+        );
+
+        // Log failed attempt for forensic traceability
+        if (klubDon.klubr?.documentId) {
+            try {
+                await logFinancialAction(
+                    strapiInstance,
+                    'transfer_created',
+                    klubDon.klubr.documentId,
+                    klubDon.documentId,
+                    dispute.amount,
+                    `failed_retransfer_${dispute.id}`,
+                    {
+                        dispute_id: dispute.id,
+                        reason: 'dispute_funds_reinstated',
+                        status: 'failed',
+                        error: error instanceof Error ? error.message : String(error),
+                    },
+                );
+            } catch (auditError) {
+                strapiLog.error(
+                    `Echec de l'audit log pour re-transfer échoué (dispute ${dispute.id}):`,
+                    auditError,
+                );
+            }
+        }
     }
 }
 
@@ -840,7 +959,7 @@ async function sendDisputeAdminAlert(
     dispute: Stripe.Dispute,
     klubDon: DisputeKlubDon,
     accountId: string,
-    alertType: 'created' | 'lost' | 'won',
+    alertType: 'created' | 'lost' | 'won' | 'reversal_failed',
 ): Promise<void> {
     try {
         const klubrName = klubDon.klubr?.denomination || 'Inconnu';
@@ -851,6 +970,7 @@ async function sendDisputeAdminAlert(
             created: `Nouveau litige ouvert - ${amountEuros}€`,
             lost: `Litige perdu - ${amountEuros}€ définitivement perdus`,
             won: `Litige gagné - ${amountEuros}€ récupérés`,
+            reversal_failed: `Echec du reversal de transfert - ${amountEuros}€`,
         };
 
         const deadline = dispute.evidence_details?.due_by
@@ -912,7 +1032,7 @@ async function sendDisputeLostKlubrNotification(
         const klubrName = klubr.denomination || 'Votre association';
         const amountEuros = (dispute.amount / 100).toFixed(2);
 
-        // Find KlubMemberLeader and AdminEditor members to notify
+        // Find club-level leaders to notify (Admin is platform-level, notified separately via destIsAdmin)
         const leaders = await strapiInstance
             .service('api::klubr-membre.klubr-membre')
             .getKlubMembres(klubr.documentId, [
@@ -980,6 +1100,25 @@ async function sendDisputeLostKlubrNotification(
                     result.reason,
                 );
             }
+        });
+
+        // Also notify platform super admin
+        await sendBrevoTransacEmail({
+            subject: `Litige perdu - ${amountEuros}€ pour ${klubrName}`,
+            templateId: BREVO_TEMPLATES.LEADER_ALERT,
+            destIsAdmin: true,
+            params: {
+                CLUB_NAME: klubrName,
+                ALERT_MESSAGE:
+                    `Un litige de ${amountEuros}€ concernant un don à ${klubrName} a été perdu. ` +
+                    `Le montant a été définitivement débité. ` +
+                    `Raison du litige : ${dispute.reason || 'non précisée'}.`,
+            },
+            tags: [
+                'admin-alert',
+                'stripe-connect',
+                'dispute-lost',
+            ],
         });
     } catch (notifError) {
         strapiLog.error(

--- a/donaction-api/src/helpers/stripe-webhook-handlers.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.ts
@@ -483,7 +483,6 @@ const DISPUTE_STATUS_MAP: Record<string, DisputeStatusValue> = {
     under_review: 'under_review',
     won: 'won',
     lost: 'lost',
-    funds_reinstated: 'won',
 };
 
 /**
@@ -581,7 +580,7 @@ export async function handleDispute(
         disputeReason: dispute.reason,
     };
     if (['won', 'lost'].includes(disputeStatus)) {
-        updateData.disputeClosedAt = new Date();
+        updateData.disputeClosedAt = new Date(event.created * 1000);
     }
 
     await strapiInstance
@@ -715,6 +714,44 @@ export async function handleDispute(
 }
 
 /**
+ * Resolves the original Stripe transfer from a dispute by following charge → transfer chain.
+ * Returns null if no transfer is found (with appropriate logging).
+ */
+async function resolveTransferFromDispute(
+    dispute: Stripe.Dispute,
+    operation: string,
+): Promise<Stripe.Transfer | null> {
+    const chargeId = typeof dispute.charge === 'string'
+        ? dispute.charge
+        : dispute.charge?.id;
+
+    if (!chargeId) {
+        logSimple({
+            message: `Dispute ${dispute.id} sans charge, ${operation} ignoré`,
+            color: 'yellow',
+            prefix: 'StripeConnect',
+        });
+        return null;
+    }
+
+    const charge = await stripe.charges.retrieve(chargeId);
+    const transferId = typeof charge.transfer === 'string'
+        ? charge.transfer
+        : charge.transfer?.id;
+
+    if (!transferId) {
+        logSimple({
+            message: `Aucun transfert trouvé sur charge ${chargeId} pour dispute ${dispute.id}, ${operation} ignoré`,
+            color: 'yellow',
+            prefix: 'StripeConnect',
+        });
+        return null;
+    }
+
+    return stripe.transfers.retrieve(transferId);
+}
+
+/**
  * Reverses the transfer to the connected account when Stripe withdraws funds (charge.dispute.funds_withdrawn).
  * Non-blocking if it fails (logged but not propagated).
  */
@@ -725,34 +762,8 @@ async function reverseTransferForDispute(
     accountId: string,
 ): Promise<void> {
     try {
-        const chargeId = typeof dispute.charge === 'string'
-            ? dispute.charge
-            : dispute.charge?.id;
-
-        if (!chargeId) {
-            logSimple({
-                message: `Dispute ${dispute.id} sans charge, reversal ignoré`,
-                color: 'yellow',
-                prefix: 'StripeConnect',
-            });
-            return;
-        }
-
-        const charge = await stripe.charges.retrieve(chargeId);
-        const transferId = typeof charge.transfer === 'string'
-            ? charge.transfer
-            : charge.transfer?.id;
-
-        if (!transferId) {
-            logSimple({
-                message: `Aucun transfert trouvé sur charge ${chargeId} pour dispute ${dispute.id}, reversal ignoré`,
-                color: 'yellow',
-                prefix: 'StripeConnect',
-            });
-            return;
-        }
-
-        const relatedTransfer = await stripe.transfers.retrieve(transferId);
+        const relatedTransfer = await resolveTransferFromDispute(dispute, 'reversal');
+        if (!relatedTransfer) return;
 
         // Idempotency: check if reversal already exists for this dispute
         const existingReversals = await stripe.transfers.listReversals(
@@ -785,7 +796,7 @@ async function reverseTransferForDispute(
 
         logSimple({
             message: `Transfert ${relatedTransfer.id} reversé: ${reversal.id} (${reversal.amount / 100}€)`,
-            color: 'yellow',
+            color: 'green',
             prefix: 'StripeConnect',
         });
 
@@ -855,34 +866,9 @@ async function reTransferForDisputeWon(
     accountId: string,
 ): Promise<void> {
     try {
-        const chargeId = typeof dispute.charge === 'string'
-            ? dispute.charge
-            : dispute.charge?.id;
+        const originalTransfer = await resolveTransferFromDispute(dispute, 're-transfer');
+        if (!originalTransfer) return;
 
-        if (!chargeId) {
-            logSimple({
-                message: `Dispute ${dispute.id} sans charge, re-transfer ignoré`,
-                color: 'yellow',
-                prefix: 'StripeConnect',
-            });
-            return;
-        }
-
-        const charge = await stripe.charges.retrieve(chargeId);
-        const transferId = typeof charge.transfer === 'string'
-            ? charge.transfer
-            : charge.transfer?.id;
-
-        if (!transferId) {
-            logSimple({
-                message: `Aucun transfert trouvé sur charge ${chargeId} pour dispute ${dispute.id}, re-transfer ignoré`,
-                color: 'yellow',
-                prefix: 'StripeConnect',
-            });
-            return;
-        }
-
-        const originalTransfer = await stripe.transfers.retrieve(transferId);
         const reinstatedAmount = Math.min(dispute.amount, originalTransfer.amount);
 
         // Create new transfer to the connected account for the reinstated amount
@@ -948,6 +934,14 @@ async function reTransferForDisputeWon(
                 );
             }
         }
+
+        // Send admin alert about the failure
+        void sendDisputeAdminAlert(
+            dispute,
+            klubDon,
+            accountId,
+            'reversal_failed',
+        );
     }
 }
 
@@ -964,13 +958,14 @@ async function sendDisputeAdminAlert(
     try {
         const klubrName = klubDon.klubr?.denomination || 'Inconnu';
         const klubrUuid = klubDon.klubr?.uuid || 'N/A';
-        const amountEuros = (dispute.amount / 100).toFixed(2);
+        const currency = (dispute.currency || 'eur').toUpperCase();
+        const amountFormatted = `${(dispute.amount / 100).toFixed(2)} ${currency}`;
 
         const alertMessages: Record<string, string> = {
-            created: `Nouveau litige ouvert - ${amountEuros}€`,
-            lost: `Litige perdu - ${amountEuros}€ définitivement perdus`,
-            won: `Litige gagné - ${amountEuros}€ récupérés`,
-            reversal_failed: `Echec du reversal de transfert - ${amountEuros}€`,
+            created: `Nouveau litige ouvert - ${amountFormatted}`,
+            lost: `Litige perdu - ${amountFormatted} définitivement perdus`,
+            won: `Litige gagné - ${amountFormatted} récupérés`,
+            reversal_failed: `Echec du reversal de transfert - ${amountFormatted}`,
         };
 
         const deadline = dispute.evidence_details?.due_by
@@ -1030,7 +1025,8 @@ async function sendDisputeLostKlubrNotification(
         }
 
         const klubrName = klubr.denomination || 'Votre association';
-        const amountEuros = (dispute.amount / 100).toFixed(2);
+        const currency = (dispute.currency || 'eur').toUpperCase();
+        const amountFormatted = `${(dispute.amount / 100).toFixed(2)} ${currency}`;
 
         // Find club-level leaders to notify (Admin is platform-level, notified separately via destIsAdmin)
         const leaders = await strapiInstance
@@ -1059,7 +1055,7 @@ async function sendDisputeLostKlubrNotification(
                     leader.email || leader.users_permissions_user?.email;
 
                 await sendBrevoTransacEmail({
-                    subject: `Litige perdu - ${amountEuros}€ pour ${klubrName}`,
+                    subject: `Litige perdu - ${amountFormatted} pour ${klubrName}`,
                     templateId: BREVO_TEMPLATES.LEADER_ALERT,
                     to: [
                         {
@@ -1070,7 +1066,7 @@ async function sendDisputeLostKlubrNotification(
                     params: {
                         CLUB_NAME: klubrName,
                         ALERT_MESSAGE:
-                            `Un litige de ${amountEuros}€ concernant un don a été perdu. ` +
+                            `Un litige de ${amountFormatted} concernant un don a été perdu. ` +
                             `Le montant a été définitivement débité. ` +
                             `Raison du litige : ${dispute.reason || 'non précisée'}. ` +
                             `Veuillez contacter votre administrateur pour plus d'informations.`,
@@ -1104,13 +1100,13 @@ async function sendDisputeLostKlubrNotification(
 
         // Also notify platform super admin
         await sendBrevoTransacEmail({
-            subject: `Litige perdu - ${amountEuros}€ pour ${klubrName}`,
+            subject: `Litige perdu - ${amountFormatted} pour ${klubrName}`,
             templateId: BREVO_TEMPLATES.LEADER_ALERT,
             destIsAdmin: true,
             params: {
                 CLUB_NAME: klubrName,
                 ALERT_MESSAGE:
-                    `Un litige de ${amountEuros}€ concernant un don à ${klubrName} a été perdu. ` +
+                    `Un litige de ${amountFormatted} concernant un don à ${klubrName} a été perdu. ` +
                     `Le montant a été définitivement débité. ` +
                     `Raison du litige : ${dispute.reason || 'non précisée'}.`,
             },

--- a/donaction-api/src/helpers/stripe-webhook-handlers.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.ts
@@ -473,9 +473,26 @@ async function sendDeauthorizedKlubrNotification(
 }
 
 /**
+ * Minimal shape for klub_don used by dispute helpers
+ */
+interface DisputeKlubDon {
+    documentId: string;
+    klubr?: {
+        documentId: string;
+        denomination?: string;
+        uuid?: string;
+    } | null;
+}
+
+/**
+ * Possible values for dispute status
+ */
+type DisputeStatusValue = 'none' | 'warning_received' | 'open' | 'under_review' | 'won' | 'lost';
+
+/**
  * Maps Stripe dispute status to internal dispute status
  */
-const DISPUTE_STATUS_MAP: Record<string, string> = {
+const DISPUTE_STATUS_MAP: Record<string, DisputeStatusValue> = {
     warning_needs_response: 'warning_received',
     warning_under_review: 'warning_received',
     warning_closed: 'none',
@@ -535,8 +552,7 @@ export async function handleDispute(
     }
 
     const klubDon = payment.klub_don;
-    const disputeStatus = (DISPUTE_STATUS_MAP[dispute.status] || 'open') as
-        'none' | 'warning_received' | 'open' | 'under_review' | 'won' | 'lost';
+    const disputeStatus = DISPUTE_STATUS_MAP[dispute.status] || 'open';
 
     // Update klub_don with dispute info
     await strapiInstance
@@ -633,7 +649,7 @@ export async function handleDispute(
 async function reverseTransferForDispute(
     strapiInstance: Core.Strapi,
     dispute: Stripe.Dispute,
-    klubDon: any,
+    klubDon: DisputeKlubDon,
     accountId: string,
 ): Promise<void> {
     try {
@@ -708,7 +724,7 @@ async function reverseTransferForDispute(
 async function sendDisputeAdminAlert(
     _strapiInstance: Core.Strapi,
     dispute: Stripe.Dispute,
-    klubDon: any,
+    klubDon: DisputeKlubDon,
     accountId: string,
     alertType: 'created' | 'lost' | 'won',
 ): Promise<void> {
@@ -765,7 +781,7 @@ async function sendDisputeAdminAlert(
 async function sendDisputeLostKlubrNotification(
     strapiInstance: Core.Strapi,
     dispute: Stripe.Dispute,
-    klubDon: any,
+    klubDon: DisputeKlubDon,
 ): Promise<void> {
     try {
         const klubr = klubDon.klubr;

--- a/donaction-api/src/helpers/stripe-webhook-handlers.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.ts
@@ -487,7 +487,7 @@ interface DisputeKlubDon {
 /**
  * Possible values for dispute status
  */
-type DisputeStatusValue = 'none' | 'warning_received' | 'open' | 'under_review' | 'won' | 'lost';
+type DisputeStatusValue = 'none' | 'warning_received' | 'warning_closed' | 'open' | 'under_review' | 'won' | 'lost';
 
 /**
  * Maps Stripe dispute status to internal dispute status
@@ -495,7 +495,7 @@ type DisputeStatusValue = 'none' | 'warning_received' | 'open' | 'under_review' 
 const DISPUTE_STATUS_MAP: Record<string, DisputeStatusValue> = {
     warning_needs_response: 'warning_received',
     warning_under_review: 'warning_received',
-    warning_closed: 'none',
+    warning_closed: 'warning_closed',
     needs_response: 'open',
     under_review: 'under_review',
     won: 'won',
@@ -521,14 +521,15 @@ export async function handleDispute(
 
     const dispute = event.data.object as Stripe.Dispute;
     const accountId = event.account ?? 'unknown';
-    const paymentIntentId = dispute.payment_intent as string;
 
-    if (!paymentIntentId) {
+    if (!dispute.payment_intent) {
         strapiLog.error(
             `Dispute ${dispute.id} reçue sans payment_intent`
         );
         return;
     }
+
+    const paymentIntentId = dispute.payment_intent as string;
 
     // Find the donation via the payment record
     const payment = await strapiInstance.db
@@ -552,6 +553,17 @@ export async function handleDispute(
     }
 
     const klubDon = payment.klub_don;
+
+    // Idempotency guard: skip if this dispute was already processed
+    if (klubDon.disputeId === dispute.id && event.type === 'charge.dispute.created') {
+        logSimple({
+            message: `Dispute ${dispute.id} déjà traitée pour don ${klubDon.documentId}, ignoré`,
+            color: 'yellow',
+            prefix: 'StripeConnect',
+        });
+        return;
+    }
+
     const disputeStatus = DISPUTE_STATUS_MAP[dispute.status] || 'open';
 
     // Update klub_don with dispute info
@@ -579,14 +591,31 @@ export async function handleDispute(
     if (event.type === 'charge.dispute.created') {
         // Send urgent admin alert
         void sendDisputeAdminAlert(
-            strapiInstance,
             dispute,
             klubDon,
             accountId,
             'created',
         );
 
-        // Reverse transfer if dispute involves funds
+        // Log audit for dispute opening
+        if (klubDon.klubr?.documentId) {
+            void logFinancialAction(
+                strapiInstance,
+                'dispute_opened',
+                klubDon.klubr.documentId,
+                klubDon.documentId,
+                dispute.amount,
+                dispute.id,
+                {
+                    dispute_status: dispute.status,
+                    dispute_reason: dispute.reason,
+                },
+            );
+        }
+    }
+
+    // Reverse transfer only when Stripe actually withdraws funds (not on dispute creation)
+    if (event.type === 'charge.dispute.funds_withdrawn') {
         if (dispute.amount > 0 && accountId !== 'unknown') {
             await reverseTransferForDispute(
                 strapiInstance,
@@ -617,7 +646,7 @@ export async function handleDispute(
         }
 
         // Notify association leaders if dispute is lost
-        if (dispute.status === 'lost') {
+        if (disputeStatus === 'lost') {
             void sendDisputeLostKlubrNotification(
                 strapiInstance,
                 dispute,
@@ -627,11 +656,10 @@ export async function handleDispute(
 
         // Send admin alert for closure
         void sendDisputeAdminAlert(
-            strapiInstance,
             dispute,
             klubDon,
             accountId,
-            dispute.status === 'lost' ? 'lost' : 'won',
+            disputeStatus === 'lost' ? 'lost' : 'won',
         );
     }
 
@@ -643,7 +671,7 @@ export async function handleDispute(
 }
 
 /**
- * Reverses the transfer to the connected account when a dispute is opened.
+ * Reverses the transfer to the connected account when Stripe withdraws funds (charge.dispute.funds_withdrawn).
  * Non-blocking if it fails (logged but not propagated).
  */
 async function reverseTransferForDispute(
@@ -653,19 +681,22 @@ async function reverseTransferForDispute(
     accountId: string,
 ): Promise<void> {
     try {
-        // Find transfers associated with this charge
+        // Find the transfer linked to this payment via metadata
         const paymentIntentId = dispute.payment_intent as string;
-        const transfers = await stripe.transfers.list({
-            destination: accountId,
-            limit: 10,
-        });
+        let relatedTransfer: Stripe.Transfer | undefined;
 
-        // Find the transfer linked to this payment via transfer_group or metadata
-        const relatedTransfer = transfers.data.find(
-            (t) =>
-                t.metadata?.payment_intent_id === paymentIntentId ||
-                t.metadata?.klub_don_id === klubDon.documentId,
-        );
+        for await (const transfer of stripe.transfers.list({
+            destination: accountId,
+            limit: 100,
+        })) {
+            if (
+                transfer.metadata?.payment_intent_id === paymentIntentId ||
+                transfer.metadata?.klub_don_id === klubDon.documentId
+            ) {
+                relatedTransfer = transfer;
+                break;
+            }
+        }
 
         if (!relatedTransfer) {
             logSimple({
@@ -683,7 +714,7 @@ async function reverseTransferForDispute(
                 amount: Math.min(dispute.amount, relatedTransfer.amount),
                 metadata: {
                     dispute_id: dispute.id,
-                    reason: 'dispute_opened',
+                    reason: 'dispute_funds_withdrawn',
                 },
             },
         );
@@ -722,7 +753,6 @@ async function reverseTransferForDispute(
  * Non-blocking: errors are logged but not propagated.
  */
 async function sendDisputeAdminAlert(
-    _strapiInstance: Core.Strapi,
     dispute: Stripe.Dispute,
     klubDon: DisputeKlubDon,
     accountId: string,

--- a/donaction-api/src/helpers/stripe-webhook-handlers.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.ts
@@ -477,6 +477,7 @@ async function sendDeauthorizedKlubrNotification(
  */
 interface DisputeKlubDon {
     documentId: string;
+    disputeId?: string | null;
     klubr?: {
         documentId: string;
         denomination?: string;
@@ -487,14 +488,14 @@ interface DisputeKlubDon {
 /**
  * Possible values for dispute status
  */
-type DisputeStatusValue = 'none' | 'warning_received' | 'warning_closed' | 'open' | 'under_review' | 'won' | 'lost';
+type DisputeStatusValue = 'none' | 'warning_received' | 'warning_under_review' | 'warning_closed' | 'open' | 'under_review' | 'won' | 'lost';
 
 /**
  * Maps Stripe dispute status to internal dispute status
  */
 const DISPUTE_STATUS_MAP: Record<string, DisputeStatusValue> = {
     warning_needs_response: 'warning_received',
-    warning_under_review: 'warning_received',
+    warning_under_review: 'warning_under_review',
     warning_closed: 'warning_closed',
     needs_response: 'open',
     under_review: 'under_review',
@@ -567,18 +568,21 @@ export async function handleDispute(
     const disputeStatus = DISPUTE_STATUS_MAP[dispute.status] || 'open';
 
     // Update klub_don with dispute info
+    // Only set disputeClosedAt on terminal statuses — never reset to null (late events could erase it)
+    const updateData: Record<string, any> = {
+        disputeStatus,
+        disputeId: dispute.id,
+        disputeReason: dispute.reason,
+    };
+    if (['won', 'lost'].includes(disputeStatus)) {
+        updateData.disputeClosedAt = new Date();
+    }
+
     await strapiInstance
         .documents('api::klub-don.klub-don')
         .update({
             documentId: klubDon.documentId,
-            data: {
-                disputeStatus,
-                disputeId: dispute.id,
-                disputeReason: dispute.reason,
-                disputeClosedAt: ['won', 'lost'].includes(disputeStatus)
-                    ? new Date()
-                    : null,
-            },
+            data: updateData,
         });
 
     logSimple({
@@ -597,20 +601,27 @@ export async function handleDispute(
             'created',
         );
 
-        // Log audit for dispute opening
+        // Log audit for dispute opening (awaited — financial audit must not be lost)
         if (klubDon.klubr?.documentId) {
-            void logFinancialAction(
-                strapiInstance,
-                'dispute_opened',
-                klubDon.klubr.documentId,
-                klubDon.documentId,
-                dispute.amount,
-                dispute.id,
-                {
-                    dispute_status: dispute.status,
-                    dispute_reason: dispute.reason,
-                },
-            );
+            try {
+                await logFinancialAction(
+                    strapiInstance,
+                    'dispute_opened',
+                    klubDon.klubr.documentId,
+                    klubDon.documentId,
+                    dispute.amount,
+                    dispute.id,
+                    {
+                        dispute_status: dispute.status,
+                        dispute_reason: dispute.reason,
+                    },
+                );
+            } catch (auditError) {
+                strapiLog.error(
+                    `Echec de l'audit log dispute_opened pour dispute ${dispute.id}:`,
+                    auditError,
+                );
+            }
         }
     }
 
@@ -629,20 +640,27 @@ export async function handleDispute(
     if (event.type === 'charge.dispute.closed') {
         const auditActionType = disputeStatus === 'won' ? 'dispute_won' : 'dispute_lost';
 
-        // Log audit for closure
+        // Log audit for closure (awaited — financial audit must not be lost)
         if (klubDon.klubr?.documentId) {
-            void logFinancialAction(
-                strapiInstance,
-                auditActionType,
-                klubDon.klubr.documentId,
-                klubDon.documentId,
-                dispute.amount,
-                dispute.id,
-                {
-                    dispute_status: dispute.status,
-                    dispute_reason: dispute.reason,
-                },
-            );
+            try {
+                await logFinancialAction(
+                    strapiInstance,
+                    auditActionType,
+                    klubDon.klubr.documentId,
+                    klubDon.documentId,
+                    dispute.amount,
+                    dispute.id,
+                    {
+                        dispute_status: dispute.status,
+                        dispute_reason: dispute.reason,
+                    },
+                );
+            } catch (auditError) {
+                strapiLog.error(
+                    `Echec de l'audit log ${auditActionType} pour dispute ${dispute.id}:`,
+                    auditError,
+                );
+            }
         }
 
         // Notify association leaders if dispute is lost
@@ -681,7 +699,6 @@ async function reverseTransferForDispute(
     accountId: string,
 ): Promise<void> {
     try {
-        // Find the transfer linked to this payment via metadata
         const paymentIntentId = dispute.payment_intent as string;
         let relatedTransfer: Stripe.Transfer | undefined;
 
@@ -701,6 +718,23 @@ async function reverseTransferForDispute(
         if (!relatedTransfer) {
             logSimple({
                 message: `Aucun transfert trouvé pour dispute ${dispute.id}, reversal ignoré`,
+                color: 'yellow',
+                prefix: 'StripeConnect',
+            });
+            return;
+        }
+
+        // Idempotency: check if reversal already exists for this dispute
+        const existingReversals = await stripe.transfers.listReversals(
+            relatedTransfer.id,
+            { limit: 10 },
+        );
+        const alreadyReversed = existingReversals.data.some(
+            (r) => r.metadata?.dispute_id === dispute.id,
+        );
+        if (alreadyReversed) {
+            logSimple({
+                message: `Reversal déjà effectué pour dispute ${dispute.id}, ignoré`,
                 color: 'yellow',
                 prefix: 'StripeConnect',
             });

--- a/donaction-api/src/helpers/stripe-webhook-handlers.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.ts
@@ -652,15 +652,15 @@ export async function handleDispute(
                 klubDon,
                 accountId,
             );
-        }
 
-        // Send admin alert
-        void sendDisputeAdminAlert(
-            dispute,
-            klubDon,
-            accountId,
-            'won',
-        );
+            // Send admin alert (only when re-transfer was attempted)
+            void sendDisputeAdminAlert(
+                dispute,
+                klubDon,
+                accountId,
+                'won',
+            );
+        }
     }
 
     if (event.type === 'charge.dispute.closed') {
@@ -757,7 +757,7 @@ async function reverseTransferForDispute(
         // Idempotency: check if reversal already exists for this dispute
         const existingReversals = await stripe.transfers.listReversals(
             relatedTransfer.id,
-            { limit: 10 },
+            { limit: 100 },
         );
         const alreadyReversed = existingReversals.data.some(
             (r) => r.metadata?.dispute_id === dispute.id,
@@ -929,7 +929,7 @@ async function reTransferForDisputeWon(
             try {
                 await logFinancialAction(
                     strapiInstance,
-                    'transfer_created',
+                    'transfer_creation_failed',
                     klubDon.klubr.documentId,
                     klubDon.documentId,
                     dispute.amount,

--- a/donaction-api/src/helpers/stripe-webhook-handlers.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.ts
@@ -478,6 +478,7 @@ async function sendDeauthorizedKlubrNotification(
 interface DisputeKlubDon {
     documentId: string;
     disputeId?: string | null;
+    disputeClosedAt?: string | Date | null;
     klubr?: {
         documentId: string;
         denomination?: string;
@@ -530,7 +531,9 @@ export async function handleDispute(
         return;
     }
 
-    const paymentIntentId = dispute.payment_intent as string;
+    const paymentIntentId = typeof dispute.payment_intent === 'string'
+        ? dispute.payment_intent
+        : dispute.payment_intent.id;
 
     // Find the donation via the payment record
     const payment = await strapiInstance.db
@@ -555,7 +558,7 @@ export async function handleDispute(
 
     const klubDon = payment.klub_don;
 
-    // Idempotency guard: skip if this dispute was already processed
+    // Idempotency guard: skip duplicate created events
     if (klubDon.disputeId === dispute.id && event.type === 'charge.dispute.created') {
         logSimple({
             message: `Dispute ${dispute.id} déjà traitée pour don ${klubDon.documentId}, ignoré`,
@@ -565,11 +568,32 @@ export async function handleDispute(
         return;
     }
 
-    const disputeStatus = DISPUTE_STATUS_MAP[dispute.status] || 'open';
+    // Idempotency guard: skip closed retries if already closed
+    if (klubDon.disputeClosedAt && event.type === 'charge.dispute.closed') {
+        logSimple({
+            message: `Dispute ${dispute.id} déjà clôturée pour don ${klubDon.documentId}, ignoré`,
+            color: 'yellow',
+            prefix: 'StripeConnect',
+        });
+        return;
+    }
+
+    const mappedStatus = DISPUTE_STATUS_MAP[dispute.status];
+    if (!mappedStatus) {
+        strapiLog.warn(
+            `Statut dispute inconnu: '${dispute.status}', mappé à 'open' par défaut`
+        );
+    }
+    const disputeStatus = mappedStatus || 'open';
 
     // Update klub_don with dispute info
     // Only set disputeClosedAt on terminal statuses — never reset to null (late events could erase it)
-    const updateData: Record<string, any> = {
+    const updateData: {
+        disputeStatus: DisputeStatusValue;
+        disputeId: string;
+        disputeReason: string | null;
+        disputeClosedAt?: Date;
+    } = {
         disputeStatus,
         disputeId: dispute.id,
         disputeReason: dispute.reason,
@@ -699,7 +723,9 @@ async function reverseTransferForDispute(
     accountId: string,
 ): Promise<void> {
     try {
-        const paymentIntentId = dispute.payment_intent as string;
+        const paymentIntentId = typeof dispute.payment_intent === 'string'
+            ? dispute.payment_intent
+            : dispute.payment_intent?.id;
         let relatedTransfer: Stripe.Transfer | undefined;
 
         for await (const transfer of stripe.transfers.list({
@@ -779,6 +805,30 @@ async function reverseTransferForDispute(
             `Echec du reversal de transfert pour dispute ${dispute.id}:`,
             error,
         );
+
+        // Audit the failed reversal attempt for forensic traceability
+        if (klubDon.klubr?.documentId) {
+            try {
+                await logFinancialAction(
+                    strapiInstance,
+                    'transfer_reversed',
+                    klubDon.klubr.documentId,
+                    klubDon.documentId,
+                    dispute.amount,
+                    `failed_${dispute.id}`,
+                    {
+                        dispute_id: dispute.id,
+                        status: 'failed',
+                        error: error instanceof Error ? error.message : String(error),
+                    },
+                );
+            } catch (auditError) {
+                strapiLog.error(
+                    `Echec de l'audit log pour reversal échoué (dispute ${dispute.id}):`,
+                    auditError,
+                );
+            }
+        }
     }
 }
 
@@ -862,10 +912,13 @@ async function sendDisputeLostKlubrNotification(
         const klubrName = klubr.denomination || 'Votre association';
         const amountEuros = (dispute.amount / 100).toFixed(2);
 
-        // Find KlubMemberLeader members to notify
+        // Find KlubMemberLeader and AdminEditor members to notify
         const leaders = await strapiInstance
             .service('api::klubr-membre.klubr-membre')
-            .getKlubMembres(klubr.documentId, ['KlubMemberLeader']);
+            .getKlubMembres(klubr.documentId, [
+                'KlubMemberLeader',
+                'AdminEditor',
+            ]);
 
         const leadersWithEmail = leaders.filter(
             (member) => member.email || member.users_permissions_user?.email,
@@ -902,7 +955,11 @@ async function sendDisputeLostKlubrNotification(
                             `Raison du litige : ${dispute.reason || 'non précisée'}. ` +
                             `Veuillez contacter votre administrateur pour plus d'informations.`,
                     },
-                    tags: ['klubr-notification', 'stripe-connect', 'dispute-lost'],
+                    tags: [
+                        'klubr-notification',
+                        'stripe-connect',
+                        'dispute-lost',
+                    ],
                 });
 
                 logSimple({

--- a/donaction-api/types/generated/contentTypes.d.ts
+++ b/donaction-api/types/generated/contentTypes.d.ts
@@ -1008,7 +1008,15 @@ export interface ApiKlubDonKlubDon extends Struct.CollectionTypeSchema {
         disputeId: Schema.Attribute.String;
         disputeReason: Schema.Attribute.String;
         disputeStatus: Schema.Attribute.Enumeration<
-            ['none', 'warning_received', 'open', 'under_review', 'won', 'lost']
+            [
+                'none',
+                'warning_received',
+                'warning_closed',
+                'open',
+                'under_review',
+                'won',
+                'lost',
+            ]
         > &
             Schema.Attribute.DefaultTo<'none'>;
         donorPaysFee: Schema.Attribute.Boolean;

--- a/donaction-api/types/generated/contentTypes.d.ts
+++ b/donaction-api/types/generated/contentTypes.d.ts
@@ -730,6 +730,7 @@ export interface ApiFinancialAuditLogFinancialAuditLog
                 'dispute_opened',
                 'dispute_won',
                 'dispute_lost',
+                'transfer_creation_failed',
             ]
         > &
             Schema.Attribute.Required;

--- a/donaction-api/types/generated/contentTypes.d.ts
+++ b/donaction-api/types/generated/contentTypes.d.ts
@@ -722,9 +722,13 @@ export interface ApiFinancialAuditLogFinancialAuditLog
         action_type: Schema.Attribute.Enumeration<
             [
                 'transfer_created',
+                'transfer_reversed',
                 'payout_initiated',
                 'refund_processed',
                 'fee_calculated',
+                'dispute_opened',
+                'dispute_won',
+                'dispute_lost',
             ]
         > &
             Schema.Attribute.Required;
@@ -1000,6 +1004,13 @@ export interface ApiKlubDonKlubDon extends Struct.CollectionTypeSchema {
             Schema.Attribute.Private;
         datePaiment: Schema.Attribute.DateTime;
         deductionFiscale: Schema.Attribute.Decimal;
+        disputeClosedAt: Schema.Attribute.DateTime;
+        disputeId: Schema.Attribute.String;
+        disputeReason: Schema.Attribute.String;
+        disputeStatus: Schema.Attribute.Enumeration<
+            ['none', 'warning_received', 'open', 'under_review', 'won', 'lost']
+        > &
+            Schema.Attribute.DefaultTo<'none'>;
         donorPaysFee: Schema.Attribute.Boolean;
         emailSent: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
         estOrganisme: Schema.Attribute.Boolean;

--- a/donaction-api/types/generated/contentTypes.d.ts
+++ b/donaction-api/types/generated/contentTypes.d.ts
@@ -723,6 +723,7 @@ export interface ApiFinancialAuditLogFinancialAuditLog
             [
                 'transfer_created',
                 'transfer_reversed',
+                'transfer_reversal_failed',
                 'payout_initiated',
                 'refund_processed',
                 'fee_calculated',

--- a/donaction-api/types/generated/contentTypes.d.ts
+++ b/donaction-api/types/generated/contentTypes.d.ts
@@ -1011,6 +1011,7 @@ export interface ApiKlubDonKlubDon extends Struct.CollectionTypeSchema {
             [
                 'none',
                 'warning_received',
+                'warning_under_review',
                 'warning_closed',
                 'open',
                 'under_review',


### PR DESCRIPTION
## Summary
- Replace stub `handleDispute` with full implementation handling `charge.dispute.created`, `updated`, `closed`, `funds_withdrawn`, `funds_reinstated`
- Add dispute fields to `klub-don` schema: `disputeStatus`, `disputeId`, `disputeReason`, `disputeClosedAt`
- Add reverse transfer logic, urgent admin alerts, and LEADER_ALERT notifications on dispute lost
- Add financial audit logging for dispute closures and transfer reversals
- Add `DisputeKlubDon` interface and `DisputeStatusValue` type for proper type safety

## Test plan
- [x] 39 tests pass in `stripe-webhook-handlers.test.ts` (15 new dispute tests)
- [x] 188 total tests pass across all test files
- [x] Build passes (`npm run build`)
- [ ] Test with Stripe CLI: `stripe trigger charge.dispute.created`