### PR TITLE
perf: store transfer_id on klub-don-payment for O(1) dispute reversal (#192)

### DIFF
--- a/donaction-api/src/api/klub-don-payment/content-types/klub-don-payment/schema.json
+++ b/donaction-api/src/api/klub-don-payment/content-types/klub-don-payment/schema.json
@@ -76,6 +76,9 @@
     },
     "application_fee_amount": {
       "type": "decimal"
+    },
+    "transfer_id": {
+      "type": "string"
     }
   }
 }

--- a/donaction-api/src/api/klub-don-payment/controllers/klub-don-payment.ts
+++ b/donaction-api/src/api/klub-don-payment/controllers/klub-don-payment.ts
@@ -411,21 +411,25 @@ export default factories.createCoreController(
                         });
 
                         // Extract transfer_id from charge for O(1) dispute reversal lookup
+                        // Only for Connect payments (those with transfer_data)
                         let transferId: string | undefined;
                         const succeededIntent = event.data.object as Stripe.PaymentIntent;
-                        const latestChargeId = typeof succeededIntent.latest_charge === 'string'
-                            ? succeededIntent.latest_charge
-                            : succeededIntent.latest_charge?.id;
-                        if (latestChargeId) {
-                            try {
-                                const charge = await stripe.charges.retrieve(latestChargeId);
-                                transferId = typeof charge.transfer === 'string'
-                                    ? charge.transfer
-                                    : charge.transfer?.id || undefined;
-                            } catch (err) {
-                                strapiLog.warn(
-                                    `Impossible de récupérer le transfer_id pour charge ${latestChargeId}: ${err.message}`
-                                );
+                        const isConnectPayment = !!succeededIntent.transfer_data;
+                        if (isConnectPayment) {
+                            const latestChargeId = typeof succeededIntent.latest_charge === 'string'
+                                ? succeededIntent.latest_charge
+                                : succeededIntent.latest_charge?.id;
+                            if (latestChargeId) {
+                                try {
+                                    const charge = await stripe.charges.retrieve(latestChargeId);
+                                    transferId = typeof charge.transfer === 'string'
+                                        ? charge.transfer
+                                        : charge.transfer?.id ?? undefined;
+                                } catch (err) {
+                                    strapiLog.warn(
+                                        `Impossible de récupérer le transfer_id pour charge ${latestChargeId}: ${(err as Error).message}`
+                                    );
+                                }
                             }
                         }
 

--- a/donaction-api/src/api/klub-don-payment/controllers/klub-don-payment.ts
+++ b/donaction-api/src/api/klub-don-payment/controllers/klub-don-payment.ts
@@ -403,20 +403,42 @@ export default factories.createCoreController(
                             intent: event.data.object,
                         });
                         break;
-                    case 'payment_intent.succeeded':
+                    case 'payment_intent.succeeded': {
                         logSimple({
                             message: `Payment successful: ${event.data.object.id}`,
                             color: 'green',
                             prefix: 'KlubDonPayment',
                         });
+
+                        // Extract transfer_id from charge for O(1) dispute reversal lookup
+                        let transferId: string | undefined;
+                        const succeededIntent = event.data.object as Stripe.PaymentIntent;
+                        const latestChargeId = typeof succeededIntent.latest_charge === 'string'
+                            ? succeededIntent.latest_charge
+                            : succeededIntent.latest_charge?.id;
+                        if (latestChargeId) {
+                            try {
+                                const charge = await stripe.charges.retrieve(latestChargeId);
+                                transferId = typeof charge.transfer === 'string'
+                                    ? charge.transfer
+                                    : charge.transfer?.id || undefined;
+                            } catch (err) {
+                                strapiLog.warn(
+                                    `Impossible de récupérer le transfer_id pour charge ${latestChargeId}: ${err.message}`
+                                );
+                            }
+                        }
+
                         await strapi.services[
                             'api::klub-don-payment.klub-don-payment'
                         ].updateDonAndDonPayment({
                             status: 'success',
                             donUuid,
-                            intent: event.data.object,
+                            intent: succeededIntent,
+                            transferId,
                         });
                         break;
+                    }
                     case 'payment_intent.payment_failed':
                         logSimple({
                             message: `Payment intent failed: ${event.data.object.id}`,

--- a/donaction-api/src/api/klub-don-payment/services/klub-don-payment.ts
+++ b/donaction-api/src/api/klub-don-payment/services/klub-don-payment.ts
@@ -17,6 +17,7 @@ export default factories.createCoreService(
             idempotencyKey,
             applicationFeeAmount,
             paymentMethod,
+            transferId,
         }: {
             status: string;
             donUuid: string;
@@ -24,6 +25,7 @@ export default factories.createCoreService(
             idempotencyKey?: string;
             applicationFeeAmount?: number;
             paymentMethod?: 'stripe_classic' | 'stripe_connect';
+            transferId?: string;
         }) {
             try {
                 const klubrDon: KlubDonEntity = await strapi.db
@@ -57,6 +59,7 @@ export default factories.createCoreService(
                         ...(applicationFeeAmount !== undefined && {
                             application_fee_amount: applicationFeeAmount,
                         }),
+                        ...(transferId && { transfer_id: transferId }),
                     },
                 };
                 const payment = klubrDon.klub_don_payments.find(

--- a/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
@@ -1187,4 +1187,105 @@ describe('handleDispute', () => {
             }),
         );
     });
+
+    // ---------- storedTransferId fast path (issue #192) ----------
+
+    it('uses stored transfer_id for O(1) lookup on funds_withdrawn (skips charges.retrieve)', async () => {
+        const mockFindOnePayment = vi.fn().mockResolvedValue({
+            intent_id: 'pi_test_456',
+            transfer_id: 'tr_stored_123',
+            klub_don: {
+                id: 1,
+                documentId: 'doc_don_123',
+                klubr: {
+                    id: 10,
+                    documentId: 'doc_klubr_456',
+                    denomination: 'Mon Association',
+                    uuid: 'klubr-uuid-789',
+                },
+            },
+        });
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockFindOnePayment });
+
+        vi.mocked(mockStripeClient.transfers.retrieve).mockResolvedValue({
+            id: 'tr_stored_123',
+            amount: 5000,
+            metadata: {},
+        } as any);
+        vi.mocked(mockStripeClient.transfers.listReversals).mockResolvedValue({
+            data: [],
+        } as any);
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.funds_withdrawn')
+        );
+
+        // Should use stored transfer_id directly — no charge lookup
+        expect(mockStripeClient.charges.retrieve).not.toHaveBeenCalled();
+        expect(mockStripeClient.transfers.retrieve).toHaveBeenCalledWith('tr_stored_123');
+        expect(mockStripeClient.transfers.createReversal).toHaveBeenCalledWith(
+            'tr_stored_123',
+            expect.objectContaining({
+                amount: 5000,
+                metadata: expect.objectContaining({ dispute_id: 'dp_test_123' }),
+            }),
+        );
+    });
+
+    it('uses stored transfer_id for O(1) lookup on funds_reinstated (skips charges.retrieve)', async () => {
+        const mockFindOnePayment = vi.fn().mockResolvedValue({
+            intent_id: 'pi_test_456',
+            transfer_id: 'tr_stored_456',
+            klub_don: {
+                id: 1,
+                documentId: 'doc_don_123',
+                klubr: {
+                    id: 10,
+                    documentId: 'doc_klubr_456',
+                    denomination: 'Mon Association',
+                    uuid: 'klubr-uuid-789',
+                },
+            },
+        });
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockFindOnePayment });
+
+        vi.mocked(mockStripeClient.transfers.retrieve).mockResolvedValue({
+            id: 'tr_stored_456',
+            amount: 5000,
+            metadata: {},
+        } as any);
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.funds_reinstated', { status: 'won' })
+        );
+
+        // Should use stored transfer_id directly — no charge lookup
+        expect(mockStripeClient.charges.retrieve).not.toHaveBeenCalled();
+        expect(mockStripeClient.transfers.retrieve).toHaveBeenCalledWith('tr_stored_456');
+        expect(createTransferToConnectedAccount).toHaveBeenCalledWith(
+            5000,
+            'acct_connect_test',
+            expect.objectContaining({
+                dispute_id: 'dp_test_123',
+                original_transfer_id: 'tr_stored_456',
+            }),
+        );
+    });
+
+    it('falls back to charge→transfer chain when transfer_id is not stored', async () => {
+        // Default mock has no transfer_id
+        const mockDisputeStrapi = makeDisputeMockStrapi();
+        mockChargeTransferLookup();
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.funds_withdrawn')
+        );
+
+        // Should fallback to charge retrieval
+        expect(mockStripeClient.charges.retrieve).toHaveBeenCalledWith('ch_test_123');
+        expect(mockStripeClient.transfers.retrieve).toHaveBeenCalledWith('tr_test_789');
+    });
 });

