### PR TITLE
feat: implement payout.failed webhook handler (US-WH-006)

### DIFF
--- a/donaction-api/src/_types.ts
+++ b/donaction-api/src/_types.ts
@@ -58,6 +58,7 @@ export type ConnectedAccountEntity =
 export type ConnectedAccountWithOptionalKlubr = {
     id: number;
     documentId: string;
+    stripe_account_id?: string;
     account_status?: string;
     klubr?: KlubrEntity | number | null;
 };

--- a/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
@@ -389,11 +389,15 @@ const makePayoutFailedMockStrapi = (overrides: Record<string, any> = {}) => {
 describe('handlePayoutFailed', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
     });
 
     it('returns early when event has no account id', async () => {
-        const event = makePayoutFailedEvent({ account: undefined });
-        // Override account at event level
+        const event = makePayoutFailedEvent();
         (event as any).account = undefined;
 
         await handlePayoutFailed(mockStrapi, event);
@@ -421,8 +425,8 @@ describe('handlePayoutFailed', () => {
 
         await handlePayoutFailed(mockStrapiInstance, event);
 
-        // Wait for fire-and-forget promises to settle
-        await new Promise((r) => setTimeout(r, 10));
+        // Flush microtask queue for fire-and-forget promises
+        await vi.runAllTimersAsync();
 
         expect(sendBrevoTransacEmail).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -451,8 +455,8 @@ describe('handlePayoutFailed', () => {
 
         await handlePayoutFailed(mockStrapiInstance, event);
 
-        // Wait for fire-and-forget promises to settle
-        await new Promise((r) => setTimeout(r, 10));
+        // Flush microtask queue for fire-and-forget promises
+        await vi.runAllTimersAsync();
 
         expect(sendBrevoTransacEmail).toHaveBeenCalledWith(
             expect.objectContaining({
@@ -476,8 +480,8 @@ describe('handlePayoutFailed', () => {
 
         await handlePayoutFailed(mockStrapiInstance, event);
 
-        // Wait for fire-and-forget promises to settle
-        await new Promise((r) => setTimeout(r, 10));
+        // Flush microtask queue for fire-and-forget promises
+        await vi.runAllTimersAsync();
 
         // Only admin alert should be sent (destIsAdmin: true), not leader alert
         const calls = vi.mocked(sendBrevoTransacEmail).mock.calls;

--- a/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.test.ts
@@ -37,6 +37,7 @@ import {
     handleWebhookEvent,
     handleAccountDeauthorized,
     handleDispute,
+    handlePayoutFailed,
 } from './stripe-webhook-handlers';
 import { syncAccountStatus, logFinancialAction, createTransferToConnectedAccount, stripe as mockStripeClient } from './stripe-connect-helper';
 import { logSimple, strapiLog } from './logger';
@@ -299,10 +300,11 @@ describe('handleWebhookEvent', () => {
         );
     });
 
-    it('routes payout.failed and logs error', async () => {
-        const event = makeEvent('payout.failed');
+    it('routes payout.failed and looks up connected account', async () => {
+        const mockPayoutStrapi = makePayoutFailedMockStrapi();
+        const event = makePayoutFailedEvent();
         await expect(
-            handleWebhookEvent(mockStrapi, event)
+            handleWebhookEvent(mockPayoutStrapi, event)
         ).resolves.toBeUndefined();
         expect(syncAccountStatus).not.toHaveBeenCalled();
         expect(strapiLog.error).toHaveBeenCalledWith(
@@ -323,6 +325,176 @@ describe('handleWebhookEvent', () => {
         await expect(
             handleWebhookEvent(mockStrapi, makeEvent('account.updated'))
         ).rejects.toThrow('sync failed');
+    });
+});
+
+// ---------- handlePayoutFailed ----------
+
+/** Build a payout.failed Stripe event */
+const makePayoutFailedEvent = (
+    overrides: Record<string, any> = {}
+): Stripe.Event =>
+    ({
+        id: 'evt_payout_failed_123',
+        type: 'payout.failed',
+        data: {
+            object: {
+                id: 'po_test_123',
+                amount: 50000,
+                failure_message: 'account_closed',
+                failure_code: 'account_closed',
+                ...overrides,
+            },
+        },
+        account: overrides.account ?? 'acct_payout_test',
+    }) as unknown as Stripe.Event;
+
+/** Build a mock Strapi instance for payout.failed tests */
+const makePayoutFailedMockStrapi = (overrides: Record<string, any> = {}) => {
+    const mockFindOneAccount = overrides.mockFindOneAccount || vi.fn().mockResolvedValue({
+        id: 1,
+        documentId: 'doc_ca_123',
+        stripe_account_id: 'acct_payout_test',
+        klubr: {
+            id: 10,
+            documentId: 'doc_klubr_payout',
+            denomination: 'Asso Test',
+            uuid: 'klubr-uuid-payout',
+        },
+    });
+    const mockGetKlubMembres = overrides.mockGetKlubMembres || vi.fn().mockResolvedValue([]);
+
+    return {
+        db: {
+            query: vi.fn().mockImplementation((uid: string) => {
+                if (uid === 'api::connected-account.connected-account') {
+                    return { findOne: mockFindOneAccount };
+                }
+                return { findOne: vi.fn() };
+            }),
+        },
+        documents: vi.fn().mockReturnValue({
+            update: vi.fn().mockResolvedValue({}),
+            create: vi.fn().mockResolvedValue({}),
+        }),
+        service: vi.fn().mockImplementation((uid: string) => {
+            if (uid === 'api::klubr-membre.klubr-membre') {
+                return { getKlubMembres: mockGetKlubMembres };
+            }
+            return {};
+        }),
+    } as unknown as Core.Strapi;
+};
+
+describe('handlePayoutFailed', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns early when event has no account id', async () => {
+        const event = makePayoutFailedEvent({ account: undefined });
+        // Override account at event level
+        (event as any).account = undefined;
+
+        await handlePayoutFailed(mockStrapi, event);
+
+        expect(strapiLog.error).toHaveBeenCalledWith(
+            expect.stringContaining('sans account id')
+        );
+    });
+
+    it('returns early when connected account is not found', async () => {
+        const mockFindOneAccount = vi.fn().mockResolvedValue(null);
+        const mockStrapiInstance = makePayoutFailedMockStrapi({ mockFindOneAccount });
+        const event = makePayoutFailedEvent();
+
+        await handlePayoutFailed(mockStrapiInstance, event);
+
+        expect(strapiLog.error).toHaveBeenCalledWith(
+            expect.stringContaining('introuvable')
+        );
+    });
+
+    it('sends admin alert with payout details', async () => {
+        const mockStrapiInstance = makePayoutFailedMockStrapi();
+        const event = makePayoutFailedEvent();
+
+        await handlePayoutFailed(mockStrapiInstance, event);
+
+        // Wait for fire-and-forget promises to settle
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(sendBrevoTransacEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                destIsAdmin: true,
+                templateId: BREVO_TEMPLATES.SUPER_ADMIN_ALERT_STRIPE,
+                params: expect.objectContaining({
+                    ALERT_TYPE: expect.stringContaining('payout.failed'),
+                    CLUB_NAME: 'Asso Test',
+                }),
+                tags: expect.arrayContaining(['payout-failed']),
+            })
+        );
+    });
+
+    it('sends leader notification when leaders exist', async () => {
+        const mockGetKlubMembres = vi.fn().mockResolvedValue([
+            {
+                prenom: 'Jean',
+                nom: 'Dupont',
+                email: 'jean@test.fr',
+                users_permissions_user: { email: 'jean@test.fr' },
+            },
+        ]);
+        const mockStrapiInstance = makePayoutFailedMockStrapi({ mockGetKlubMembres });
+        const event = makePayoutFailedEvent();
+
+        await handlePayoutFailed(mockStrapiInstance, event);
+
+        // Wait for fire-and-forget promises to settle
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(sendBrevoTransacEmail).toHaveBeenCalledWith(
+            expect.objectContaining({
+                templateId: BREVO_TEMPLATES.LEADER_ALERT,
+                to: expect.arrayContaining([
+                    expect.objectContaining({ email: 'jean@test.fr' }),
+                ]),
+                params: expect.objectContaining({
+                    CLUB_NAME: 'Asso Test',
+                    ALERT_MESSAGE: expect.stringContaining('500€'),
+                }),
+                tags: expect.arrayContaining(['payout-failed']),
+            })
+        );
+    });
+
+    it('does not send leader notification when no leaders found', async () => {
+        const mockGetKlubMembres = vi.fn().mockResolvedValue([]);
+        const mockStrapiInstance = makePayoutFailedMockStrapi({ mockGetKlubMembres });
+        const event = makePayoutFailedEvent();
+
+        await handlePayoutFailed(mockStrapiInstance, event);
+
+        // Wait for fire-and-forget promises to settle
+        await new Promise((r) => setTimeout(r, 10));
+
+        // Only admin alert should be sent (destIsAdmin: true), not leader alert
+        const calls = vi.mocked(sendBrevoTransacEmail).mock.calls;
+        const leaderCalls = calls.filter(
+            (call) => call[0].templateId === BREVO_TEMPLATES.LEADER_ALERT
+        );
+        expect(leaderCalls).toHaveLength(0);
+    });
+
+    it('propagates errors from connected account lookup', async () => {
+        const mockFindOneAccount = vi.fn().mockRejectedValue(new Error('db error'));
+        const mockStrapiInstance = makePayoutFailedMockStrapi({ mockFindOneAccount });
+        const event = makePayoutFailedEvent();
+
+        await expect(
+            handlePayoutFailed(mockStrapiInstance, event)
+        ).rejects.toThrow('db error');
     });
 });
 

--- a/donaction-api/src/helpers/stripe-webhook-handlers.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.ts
@@ -1188,14 +1188,14 @@ export async function handlePayoutPaid(
 
 /**
  * Handles payout.failed webhook event
- * Stub handler - detailed payout logic in follow-up US
+ * Alerts admin and notifies klubr leaders when a payout to an association fails.
  */
 export async function handlePayoutFailed(
-    _strapiInstance: Core.Strapi,
+    strapiInstance: Core.Strapi,
     event: Stripe.Event
 ): Promise<void> {
     logBlock({
-        statusColor: COLORS.yellow,
+        statusColor: COLORS.red,
         entries: [
             { key: 'Webhook', value: 'payout.failed' },
             { key: 'Event ID', value: event.id },
@@ -1204,13 +1204,219 @@ export async function handlePayoutFailed(
     });
 
     const payout = event.data.object as Stripe.Payout;
-    const accountId = event.account ?? 'unknown';
+    const accountId = event.account;
+
+    if (!accountId) {
+        strapiLog.error(
+            'payout.failed reçu sans account id'
+        );
+        return;
+    }
+
+    const amountInEuros = (payout.amount || 0) / 100;
+    const failureMessage = payout.failure_message || 'Raison inconnue';
+    const failureCode = payout.failure_code || 'unknown';
 
     strapiLog.error(
-        `Payout ${payout.id} échoué pour compte ${accountId}`
+        `Payout ${payout.id} échoué pour compte ${accountId}: ${failureMessage} (${failureCode})`
     );
 
-    // TODO: Implement payout failure handling + notification in follow-up US
+    try {
+        // Find connected account with klubr relation
+        const connectedAccount = await strapiInstance.db
+            .query('api::connected-account.connected-account')
+            .findOne({
+                where: { stripe_account_id: accountId },
+                populate: { klubr: true },
+            });
+
+        if (!connectedAccount) {
+            strapiLog.error(
+                `Compte connecté introuvable pour payout.failed: ${accountId}`
+            );
+            return;
+        }
+
+        // Fire-and-forget: send admin alert
+        void sendPayoutFailedAdminAlert(
+            accountId,
+            connectedAccount,
+            payout,
+            amountInEuros,
+            failureMessage,
+        );
+
+        // Fire-and-forget: send notification to klubr leaders
+        void sendPayoutFailedKlubrNotification(
+            strapiInstance,
+            accountId,
+            connectedAccount,
+            amountInEuros,
+            failureMessage,
+        );
+
+        logSimple({
+            message: `Payout ${payout.id} échoué pour ${accountId} — notifications envoyées`,
+            color: 'red',
+            prefix: 'StripeConnect',
+        });
+    } catch (error) {
+        strapiLog.error(
+            'Erreur lors du traitement du webhook payout.failed:',
+            error
+        );
+        throw error;
+    }
+}
+
+/**
+ * Sends an admin alert when a payout fails.
+ * Non-blocking: errors are logged but not propagated.
+ */
+async function sendPayoutFailedAdminAlert(
+    accountId: string,
+    connectedAccount: ConnectedAccountWithOptionalKlubr,
+    payout: Stripe.Payout,
+    amountInEuros: number,
+    failureMessage: string,
+): Promise<void> {
+    try {
+        let klubrName = 'Inconnu';
+        let klubrUuid = 'N/A';
+
+        if (
+            connectedAccount.klubr &&
+            typeof connectedAccount.klubr === 'object'
+        ) {
+            klubrName = connectedAccount.klubr.denomination || 'Inconnu';
+            klubrUuid = connectedAccount.klubr.uuid || 'N/A';
+        }
+
+        await sendBrevoTransacEmail({
+            subject: `[ALERTE] Virement échoué: ${klubrName} — ${amountInEuros}€`,
+            templateId: BREVO_TEMPLATES.SUPER_ADMIN_ALERT_STRIPE,
+            destIsAdmin: true,
+            params: {
+                ALERT_TYPE: 'Virement échoué (payout.failed)',
+                CLUB_NAME: klubrName,
+                KLUBR_UUID: klubrUuid,
+                STRIPE_ACCOUNT_ID: accountId,
+                ACCOUNT_STATUS: `Payout ${payout.id} échoué`,
+                DISABLED_REASON: failureMessage,
+                CURRENTLY_DUE: `${amountInEuros}€`,
+                CHARGES_ENABLED: 'N/A',
+                PAYOUTS_ENABLED: 'N/A',
+            },
+            tags: ['admin-alert', 'stripe-connect', 'payout-failed'],
+        });
+
+        logSimple({
+            message: `Alerte admin envoyée pour payout échoué: ${payout.id}`,
+            color: 'yellow',
+            prefix: 'StripeConnect',
+        });
+    } catch (alertError) {
+        strapiLog.error(
+            `Echec de l'envoi de l'alerte admin pour payout échoué ${payout.id}:`,
+            alertError
+        );
+    }
+}
+
+/**
+ * Sends a LEADER_ALERT notification to klubr leaders when a payout fails.
+ * Non-blocking: errors are logged but not propagated.
+ */
+async function sendPayoutFailedKlubrNotification(
+    strapiInstance: Core.Strapi,
+    accountId: string,
+    connectedAccount: ConnectedAccountWithOptionalKlubr,
+    amountInEuros: number,
+    failureMessage: string,
+): Promise<void> {
+    try {
+        // Guard: klubr must be a populated object (not a numeric FK)
+        if (
+            !connectedAccount.klubr ||
+            typeof connectedAccount.klubr !== 'object'
+        ) {
+            logSimple({
+                message: `Pas de klubr associé pour la notification de payout échoué: ${accountId}`,
+                color: 'yellow',
+                prefix: 'StripeConnect',
+            });
+            return;
+        }
+
+        const klubr = connectedAccount.klubr;
+
+        if (!klubr.documentId) {
+            logSimple({
+                message: `Klubr sans documentId, notification payout échoué ignorée: ${accountId}`,
+                color: 'yellow',
+                prefix: 'StripeConnect',
+            });
+            return;
+        }
+
+        const klubrName = klubr.denomination || 'Votre association';
+
+        // Find KlubMemberLeader + AdminEditor members to notify
+        const leaders = await strapiInstance
+            .service('api::klubr-membre.klubr-membre')
+            .getKlubMembres(klubr.documentId, ['KlubMemberLeader', 'AdminEditor']);
+
+        const leadersWithEmail = leaders.filter(
+            (member) => member.email || member.users_permissions_user?.email,
+        );
+
+        if (leadersWithEmail.length === 0) {
+            logSimple({
+                message: `Aucun dirigeant avec email trouvé pour le klubr ${klubrName}`,
+                color: 'yellow',
+                prefix: 'StripeConnect',
+            });
+            return;
+        }
+
+        // Send LEADER_ALERT to all leaders in parallel
+        const results = await Promise.allSettled(leadersWithEmail.map(async (leader) => {
+            const leaderEmail =
+                leader.email || leader.users_permissions_user?.email;
+
+            await sendBrevoTransacEmail({
+                subject: `Action requise - Virement échoué pour ${klubrName}`,
+                templateId: BREVO_TEMPLATES.LEADER_ALERT,
+                to: [{ email: leaderEmail, name: `${leader.prenom || ''} ${leader.nom || ''}`.trim() }],
+                params: {
+                    CLUB_NAME: klubrName,
+                    ALERT_MESSAGE:
+                        `Un virement de ${amountInEuros}€ vers votre association a échoué. ` +
+                        `Raison : ${failureMessage}. ` +
+                        'Veuillez vérifier vos coordonnées bancaires dans les paramètres de votre compte Stripe.',
+                },
+                tags: ['klubr-notification', 'stripe-connect', 'payout-failed'],
+            });
+
+            logSimple({
+                message: `Notification LEADER_ALERT envoyée à ${leaderEmail} pour payout échoué: ${accountId}`,
+                color: 'yellow',
+                prefix: 'StripeConnect',
+            });
+        }));
+
+        results.forEach((result, i) => {
+            if (result.status === 'rejected') {
+                const leaderEmail = leadersWithEmail[i].email || leadersWithEmail[i].users_permissions_user?.email;
+                strapiLog.error(`Echec envoi notification payout échoué à ${leaderEmail}:`, result.reason);
+            }
+        });
+    } catch (notifError) {
+        strapiLog.error(
+            `Echec de l'envoi de la notification klubr pour payout échoué ${accountId}:`,
+            notifError
+        );
+    }
 }
 
 /**

--- a/donaction-api/src/helpers/stripe-webhook-handlers.ts
+++ b/donaction-api/src/helpers/stripe-webhook-handlers.ts
@@ -1237,23 +1237,18 @@ export async function handlePayoutFailed(
             return;
         }
 
-        // Fire-and-forget: send admin alert
-        void sendPayoutFailedAdminAlert(
+        const notificationContext = {
             accountId,
             connectedAccount,
-            payout,
             amountInEuros,
             failureMessage,
-        );
+        };
+
+        // Fire-and-forget: send admin alert
+        void sendPayoutFailedAdminAlert({ ...notificationContext, payout });
 
         // Fire-and-forget: send notification to klubr leaders
-        void sendPayoutFailedKlubrNotification(
-            strapiInstance,
-            accountId,
-            connectedAccount,
-            amountInEuros,
-            failureMessage,
-        );
+        void sendPayoutFailedKlubrNotification(strapiInstance, notificationContext);
 
         logSimple({
             message: `Payout ${payout.id} échoué pour ${accountId} — notifications envoyées`,
@@ -1269,17 +1264,21 @@ export async function handlePayoutFailed(
     }
 }
 
+interface PayoutFailedNotificationContext {
+    accountId: string;
+    connectedAccount: ConnectedAccountWithOptionalKlubr;
+    amountInEuros: number;
+    failureMessage: string;
+}
+
 /**
  * Sends an admin alert when a payout fails.
  * Non-blocking: errors are logged but not propagated.
  */
 async function sendPayoutFailedAdminAlert(
-    accountId: string,
-    connectedAccount: ConnectedAccountWithOptionalKlubr,
-    payout: Stripe.Payout,
-    amountInEuros: number,
-    failureMessage: string,
+    opts: PayoutFailedNotificationContext & { payout: Stripe.Payout },
 ): Promise<void> {
+    const { accountId, connectedAccount, payout, amountInEuros, failureMessage } = opts;
     try {
         let klubrName = 'Inconnu';
         let klubrUuid = 'N/A';
@@ -1296,6 +1295,9 @@ async function sendPayoutFailedAdminAlert(
             subject: `[ALERTE] Virement échoué: ${klubrName} — ${amountInEuros}€`,
             templateId: BREVO_TEMPLATES.SUPER_ADMIN_ALERT_STRIPE,
             destIsAdmin: true,
+            // Template SUPER_ADMIN_ALERT_STRIPE has fixed param names designed for account alerts.
+            // We repurpose them for payout context: CURRENTLY_DUE = payout amount,
+            // DISABLED_REASON = failure message, ACCOUNT_STATUS = payout status.
             params: {
                 ALERT_TYPE: 'Virement échoué (payout.failed)',
                 CLUB_NAME: klubrName,
@@ -1329,11 +1331,9 @@ async function sendPayoutFailedAdminAlert(
  */
 async function sendPayoutFailedKlubrNotification(
     strapiInstance: Core.Strapi,
-    accountId: string,
-    connectedAccount: ConnectedAccountWithOptionalKlubr,
-    amountInEuros: number,
-    failureMessage: string,
+    opts: PayoutFailedNotificationContext,
 ): Promise<void> {
+    const { accountId, connectedAccount, amountInEuros, failureMessage } = opts;
     try {
         // Guard: klubr must be a populated object (not a numeric FK)
         if (


### PR DESCRIPTION
## Summary

- Replace stub `handlePayoutFailed` with full implementation: lookup connected account, send admin alert + leader notifications
- Admin alert via `SUPER_ADMIN_ALERT_STRIPE` template with payout details (amount, failure reason, klubr info)
- Leader notification via `LEADER_ALERT` to `KlubMemberLeader` + `AdminEditor` members with actionable message
- Fire-and-forget pattern for emails (non-blocking, errors logged but not propagated)
- 6 new test cases covering: missing account id, missing connected account, admin alert, leader notification, no leaders, DB errors

Closes #66

## Test plan
- [x] All 217 tests pass (8 test files)
- [x] 6 new tests for `handlePayoutFailed` handler
- [x] Existing `payout.failed` routing test updated
- [ ] Manual verification with Stripe test webhook event