--- a/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
@@ -1288,4 +1288,84 @@ describe('handleDispute', () => {
         expect(mockStripeClient.charges.retrieve).toHaveBeenCalledWith('ch_test_123');
         expect(mockStripeClient.transfers.retrieve).toHaveBeenCalledWith('tr_test_789');
     });
+
+    it('falls back to charge→transfer chain when stored transfer_id retrieval fails', async () => {
+        const mockFindOnePayment = vi.fn().mockResolvedValue({
+            intent_id: 'pi_test_456',
+            transfer_id: 'tr_stale_invalid',
+            klub_don: {
+                id: 1,
+                documentId: 'doc_don_123',
+                klubr: {
+                    id: 10,
+                    documentId: 'doc_klubr_456',
+                    denomination: 'Mon Association',
+                    uuid: 'klubr-uuid-789',
+                },
+            },
+        });
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockFindOnePayment });
+
+        // First call (fast path) rejects, second call (fallback) resolves
+        vi.mocked(mockStripeClient.transfers.retrieve)
+            .mockRejectedValueOnce(new Error('No such transfer: tr_stale_invalid'))
+            .mockResolvedValueOnce({
+                id: 'tr_test_789',
+                amount: 5000,
+                metadata: {},
+            } as any);
+        vi.mocked(mockStripeClient.charges.retrieve).mockResolvedValue({
+            id: 'ch_test_123',
+            transfer: 'tr_test_789',
+        } as any);
+        vi.mocked(mockStripeClient.transfers.listReversals).mockResolvedValue({
+            data: [],
+        } as any);
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.funds_withdrawn')
+        );
+
+        // Should have tried stored ID first, then fallen back to charge chain
+        expect(mockStripeClient.transfers.retrieve).toHaveBeenCalledWith('tr_stale_invalid');
+        expect(mockStripeClient.charges.retrieve).toHaveBeenCalledWith('ch_test_123');
+        expect(mockStripeClient.transfers.retrieve).toHaveBeenCalledWith('tr_test_789');
+    });
+
+    it('handles classic payment (no transfer on charge) gracefully', async () => {
+        const mockFindOnePayment = vi.fn().mockResolvedValue({
+            intent_id: 'pi_test_456',
+            // no transfer_id stored (classic payment)
+            klub_don: {
+                id: 1,
+                documentId: 'doc_don_123',
+                klubr: {
+                    id: 10,
+                    documentId: 'doc_klubr_456',
+                    denomination: 'Mon Association',
+                    uuid: 'klubr-uuid-789',
+                },
+            },
+        });
+        const mockDisputeStrapi = makeDisputeMockStrapi({ mockFindOnePayment });
+
+        // charge.transfer is null (classic, non-Connect payment)
+        vi.mocked(mockStripeClient.charges.retrieve).mockResolvedValue({
+            id: 'ch_test_classic',
+            transfer: null,
+        } as any);
+
+        await handleDispute(
+            mockDisputeStrapi,
+            makeDisputeEvent('charge.dispute.funds_withdrawn')
+        );
+
+        // Should attempt charge lookup but find no transfer
+        expect(mockStripeClient.charges.retrieve).toHaveBeenCalledWith('ch_test_123');
+        // Should NOT attempt transfer retrieval since charge.transfer is null
+        expect(mockStripeClient.transfers.retrieve).not.toHaveBeenCalled();
+        // Should NOT attempt reversal
+        expect(mockStripeClient.transfers.createReversal).not.toHaveBeenCalled();
+    });
 });

--- a/donaction-api/src/helpers/stripe-webhook-handlers.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.ts
@@ -717,7 +717,8 @@ export async function handleDispute(
 }
 
 /**
- * Resolves the original Stripe transfer from a dispute by following charge → transfer chain.
+ * Resolves the original Stripe transfer from a dispute.
+ * Uses stored transfer_id for O(1) lookup if available, otherwise follows charge → transfer chain.
  * Returns null if no transfer is found (with appropriate logging).
  */
 async function resolveTransferFromDispute(

--- a/donaction-api/src/helpers/stripe-webhook-handlers.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.ts
@@ -538,7 +538,7 @@ export async function handleDispute(
     }
 
     const klubDon = payment.klub_don;
-    const storedTransferId: string | undefined = payment.transfer_id || undefined;
+    const storedTransferId: string | undefined = payment.transfer_id ?? undefined;
 
     // Idempotency guard: skip duplicate created events
     if (klubDon.disputeId === dispute.id && event.type === 'charge.dispute.created') {
@@ -728,12 +728,21 @@ async function resolveTransferFromDispute(
 ): Promise<Stripe.Transfer | null> {
     // Fast path: use stored transfer_id for O(1) lookup
     if (storedTransferId) {
-        logSimple({
-            message: `Utilisation du transfer_id stocké ${storedTransferId} pour dispute ${dispute.id}`,
-            color: 'green',
-            prefix: 'StripeConnect',
-        });
-        return stripe.transfers.retrieve(storedTransferId);
+        try {
+            logSimple({
+                message: `Utilisation du transfer_id stocké ${storedTransferId} pour dispute ${dispute.id}`,
+                color: 'green',
+                prefix: 'StripeConnect',
+            });
+            return await stripe.transfers.retrieve(storedTransferId);
+        } catch (err) {
+            logSimple({
+                message: `Échec récupération transfer ${storedTransferId}, fallback sur charge chain: ${(err as Error).message}`,
+                color: 'yellow',
+                prefix: 'StripeConnect',
+            });
+            // Fall through to charge → transfer chain
+        }
     }
 
     // Fallback: resolve via charge → transfer chain (2 API calls)

--- a/donaction-api/src/helpers/stripe-webhook-handlers.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.ts
@@ -538,6 +538,7 @@ export async function handleDispute(
     }
 
     const klubDon = payment.klub_don;
+    const storedTransferId: string | undefined = payment.transfer_id || undefined;
 
     // Idempotency guard: skip duplicate created events
     if (klubDon.disputeId === dispute.id && event.type === 'charge.dispute.created') {
@@ -638,6 +639,7 @@ export async function handleDispute(
                 dispute,
                 klubDon,
                 accountId,
+                storedTransferId,
             );
         }
     }
@@ -650,6 +652,7 @@ export async function handleDispute(
                 dispute,
                 klubDon,
                 accountId,
+                storedTransferId,
             );
 
             // Send admin alert (only when re-transfer was attempted)
@@ -720,7 +723,25 @@ export async function handleDispute(
 async function resolveTransferFromDispute(
     dispute: Stripe.Dispute,
     operation: string,
+    storedTransferId?: string,
 ): Promise<Stripe.Transfer | null> {
+    // Fast path: use stored transfer_id for O(1) lookup
+    if (storedTransferId) {
+        logSimple({
+            message: `Utilisation du transfer_id stocké ${storedTransferId} pour dispute ${dispute.id}`,
+            color: 'green',
+            prefix: 'StripeConnect',
+        });
+        return stripe.transfers.retrieve(storedTransferId);
+    }
+
+    // Fallback: resolve via charge → transfer chain (2 API calls)
+    logSimple({
+        message: `Aucun transfer_id stocké, résolution via charge pour dispute ${dispute.id}`,
+        color: 'yellow',
+        prefix: 'StripeConnect',
+    });
+
     const chargeId = typeof dispute.charge === 'string'
         ? dispute.charge
         : dispute.charge?.id;
@@ -760,9 +781,10 @@ async function reverseTransferForDispute(
     dispute: Stripe.Dispute,
     klubDon: DisputeKlubDon,
     accountId: string,
+    storedTransferId?: string,
 ): Promise<void> {
     try {
-        const relatedTransfer = await resolveTransferFromDispute(dispute, 'reversal');
+        const relatedTransfer = await resolveTransferFromDispute(dispute, 'reversal', storedTransferId);
         if (!relatedTransfer) return;
 
         // Idempotency: check if reversal already exists for this dispute
@@ -864,9 +886,10 @@ async function reTransferForDisputeWon(
     dispute: Stripe.Dispute,
     klubDon: DisputeKlubDon,
     accountId: string,
+    storedTransferId?: string,
 ): Promise<void> {
     try {
-        const originalTransfer = await resolveTransferFromDispute(dispute, 're-transfer');
+        const originalTransfer = await resolveTransferFromDispute(dispute, 're-transfer', storedTransferId);
         if (!originalTransfer) return;
 
         const reinstatedAmount = Math.min(dispute.amount, originalTransfer.amount);

--- a/donaction-api/types/generated/contentTypes.d.ts
+++ b/donaction-api/types/generated/contentTypes.d.ts
@@ -966,6 +966,7 @@ export interface ApiKlubDonPaymentKlubDonPayment
             Schema.Attribute.Required &
             Schema.Attribute.DefaultTo<'none'>;
         status: Schema.Attribute.String;
+        transfer_id: Schema.Attribute.String;
         updatedAt: Schema.Attribute.DateTime;
         updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
             Schema.Attribute.Private;


### PR DESCRIPTION
## Summary
- Add `transfer_id` field to `klub-don-payment` schema for persisting the Stripe transfer ID
- Extract transfer_id from charge on `payment_intent.succeeded` webhook and store it
- Use stored transfer_id in `reverseTransferForDispute()` and `reTransferForDisputeWon()` for O(1) lookup, falling back to charge→transfer API chain when not available
- Eliminates unnecessary `stripe.charges.retrieve()` call during dispute handling for existing payments

## Changes
| File | Change |
|------|--------|
| `schema.json` | Add optional `transfer_id` string field |
| `klub-don-payment.ts` (controller) | Extract transfer_id from charge on payment succeeded |
| `klub-don-payment.ts` (service) | Accept and persist optional `transferId` param |
| `stripe-webhook-handlers.ts` | Use stored transfer_id in dispute functions with fallback |
| `stripe-webhook-handlers.test.ts` | 3 new tests: fast path, re-transfer fast path, fallback |

## Test plan
- [x] All 209 tests pass (206 existing + 3 new)
- [x] Build succeeds
- [x] Backward compatible — fallback to charge→transfer chain for payments without stored transfer_id
- [ ] Manual: verify transfer_id is stored after a Stripe Connect payment succeeds
- [ ] Manual: verify dispute reversal uses stored transfer_id (check logs for "Utilisation du transfer_id stocké")

Closes #192